### PR TITLE
Allow setting ClientIdentifier=mac for networkd-renderered devices

### DIFF
--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -147,6 +147,12 @@ Virtual devices
 
 :   Enable DHCP for IPv6. Off by default.
 
+``dhcp-identifier`` (scalar)
+
+:   When set to 'mac'; pass that setting over to systemd-networkd to use the
+    device's MAC address as a unique identifier rather than a RFC4361-compliant
+    Client ID. This has no effect when NetworkManager is used as a renderer.
+
 ``accept-ra`` (bool)
 
 :   Accept Router Advertisement that would have the kernel configure IPv6 by itself.

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -350,6 +350,8 @@ write_network_file(net_definition* def, const char* rootdir, const char* path)
         g_string_append_printf(s, "\n[DHCP]\nUseMTU=true\n");
         /* NetworkManager compatible route metrics */
         g_string_append_printf(s, "RouteMetric=%i\n", (def->type == ND_WIFI ? 600 : 100));
+        if (g_strcmp0(def->dhcp_identifier, "duid") != 0)
+            g_string_append_printf(s, "ClientIdentifier=%s\n", def->dhcp_identifier);
     }
 
     g_string_free_to_file(s, rootdir, path, ".network");

--- a/src/parse.c
+++ b/src/parse.c
@@ -1190,6 +1190,20 @@ handle_bonding(yaml_document_t* doc, yaml_node_t* node, const void* _, GError** 
     return process_mapping(doc, node, bond_params_handlers, error);
 }
 
+static gboolean
+handle_dhcp_identifier(yaml_document_t* doc, yaml_node_t* node, const void* data, GError** error)
+{
+    if (cur_netdef->dhcp_identifier)
+        g_free(cur_netdef->dhcp_identifier);
+    cur_netdef->dhcp_identifier = g_strdup(scalar(node));
+
+    if (g_ascii_strcasecmp(cur_netdef->dhcp_identifier, "duid") == 0 ||
+        g_ascii_strcasecmp(cur_netdef->dhcp_identifier, "mac") == 0)
+        return TRUE;
+
+    return yaml_error(node, error, "invalid DHCP client identifier type '%s'", cur_netdef->dhcp_identifier);
+}
+
 /****************************************************
  * Grammar and handlers for network devices
  ****************************************************/
@@ -1204,6 +1218,7 @@ const mapping_entry_handler ethernet_def_handlers[] = {
     {"addresses", YAML_SEQUENCE_NODE, handle_addresses},
     {"dhcp4", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(dhcp4)},
     {"dhcp6", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(dhcp6)},
+    {"dhcp-identifier", YAML_SCALAR_NODE, handle_dhcp_identifier},
     {"accept-ra", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(accept_ra)},
     {"gateway4", YAML_SCALAR_NODE, handle_gateway4},
     {"gateway6", YAML_SCALAR_NODE, handle_gateway6},
@@ -1225,6 +1240,7 @@ const mapping_entry_handler wifi_def_handlers[] = {
     {"addresses", YAML_SEQUENCE_NODE, handle_addresses},
     {"dhcp4", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(dhcp4)},
     {"dhcp6", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(dhcp6)},
+    {"dhcp-identifier", YAML_SCALAR_NODE, handle_dhcp_identifier},
     {"accept-ra", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(accept_ra)},
     {"gateway4", YAML_SCALAR_NODE, handle_gateway4},
     {"gateway6", YAML_SCALAR_NODE, handle_gateway6},
@@ -1245,6 +1261,7 @@ const mapping_entry_handler bridge_def_handlers[] = {
     {"addresses", YAML_SEQUENCE_NODE, handle_addresses},
     {"dhcp4", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(dhcp4)},
     {"dhcp6", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(dhcp6)},
+    {"dhcp-identifier", YAML_SCALAR_NODE, handle_dhcp_identifier},
     {"accept-ra", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(accept_ra)},
     {"gateway4", YAML_SCALAR_NODE, handle_gateway4},
     {"gateway6", YAML_SCALAR_NODE, handle_gateway6},
@@ -1264,6 +1281,7 @@ const mapping_entry_handler bond_def_handlers[] = {
     {"addresses", YAML_SEQUENCE_NODE, handle_addresses},
     {"dhcp4", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(dhcp4)},
     {"dhcp6", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(dhcp6)},
+    {"dhcp-identifier", YAML_SCALAR_NODE, handle_dhcp_identifier},
     {"accept-ra", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(accept_ra)},
     {"gateway4", YAML_SCALAR_NODE, handle_gateway4},
     {"gateway6", YAML_SCALAR_NODE, handle_gateway6},
@@ -1283,6 +1301,7 @@ const mapping_entry_handler vlan_def_handlers[] = {
     {"addresses", YAML_SEQUENCE_NODE, handle_addresses},
     {"dhcp4", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(dhcp4)},
     {"dhcp6", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(dhcp6)},
+    {"dhcp-identifier", YAML_SCALAR_NODE, handle_dhcp_identifier},
     {"accept-ra", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(accept_ra)},
     {"gateway4", YAML_SCALAR_NODE, handle_gateway4},
     {"gateway6", YAML_SCALAR_NODE, handle_gateway6},
@@ -1396,6 +1415,7 @@ handle_network_type(yaml_document_t* doc, yaml_node_t* node, const void* data, G
             cur_netdef->id = g_strdup(scalar(key));
             cur_netdef->vlan_id = G_MAXUINT; /* 0 is a valid ID */
             cur_netdef->accept_ra = TRUE; /* By default, accept RAs */
+            cur_netdef->dhcp_identifier = g_strdup("duid"); /* keep networkd's default */
             g_hash_table_insert(netdefs, cur_netdef->id, cur_netdef);
         }
 

--- a/src/parse.h
+++ b/src/parse.h
@@ -70,6 +70,7 @@ typedef struct net_definition {
     /* addresses */
     gboolean dhcp4;
     gboolean dhcp6;
+    char* dhcp_identifier;
     gboolean accept_ra;
     GArray* ip4_addresses;
     GArray* ip6_addresses;


### PR DESCRIPTION
WIP while adding tests.