### PR TITLE
Fixup for optional=true

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -25,7 +25,7 @@ Depends: ${shlibs:Depends},
  ${misc:Depends},
  python3,
  python3-yaml,
- systemd,
+ systemd (>= 235-3ubuntu3),
 Suggests: network-manager | wpasupplicant
 Conflicts: netplan
 Breaks: network-manager (<< 1.2.2-0ubuntu4~)

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -234,7 +234,7 @@ write_network_file(net_definition* def, const char* rootdir, const char* path)
     append_match_section(def, s, TRUE);
 
     if (def->optional)
-        g_string_append(s, "\n[Link]\nRequiredForOnline=yes\n");
+        g_string_append(s, "\n[Link]\nRequiredForOnline=no\n");
 
     g_string_append(s, "\n[Network]\n");
     if (def->dhcp4 && def->dhcp6)

--- a/tests/generate.py
+++ b/tests/generate.py
@@ -287,7 +287,7 @@ class TestNetworkd(TestBase):
 Name=eth0
 
 [Link]
-RequiredForOnline=yes
+RequiredForOnline=no
 
 [Network]
 DHCP=ipv6


### PR DESCRIPTION
As discussed on IRC, optional=true => RequiredForOnline=no

I also noticed when testing this that we need a very recent systemd for this to work, so require that in debian/control, which prevents installing this on e.g. artful where the option has no effect.