### PR TITLE
parser: print helpful message if tabs are used

### DIFF
--- a/tests/generate.py
+++ b/tests/generate.py
@@ -144,6 +144,9 @@ class TestConfigArgs(TestBase):
         self.assertEqual(os.listdir(self.workdir.name), ['etc'])
         self.assert_udev(None)
 
+    def test_tabs(self):
+        self.generate("\t", expect_fail=True)
+
     def test_file_args(self):
         conf = os.path.join(self.workdir.name, 'config')
         with open(conf, 'w') as f:


### PR DESCRIPTION
libyaml's error message is unhelpful:
Invalid YAML at //etc/netplan/10-bridge.yaml line 5 column 0: found
character that cannot start any token

Replace it with something more helpful.

Signed-off-by: Daniel Axtens <dja@axtens.net>