### PR TITLE
Support migrating static interfaces from /e/n/i

### DIFF
--- a/netplan/cli/commands/__init__.py
+++ b/netplan/cli/commands/__init__.py
@@ -16,5 +16,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from netplan.cli.commands.ip import NetplanIp
+from netplan.cli.commands.ifupdown_migrate import NetplanIfupdownMigrate
 
-__all__ = [NetplanIp]
+__all__ = [NetplanIp, NetplanIfupdownMigrate]

--- a/netplan/cli/commands/ifupdown_migrate.py
+++ b/netplan/cli/commands/ifupdown_migrate.py
@@ -1,0 +1,210 @@
+#!/usr/bin/python3
+#
+# Copyright (C) 2016, 2018 Canonical, Ltd.
+# Author: Martin Pitt <martin.pitt@ubuntu.com>
+# Author: Mathieu Trudel-Lapierre <mathieu.trudel-lapierre@canonical.com>
+# Author: Daniel Axtens <daniel.axtens@canonical.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+'''netplan ifupdown-migrate command line'''
+
+import argparse
+import logging
+import os
+import sys
+import re
+from glob import glob
+import yaml
+from collections import OrderedDict
+
+from netplan.cli.core import Netplan
+
+
+class NetplanIfupdownMigrate(Netplan):
+
+    def __init__(self):
+        self._args = None
+
+    def update(self, args):
+        self._args = args
+
+    def _ifupdown_lines_from_file(self, rootdir, path):
+        '''Return normalized lines from ifupdown config
+
+        This resolves "source" and "source-directory" includes.
+        '''
+        def expand_source_arg(rootdir, curdir, line):
+            arg = line.split()[1]
+            if arg.startswith('/'):
+                return rootdir + arg
+            else:
+                return curdir + '/' + arg
+
+        lines = []
+        rootdir_len = len(rootdir) + 1
+        try:
+            with open(rootdir + '/' + path) as f:
+                logging.debug('reading %s', f.name)
+                for line in f:
+                    # normalize, strip empty lines and comments
+                    line = line.strip()
+                    if not line or line.startswith('#'):
+                        continue
+
+                    if line.startswith('source-directory '):
+                        valid_re = re.compile('^[a-zA-Z0-9_-]+$')
+                        d = expand_source_arg(rootdir, os.path.dirname(f.name), line)
+                        for f in os.listdir(d):
+                            if valid_re.match(f):
+                                lines += self._ifupdown_lines_from_file(rootdir, os.path.join(d[rootdir_len:], f))
+                    elif line.startswith('source '):
+                        for f in glob(expand_source_arg(rootdir, os.path.dirname(f.name), line)):
+                            lines += self._ifupdown_lines_from_file(rootdir, f[rootdir_len:])
+                    else:
+                        lines.append(line)
+        except FileNotFoundError:
+            logging.debug('%s/%s does not exist, ignoring', rootdir, path)
+        return lines
+
+    def parse_ifupdown(self, rootdir='/'):
+        '''Parse ifupdown configuration.
+
+        Return (iface_name →  family → {method, options}, auto_ifaces: set) tuple
+        on successful parsing, or a ValueError when encountering an invalid file or
+        ifupdown features which are not supported (such as "mapping").
+
+        options is itself a dictionary option_name → value.
+        '''
+        # expected number of fields for every possible keyword, excluding the keyword itself
+        fieldlen = {'auto': 1, 'allow-auto': 1, 'allow-hotplug': 1, 'mapping': 1, 'no-scripts': 1, 'iface': 3}
+
+        # read and normalize all lines from config, with resolving includes
+        lines = self._ifupdown_lines_from_file(rootdir, '/etc/network/interfaces')
+
+        ifaces = OrderedDict()
+        auto = set()
+        in_options = None  # interface name if parsing options lines after iface stanza
+        in_family = None
+
+        # we now have resolved all includes and normalized lines
+        for line in lines:
+            fields = line.split()
+
+            try:
+                # does the line start with a known stanza field?
+                exp_len = fieldlen[fields[0]]
+                logging.debug('line fields %s (expected length: %i)', fields, exp_len)
+                in_options = None  # stop option line parsing of iface stanza
+                in_family = None
+            except KeyError:
+                # no known stanza field, are we in an iface stanza and parsing options?
+                if in_options:
+                    logging.debug('in_options %s, parsing as option: %s', in_options, line)
+                    ifaces[in_options][in_family]['options'][fields[0]] = line.split(maxsplit=1)[1]
+                    continue
+                else:
+                    raise ValueError('Unknown stanza type %s' % fields[0])
+
+            # do we have the expected #parameters?
+            if len(fields) != exp_len + 1:
+                raise ValueError('Expected %i fields for stanza type %s but got %i' %
+                                 (exp_len, fields[0], len(fields) - 1))
+
+            # we have a valid stanza line now, handle them
+            if fields[0] in ('auto', 'allow-auto', 'allow-hotplug'):
+                auto.add(fields[1])
+            elif fields[0] == 'mapping':
+                raise ValueError('mapping stanza is not supported')
+            elif fields[0] == 'no-scripts':
+                pass  # ignore these
+            elif fields[0] == 'iface':
+                if fields[2] not in ('inet', 'inet6'):
+                    raise ValueError('Unknown address family %s' % fields[2])
+                if fields[3] not in ('loopback', 'static', 'dhcp'):
+                    raise ValueError('Unsupported method %s' % fields[3])
+                in_options = fields[1]
+                in_family = fields[2]
+                ifaces.setdefault(fields[1], OrderedDict())[in_family] = {'method': fields[3], 'options': {}}
+            else:
+                raise NotImplementedError('stanza type %s is not implemented' % fields[0])  # pragma nocover
+
+        logging.debug('final parsed interfaces: %s; auto ifaces: %s', ifaces, auto)
+        return (ifaces, auto)
+
+    def run(self):
+        parser = argparse.ArgumentParser(prog='netplan ifupdown-migrate',
+                                         description='Try to convert /etc/network/interfaces to netplan '
+                                                     'If successful, disable /etc/network/interfaces')
+        parser.add_argument('--root-dir',
+                            help='Search for and generate configuration files in this root directory instead of /')
+        parser.add_argument('--dry-run', action='store_true',
+                            help='Print converted netplan configuration to stdout instead of writing/changing files')
+
+        parser.parse_args(self._args, namespace=self)
+
+        netplan_config = {}
+        try:
+            ifaces, auto_ifaces = self.parse_ifupdown(self.root_dir or '')
+        except ValueError as e:
+            logging.error(str(e))
+            sys.exit(2)
+        for iface, family_config in ifaces.items():
+            for family, config in family_config.items():
+                logging.debug('Converting %s family %s %s', iface, family, config)
+                if iface not in auto_ifaces:
+                    logging.error('%s: non-automatic interfaces are not supported', iface)
+                    sys.exit(2)
+                if config['method'] == 'loopback':
+                    # both systemd and modern ifupdown set up lo automatically
+                    logging.debug('Ignoring loopback interface %s', iface)
+                elif config['method'] == 'dhcp':
+                    if config['options']:
+                        logging.error('%s: options are not supported for dhcp method', iface)
+                        sys.exit(2)
+                    c = netplan_config.setdefault('network', {}).setdefault('ethernets', {}).setdefault(iface, {})
+                    if family == 'inet':
+                        c['dhcp4'] = True
+                    else:
+                        assert family == 'inet6'
+                        c['dhcp6'] = True
+                else:
+                    logging.error('%s: method %s is not supported', iface, config['method'])
+                    sys.exit(2)
+
+        if_config = os.path.join(self.root_dir or '/', 'etc/network/interfaces')
+
+        if netplan_config:
+            netplan_config['network']['version'] = 2
+            netplan_yaml = yaml.dump(netplan_config)
+            if self.dry_run:
+                print(netplan_yaml)
+            else:
+                dest = os.path.join(self.root_dir or '/', 'etc/netplan/10-ifupdown.yaml')
+                try:
+                    os.makedirs(os.path.dirname(dest))
+                except FileExistsError:
+                    pass
+                try:
+                    with open(dest, 'x') as f:
+                        f.write(netplan_yaml)
+                except FileExistsError:
+                    logging.error('%s already exists; remove it if you want to run the migration again', dest)
+                    sys.exit(3)
+                logging.info('migration complete, wrote %s', dest)
+        else:
+            logging.info('ifupdown does not configure any interfaces, nothing to migrate')
+
+        if not self.dry_run:
+            logging.info('renaming %s to %s.netplan-converted', if_config, if_config)
+            os.rename(if_config, if_config + '.netplan-converted')

