### PR TITLE
migrate: line up accept_ra behaviour with systemd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ clean:
 
 check: default linting
 	tests/generate.py
-	tests/cli.py
+	ENABLE_TEST_COMMANDS=1 tests/cli.py
 
 linting:
 	$(shell which pyflakes3 || echo true) $(PYCODE)

--- a/netplan/cli/commands/migrate.py
+++ b/netplan/cli/commands/migrate.py
@@ -213,7 +213,7 @@ class NetplanMigrate(utils.NetplanCommand):
 
                         # Already handled: mtu, hwaddress
                         # supported: address netmask gateway
-                        # partially supported: accept_ra (0/1 supported, 2 has no YAML rep)
+                        # partially supported: accept_ra (0/2 supported, 1 unsupported by systemd)
                         # unsupported: metric(?)
                         # no YAML representation: media autoconf privext scope
                         #                         preferred-lifetime dad-attempts dad-interval
@@ -270,10 +270,10 @@ class NetplanMigrate(utils.NetplanCommand):
                         if 'accept_ra' in config['options']:
                             if config['options']['accept_ra'] == '0':
                                 c['accept_ra'] = False
-                            elif config['options']['accept_ra'] == '1':
-                                c['accept_ra'] = True
                             elif config['options']['accept_ra'] == '2':
-                                logging.error('%s: netplan does not support accept_ra=2', iface)
+                                c['accept_ra'] = True
+                            elif config['options']['accept_ra'] == '1':
+                                logging.error('%s: netplan does not support accept_ra=1', iface)
                                 sys.exit(2)
                             else:
                                 logging.error('%s: unexpected accept_ra value "%s"', iface,

--- a/netplan/cli/utils.py
+++ b/netplan/cli/utils.py
@@ -122,7 +122,7 @@ class NetplanCommand(argparse.Namespace):
 
         if instance.testing:
             if not os.environ.get('ENABLE_TEST_COMMANDS', None):
-                return
+                return  # pragma: nocover
 
         p = self.subparsers.add_parser(instance.command_id,
                                        description=instance.description,

--- a/tests/cli.py
+++ b/tests/cli.py
@@ -393,19 +393,19 @@ source-directory /etc/network/interfaces.d''')[0]
             'ethernets': {'en1': {'addresses': ["fc00:123:4567:89ab:cdef::1234/64"],
                                   'accept_ra': False}}}}, out.decode())
 
-    def test_static_ipv6_accept_ra_1(self):
+    def test_static_ipv6_accept_ra_2(self):
         out = self.do_test('auto en1\niface en1 inet6 static\n'
-                           'address fc00:0123:4567:89ab:cdef::1234/64\naccept_ra 1', dry_run=True)[0]
+                           'address fc00:0123:4567:89ab:cdef::1234/64\naccept_ra 2', dry_run=True)[0]
         self.assertEqual(yaml.load(out), {'network': {
             'version': 2,
             'ethernets': {'en1': {'addresses': ["fc00:123:4567:89ab:cdef::1234/64"],
                                   'accept_ra': True}}}}, out.decode())
 
-    def test_static_ipv6_accept_ra_2(self):
+    def test_static_ipv6_accept_ra_1(self):
         out, err = self.do_test('auto en1\niface en1 inet6 static\n'
-                                'address fc00:0123:4567:89ab:cdef::1234/64\naccept_ra 2', expect_success=False)
+                                'address fc00:0123:4567:89ab:cdef::1234/64\naccept_ra 1', expect_success=False)
         self.assertEqual(out, b'')
-        self.assertIn(b'netplan does not support accept_ra=2', err)
+        self.assertIn(b'netplan does not support accept_ra=1', err)
 
     def test_static_ipv6_accept_ra_unexpected(self):
         out, err = self.do_test('auto en1\niface en1 inet6 static\n'


### PR DESCRIPTION
Per https://www.freedesktop.org/software/systemd/man/systemd.network.html:
"systemd's setting of 1 (i.e. true) corresponds to kernel's setting of 2."

Fix the migration code to recognise 0 and 2 but not 1, rather than 0 and 1
but not 2.

Signed-off-by: Daniel Axtens <dja@axtens.net>