### PR TITLE
Support blacklisting devices for replug in config files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ clean:
 check: default linting
 	tests/generate.py
 	tests/cli.py
+	python3-coverage run --append --omit=tests/\* -- tests/internals.py
 
 linting:
 	$(PYFLAKES3) $(PYCODE)
@@ -70,6 +71,7 @@ install: default
 	install -m 755 generate $(DESTDIR)/$(ROOTLIBEXECDIR)/netplan/
 	find netplan/ -name '*.py' -exec install -Dm 644 "{}" "$(DESTDIR)/$(DATADIR)/netplan/{}" \;
 	install -m 755 src/netplan.script $(DESTDIR)/$(DATADIR)/netplan/
+	install -m 644 blacklist.yaml $(DESTDIR)/$(ROOTLIBEXECDIR)/netplan/00-netplan-replug-blacklist.yaml
 	ln -sr $(DESTDIR)/$(DATADIR)/netplan/netplan.script $(DESTDIR)/$(SBINDIR)/netplan
 	ln -sr $(DESTDIR)/$(ROOTLIBEXECDIR)/netplan/generate $(DESTDIR)/$(SYSTEMD_GENERATOR_DIR)/netplan
 	install -m 644 doc/*.html $(DESTDIR)/$(DOCDIR)/netplan/

--- a/blacklist.yaml
+++ b/blacklist.yaml
@@ -1,0 +1,40 @@
+# devices that are blacklisted for replug
+#
+# Each entry in the list can specify a driver, a subsystem, and a
+# reason. All are optional. Globbing is supported for driver and
+# subsystem.
+#
+# A device will be blacklisted if the driver (if supplied) matches and
+# the subsystem (if supplied) matches. The reason will be printed when
+# blacklisting a device, if supplied.
+
+replug:
+    blacklist:
+        - driver: 'mac80211_hwsim'
+
+        # mwifiex_pcie: workaround for https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1630285
+        - driver: 'mwifiex_pcie'
+          reason: 'crashes on rebind'
+
+        # xen: workaround for https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1729573
+        - subsystem: 'xen'
+          driver: 'vif'
+          reason: 'fails on rebind'
+
+        # workaround for problem with ath9k_htc module: this driver is async and does not support
+        # sequential unbind / rebind, one soon after the other
+        - driver: 'ath9k_htc'
+
+        # workaround for ath6kl_sdio, interface does not work after unbinding
+        - driver: 'ath6kl_sdio'
+
+        # workaround for brcmfmac, interface will be gone after unbind
+        - driver: 'brcmfmac*'
+
+        # workaround for qeth: driver does not recognize unbind command
+        # https://bugs.launchpad.net/ubuntu/+source/netplan.io/+bug/1756322
+        - driver: 'qeth'
+          reason: 'qeth driver does not support rebinding (LP: #1756322)'
+
+    # kill switch - this disables all replugging completely.
+    # disable_all_replug: true

--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -666,5 +666,72 @@ This is a complex example which shows most available features:
           interfaces: [wlp1s0, switchports]
           dhcp4: true
 
+## Replug behaviour
+
+``netplan apply`` finds devices that are down and unbinds them from their
+driver and rebinds them so that ``udev`` rules can take effect. This works for
+most devices but can cause issues in other devices.
+
+To change netplan's behaviour, a ``replug:`` mapping can be provided at the top
+level of any netplan YAML file.
+
+Two properties are supported in the mapping:
+
+``disable_all_replug`` (scalar)
+:    Disables all replugging if specified and not False or empty.
+
+``blacklist`` (sequence of mappings)
+:    A list of devices that should not be repluged. Each entry describes
+     something that should not be replugged.
+
+     ``driver`` (scalar)
+     :    The name of a driver that should not be replugged. Globbing is
+          supported. Optional - an absent value matches any driver.
+
+     ``subsystem`` (scalar)
+     :    The name of a subsystem containing devices that should not be
+          replugged. Globbing is supported. Optional - an absent value matches
+	  any subsystem. Useful if there are similarly named devices in
+          multiple subsystems.
+
+     ``reason`` (scalar)
+     :    Why should the device not be replugged? Printed in debug output,
+          optional.
+
+If multiple YAML files specify a blacklist, the blacklists are concatenated.
+
+Examples:
+
+This will blacklist all ``qeth`` devices:
+
+    replug:
+      blacklist:
+        - driver: qeth
+
+This will blacklist all devices in the Xen subsystem:
+
+    replug:
+      blacklist:
+        - subsystem: xen
+
+This will blacklist only ``vif`` devices in the Xen subsystem, and it will
+print a reason if debug logging is enabled:
+
+    replug:
+      blacklist:
+        - driver: vif
+          subsystem: xen
+          reason: 'fails on rebind'
+
+A single YAML file can contain both ``replug`` and ``network`` information.
+Note that ``network`` and ``replug`` both sit at the top level.
+
+    network:
+        version: 2
+        ethernets:
+            ens3: ...
+    replug:
+        disable_all_replug: true
+
 <!--- vim: ft=markdown
 -->

--- a/netplan/cli/commands/apply.py
+++ b/netplan/cli/commands/apply.py
@@ -22,6 +22,7 @@ import os
 import sys
 import glob
 import subprocess
+import fnmatch
 
 import netplan.cli.utils as utils
 
@@ -37,6 +38,13 @@ class NetplanApply(utils.NetplanCommand):
         self.func = self.command_apply
 
         self.parse_args()
+
+        # apply doesn't currently support an alternative root-dir
+        config = utils.gather_replug_yaml('/')
+
+        self.disable_all_replug = config['disable_all_replug']
+        self.blacklist = config['blacklist']
+
         self.run_command()
 
     def command_apply(self):  # pragma: nocover (covered in autopkgtest)
@@ -98,6 +106,10 @@ class NetplanApply(utils.NetplanCommand):
     def replug(self, device):  # pragma: nocover (covered in autopkgtest)
         '''Unbind and rebind device if it is down'''
 
+        if self.disable_all_replug:
+            logging.debug('disable_all_replug is set, not replugging')
+            return True
+
         devdir = os.path.join('/sys/class/net', device)
 
         try:
@@ -124,35 +136,27 @@ class NetplanApply(utils.NetplanCommand):
             subsystem_name = os.path.basename(subsystem)
             driver = os.path.realpath(os.path.join(devdir, 'device', 'driver'))
             driver_name = os.path.basename(driver)
-            if driver_name == 'mac80211_hwsim':
-                logging.debug('replug %s: mac80211_hwsim does not support rebinding, ignoring', device)
+
+            for entry in self.blacklist:
+                # if a device matches all the criteria in a blacklist entry,
+                # then do not replug it
+                # note that an empty blacklist entry will match everything!
+
+                if 'driver' in entry:
+                    if not fnmatch.fnmatchcase(driver_name, entry['driver']):
+                        continue
+
+                if 'subsystem' in entry:
+                    if not fnmatch.fnmatchcase(subsystem_name, entry['subsystem']):
+                        continue
+
+                logging.debug('replug %s: %s:%s is blacklisted from rebinding: %s',
+                              device,
+                              (entry['subsystem'] if 'subsystem' in entry else '*'),
+                              (entry['driver'] if 'driver' in entry else '*'),
+                              (entry['reason'] if 'reason' in entry else 'unsupported'))
                 return False
-            # workaround for https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1630285
-            if driver_name == 'mwifiex_pcie':
-                logging.debug('replug %s: mwifiex_pcie crashes on rebinding, ignoring', device)
-                return False
-            # workaround for https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1729573
-            if subsystem_name == 'xen' and driver_name == 'vif':
-                logging.debug('replug %s: xen:vif fails on rebinding, ignoring', device)
-                return False
-            # workaround for problem with ath9k_htc module: this driver is async and does not support
-            # sequential unbind / rebind, one soon after the other
-            if driver_name == 'ath9k_htc':
-                logging.debug('replug %s: ath9k_htc does not support rebinding, ignoring', device)
-                return False
-            # workaround for ath6kl_sdio, interface does not work after unbinding
-            if 'ath6kl_sdio' in driver_name:
-                logging.debug('replug %s: ath6kl_sdio driver does not support rebinding, ignoring', device)
-                return False
-            # workaround for brcmfmac, interface will be gone after unbind
-            if 'brcmfmac' in driver_name:
-                logging.debug('replug %s: brcmfmac drivers do not support rebinding, ignoring', device)
-                return False
-            # workaround for qeth: driver does not recognize unbind command
-            # https://bugs.launchpad.net/ubuntu/+source/netplan.io/+bug/1756322
-            if driver_name == 'qeth':
-                logging.debug('replug %s: qeth driver do not support rebinding, ignoring (LP: #1756322)', device)
-                return False
+
             logging.debug('replug %s: unbinding %s from %s', device, devname, driver)
             with open(os.path.join(driver, 'unbind'), 'w') as f:
                 f.write(devname)

--- a/src/parse.c
+++ b/src/parse.c
@@ -1463,8 +1463,15 @@ const mapping_entry_handler network_handlers[] = {
  * Grammar and handlers for root node
  ****************************************************/
 