--- a/netplan/cli/core.py
+++ b/netplan/cli/core.py
@@ -21,10 +21,8 @@
 import logging
 import os
 import sys
-import re
 import subprocess
 from glob import glob
-import yaml
 
 import netplan.cli.utils as utils
 
@@ -41,6 +39,7 @@ class Netplan(utils.NetplanCommand):
     #
     def parse_args(self):
         from netplan.cli.commands import NetplanIp
+        from netplan.cli.commands import NetplanIfupdownMigrate
 
         # command: generate
         p_generate = self.subparsers.add_parser('generate',
@@ -60,15 +59,14 @@ class Netplan(utils.NetplanCommand):
         p_apply.set_defaults(func=self.command_apply)
 
         # command: ifupdown-migrate
+        self.command_ifupdown_migrate = NetplanIfupdownMigrate()
         p_ifupdown = self.subparsers.add_parser('ifupdown-migrate',
                                                 description='Migration of /etc/network/interfaces to netplan',
                                                 help='Try to convert /etc/network/interfaces to netplan '
-                                                     'If successful, disable /etc/network/interfaces')
-        p_ifupdown.add_argument('--root-dir',
-                                help='Search for and generate configuration files in this root directory instead of /')
-        p_ifupdown.add_argument('--dry-run', action='store_true',
-                                help='Print converted netplan configuration to stdout instead of writing/changing files')
-        p_ifupdown.set_defaults(func=self.command_ifupdown_migrate)
+                                                     'If successful, disable /etc/network/interfaces',
+                                                add_help=False)
+        p_ifupdown.set_defaults(func=self.command_ifupdown_migrate.run,
+                                commandclass=self.command_ifupdown_migrate)
 
         # command: ip
         self.command_ip = NetplanIp()
@@ -145,109 +143,6 @@ class Netplan(utils.NetplanCommand):
 
         return True
 
-    def _ifupdown_lines_from_file(self, rootdir, path):
-        '''Return normalized lines from ifupdown config
-
-        This resolves "source" and "source-directory" includes.
-        '''
-        def expand_source_arg(rootdir, curdir, line):
-            arg = line.split()[1]
-            if arg.startswith('/'):
-                return rootdir + arg
-            else:
-                return curdir + '/' + arg
-
-        lines = []
-        rootdir_len = len(rootdir) + 1
-        try:
-            with open(rootdir + '/' + path) as f:
-                logging.debug('reading %s', f.name)
-                for line in f:
-                    # normalize, strip empty lines and comments
-                    line = line.strip()
-                    if not line or line.startswith('#'):
-                        continue
-
-                    if line.startswith('source-directory '):
-                        valid_re = re.compile('^[a-zA-Z0-9_-]+$')
-                        d = expand_source_arg(rootdir, os.path.dirname(f.name), line)
-                        for f in os.listdir(d):
-                            if valid_re.match(f):
-                                lines += self._ifupdown_lines_from_file(rootdir, os.path.join(d[rootdir_len:], f))
-                    elif line.startswith('source '):
-                        for f in glob(expand_source_arg(rootdir, os.path.dirname(f.name), line)):
-                            lines += self._ifupdown_lines_from_file(rootdir, f[rootdir_len:])
-                    else:
-                        lines.append(line)
-        except FileNotFoundError:
-            logging.debug('%s/%s does not exist, ignoring', rootdir, path)
-        return lines
-
-    def parse_ifupdown(self, rootdir='/'):
-        '''Parse ifupdown configuration.
-
-        Return (iface_name →  family → {method, options}, auto_ifaces: set) tuple
-        on successful parsing, or a ValueError when encountering an invalid file or
-        ifupdown features which are not supported (such as "mapping").
-
-        options is itself a dictionary option_name → value.
-        '''
-        # expected number of fields for every possible keyword, excluding the keyword itself
-        fieldlen = {'auto': 1, 'allow-auto': 1, 'allow-hotplug': 1, 'mapping': 1, 'no-scripts': 1, 'iface': 3}
-
-        # read and normalize all lines from config, with resolving includes
-        lines = self._ifupdown_lines_from_file(rootdir, '/etc/network/interfaces')
-
-        ifaces = {}
-        auto = set()
-        in_options = None  # interface name if parsing options lines after iface stanza
-        in_family = None
-
-        # we now have resolved all includes and normalized lines
-        for line in lines:
-            fields = line.split()
-
-            try:
-                # does the line start with a known stanza field?
-                exp_len = fieldlen[fields[0]]
-                logging.debug('line fields %s (expected length: %i)', fields, exp_len)
-                in_options = None  # stop option line parsing of iface stanza
-                in_family = None
-            except KeyError:
-                # no known stanza field, are we in an iface stanza and parsing options?
-                if in_options:
-                    logging.debug('in_options %s, parsing as option: %s', in_options, line)
-                    ifaces[in_options][in_family]['options'][fields[0]] = line.split(maxsplit=1)[1]
-                    continue
-                else:
-                    raise ValueError('Unknown stanza type %s' % fields[0])
-
-            # do we have the expected #parameters?
-            if len(fields) != exp_len + 1:
-                raise ValueError('Expected %i fields for stanza type %s but got %i' %
-                                 (exp_len, fields[0], len(fields) - 1))
-
-            # we have a valid stanza line now, handle them
-            if fields[0] in ('auto', 'allow-auto', 'allow-hotplug'):
-                auto.add(fields[1])
-            elif fields[0] == 'mapping':
-                raise ValueError('mapping stanza is not supported')
-            elif fields[0] == 'no-scripts':
-                pass  # ignore these
-            elif fields[0] == 'iface':
-                if fields[2] not in ('inet', 'inet6'):
-                    raise ValueError('Unknown address family %s' % fields[2])
-                if fields[3] not in ('loopback', 'static', 'dhcp'):
-                    raise ValueError('Unsupported method %s' % fields[3])
-                in_options = fields[1]
-                in_family = fields[2]
-                ifaces.setdefault(fields[1], {})[in_family] = {'method': fields[3], 'options': {}}
-            else:
-                raise NotImplementedError('stanza type %s is not implemented' % fields[0])  # pragma nocover
-
-        logging.debug('final parsed interfaces: %s; auto ifaces: %s', ifaces, auto)
-        return (ifaces, auto)
-
     #
     # implementation of the top-level commands
     #