+/* we don't stress about validating this as it only affects apply */
+static gboolean noop_handler(yaml_document_t* doc, yaml_node_t* node, const void* _, GError** error)
+{
+    return TRUE;
+}
+
 const mapping_entry_handler root_handlers[] = {
     {"network", YAML_MAPPING_NODE, NULL, network_handlers},
+    {"replug", YAML_MAPPING_NODE, noop_handler},
     {NULL}
 };
 

--- a/tests/generate.py
+++ b/tests/generate.py
@@ -144,6 +144,12 @@ class TestConfigArgs(TestBase):
         self.assertEqual(os.listdir(self.workdir.name), ['etc'])
         self.assert_udev(None)
 
+    def test_replug_config(self):
+        self.generate('replug:\n  disable_all_replug: true\n')
+        # should not write any files
+        self.assertEqual(os.listdir(self.workdir.name), ['etc'])
+        self.assert_udev(None)
+
     def test_file_args(self):
         conf = os.path.join(self.workdir.name, 'config')
         with open(conf, 'w') as f:

--- a/tests/internals.py
+++ b/tests/internals.py
@@ -1,0 +1,107 @@
+#!/usr/bin/python3
+# Tests of some internal netplan logic that isn't exposed by the CLI
+# but is worth testing outside of the integration tests. These are run
+# during "make check" and don't touch the system configuration at all.
+#
+# Copyright (C) 2018 Canonical, Ltd.
+# Author: Daniel Axtens <daniel.axtens@canonical.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import sys
+import unittest
+import tempfile
+import logging
+
+# for tests of replug logic, we want to import utils from netplan directly
+# as there's no command you can run
+sys.path.append(".")
+from netplan.cli import utils  # noqa: E402 (must import after updating path)
+
+
+class TestGatherReplugYAML(unittest.TestCase):
+    """We want to unit test the replug parsing code as the shadowing and
+    updating is easy to get wrong. We can't test the actual replug
+    here.
+    """
+
+    def setUp(self):
+        self.workdir = tempfile.TemporaryDirectory()
+        for yaml_dir in ['etc', 'lib', 'run']:
+            os.makedirs(os.path.join(self.workdir.name, yaml_dir, 'netplan'))
+
+    def test_noop(self):
+        result = utils.gather_replug_yaml(self.workdir.name)
+        self.assertFalse(result['disable_all_replug'])
+        self.assertEqual(result['blacklist'], [])
+
+    def test_no_replug_data(self):
+        fname = os.path.join(self.workdir.name, 'etc', 'netplan', '10-network.yaml')
+        with open(fname, 'w') as f:
+            f.write('network:\n version: 2\n ethernets:\n  enlol: {dhcp4: yes}')
+
+        result = utils.gather_replug_yaml(self.workdir.name)
+        self.assertFalse(result['disable_all_replug'])
+        self.assertEqual(result['blacklist'], [])
+
+    def test_kill_switch(self):
+        fname = os.path.join(self.workdir.name, 'etc', 'netplan', '10-killall.yaml')
+        with open(fname, 'w') as f:
+            f.write("replug:\n disable_all_replug: true")
+
+        result = utils.gather_replug_yaml(self.workdir.name)
+        self.assertTrue(result['disable_all_replug'])
+
+    def test_broken_yaml(self):
+        # we silence logging to suppress the error printed in the function
+        old_level = logging.getLogger().getEffectiveLevel()
+        logging.getLogger().setLevel(logging.CRITICAL)
+        fname = os.path.join(self.workdir.name, 'etc', 'netplan', '10-broken.yaml')
+        with open(fname, 'w') as f:
+            f.write('\n]}?x*')
+
+        with self.assertRaises(SystemExit):
+            utils.gather_replug_yaml(self.workdir.name)
+
+        logging.getLogger().setLevel(old_level)
+
+    def test_shadowing(self):
+        fname_lib = os.path.join(self.workdir.name, 'lib', 'netplan', 'file.yaml')
+        with open(fname_lib, 'w') as f:
+            f.write('replug:\n blacklist:\n  - driver: fish')
+
+        fname_etc = os.path.join(self.workdir.name, 'etc', 'netplan', 'file.yaml')
+        with open(fname_etc, 'w') as f:
+            f.write('replug:\n blacklist:\n  - driver: seal')
+
+        result = utils.gather_replug_yaml(self.workdir.name)
+
+        self.assertEqual(result['blacklist'], [{'driver': 'seal'}])
+
+    def test_updating(self):
+        fname_lib = os.path.join(self.workdir.name, 'lib', 'netplan', 'lib.yaml')
+        with open(fname_lib, 'w') as f:
+            f.write('replug:\n blacklist:\n  - driver: fish')
+
+        fname_etc = os.path.join(self.workdir.name, 'run', 'netplan', 'run.yaml')
+        with open(fname_etc, 'w') as f:
+            f.write('replug:\n blacklist:\n  - driver: seal')
+
+        result = utils.gather_replug_yaml(self.workdir.name)
+
+        self.assertTrue(any([x['driver'] == 'seal' for x in result['blacklist']]))
+        self.assertTrue(any([x['driver'] == 'fish' for x in result['blacklist']]))
+
+
+unittest.main(testRunner=unittest.TextTestRunner(stream=sys.stdout, verbosity=2))


### PR DESCRIPTION
Currently, devices that are blacklisted for replug are hardcoded
in `apply.py`. This is going to make support harder as people will
have to patch a python file to add another blacklist entry.

Introduce `replug:` as a mapping at the top level that contains:

 - `disable_all_replug`: a kill switch for replugging

 - `blacklist`: a sequence of mappings that describes devices to be
              blacklisted

The contents of the current list is moved to `blacklist.yaml` which
is installed in `/lib/netplan/00-netplan-replug-blacklist.yaml`