@@ -316,63 +211,6 @@ class Netplan(utils.NetplanCommand):
                                   [os.path.basename(f) for f in glob('/run/systemd/system/*.wants/netplan-wpa@*.service')])
         if restart_nm:
             utils.systemctl_network_manager('start')
-
-    def command_ifupdown_migrate(self):
-        netplan_config = {}
-        try:
-            ifaces, auto_ifaces = self.parse_ifupdown(self.root_dir or '')
-        except ValueError as e:
-            logging.error(str(e))
-            sys.exit(2)
-        for iface, family_config in ifaces.items():
-            for family, config in family_config.items():
-                logging.debug('Converting %s family %s %s', iface, family, config)
-                if iface not in auto_ifaces:
-                    logging.error('%s: non-automatic interfaces are not supported', iface)
-                    sys.exit(2)
-                if config['method'] == 'loopback':
-                    # both systemd and modern ifupdown set up lo automatically
-                    logging.debug('Ignoring loopback interface %s', iface)
-                elif config['method'] == 'dhcp':
-                    if config['options']:
-                        logging.error('%s: options are not supported for dhcp method', iface)
-                        sys.exit(2)
-                    c = netplan_config.setdefault('network', {}).setdefault('ethernets', {}).setdefault(iface, {})
-                    if family == 'inet':
-                        c['dhcp4'] = True
-                    else:
-                        assert family == 'inet6'
-                        c['dhcp6'] = True
-                else:
-                    logging.error('%s: method %s is not supported', iface, config['method'])
-                    sys.exit(2)
-
-        if_config = os.path.join(self.root_dir or '/', 'etc/network/interfaces')
-
-        if netplan_config:
-            netplan_config['network']['version'] = 2
-            netplan_yaml = yaml.dump(netplan_config)
-            if self.dry_run:
-                print(netplan_yaml)
-            else:
-                dest = os.path.join(self.root_dir or '/', 'etc/netplan/10-ifupdown.yaml')
-                try:
-                    os.makedirs(os.path.dirname(dest))
-                except FileExistsError:
-                    pass
-                try:
-                    with open(dest, 'x') as f:
-                        f.write(netplan_yaml)
-                except FileExistsError:
-                    logging.error('%s already exists; remove it if you want to run the migration again', dest)
-                    sys.exit(3)
-                logging.info('migration complete, wrote %s', dest)
-        else:
-            logging.info('ifupdown does not configure any interfaces, nothing to migrate')
-
-        if not self.dry_run:
-            logging.info('renaming %s to %s.netplan-converted', if_config, if_config)
-            os.rename(if_config, if_config + '.netplan-converted')
 
     #
     # main

--- a/tests/cli.py
+++ b/tests/cli.py
@@ -476,6 +476,19 @@ iface en1 inet6 static
         self.assertEqual(b'', out)
         self.assertIn(b'tried to set MTU=9000, but already have MTU=1280', err)
 
+    def test_static_hwaddress(self):
+        out = self.do_test('auto en1\niface en1 inet static\naddress 1.2.3.4/8\nhwaddress 52:54:00:6b:3c:59', dry_run=True)[0]
+        self.assertEqual(yaml.load(out), {'network': {
+            'version': 2,
+            'ethernets': {'en1': {'addresses': ["1.2.3.4/8"],
+                                  'macaddress': '52:54:00:6b:3c:59'}}}}, out.decode())
+
+    def test_static_two_different_macs(self):
+        out, err = self.do_test('auto en1\niface en1 inet static\naddress 1.2.3.4/8\nhwaddress 52:54:00:6b:3c:59\n'
+                                'iface en1 inet6 static\naddress 2001::1/64\nhwaddress 52:54:00:6b:3c:58', expect_success=False)
+        self.assertEqual(b'', out)
+        self.assertIn(b'tried to set MAC 52:54:00:6b:3c:58, but already have MAC 52:54:00:6b:3c:59', err)
+
     #
     # configs which are not supported
     #


### PR DESCRIPTION
This allows migration of most uses of static interfaces:
 - IPv4
 - IPv6
 - setting DNS nameservers and search domains (also for DHCP)
 - setting custom MTUs
 - setting custom MAC addresses (also for DHCP)

It doesn't support static bonds or bridges because currently there's no support for that at all in ifupdown-migrate.