### PR TITLE
bonds: default to milliseconds for unspecified values in intervals

### DIFF
--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -441,7 +441,7 @@ wpasupplicant installed if you let the ``networkd`` renderer handle wifi.
 :    Customization parameters for special bonding options. Using the
      NetworkManager renderer, parameter values for intervals should be
      expressed in milliseconds; for the systemd renderer, they are interpreted
-     to be in seconds unless a time suffix (such as "ms" for milliseconds) is
+     to be in milliseconds unless a time suffix (such as "s" for seconds) is
      specified. Time values are passed directly to the backend.
 
      ``mode`` (scalar)
@@ -553,11 +553,11 @@ wpasupplicant installed if you let the ``networkd`` renderer handle wifi.
           are sent at 200ms intervals.
 
      ``learn-packet-interval`` (scalar)
-     :    Specify the interval between sending learning packets to each slave.
-          The value range is between ``1`` and ``0x7fffffff``. The default
-          value is ``1``. This option only affects ``balance-tlb`` and
-          ``balance-alb`` modes. Using the networkd renderer, this field maps
-          to the LearnPacketIntervalSec= property.
+     :    Specify the interval (seconds) between sending learning packets to
+          each slave.  The value range is between ``1`` and ``0x7fffffff``.
+          The default value is ``1``. This option only affects ``balance-tlb``
+          and ``balance-alb`` modes. Using the networkd renderer, this field
+          maps to the LearnPacketIntervalSec= property.
 
      ``primary`` (scalar)
      :    Specify a device to be used as a primary slave, or preferred device

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -113,6 +113,19 @@ write_link_file(net_definition* def, const char* rootdir, const char* path)
     g_string_free_to_file(s, rootdir, path, ".link");
 }
 
+
+static gboolean
+interval_has_suffix(const char* param) {
+    gchar* endptr;
+
+    g_ascii_strtoull(param, &endptr, 10);
+    if (*endptr == '\0')
+        return FALSE;
+
+    return TRUE;
+}
+
+
 static void
 write_bond_parameters(net_definition* def, GString* s)
 {
@@ -124,8 +137,13 @@ write_bond_parameters(net_definition* def, GString* s)
         g_string_append_printf(params, "\nMode=%s", def->bond_params.mode);
     if (def->bond_params.lacp_rate)
         g_string_append_printf(params, "\nLACPTransmitRate=%s", def->bond_params.lacp_rate);
-    if (def->bond_params.monitor_interval)
-        g_string_append_printf(params, "\nMIIMonitorSec=%s", def->bond_params.monitor_interval);
+    if (def->bond_params.monitor_interval) {
+        g_string_append(params, "\nMIIMonitorSec=");
+        if (interval_has_suffix(def->bond_params.monitor_interval))
+            g_string_append(params, def->bond_params.monitor_interval);
+        else
+            g_string_append_printf(params, "%sms", def->bond_params.monitor_interval);
+    }
     if (def->bond_params.min_links)
         g_string_append_printf(params, "\nMinLinks=%d", def->bond_params.min_links);
     if (def->bond_params.transmit_hash_policy)
@@ -134,8 +152,13 @@ write_bond_parameters(net_definition* def, GString* s)
         g_string_append_printf(params, "\nAdSelect=%s", def->bond_params.selection_logic);
     if (def->bond_params.all_slaves_active)
         g_string_append_printf(params, "\nAllSlavesActive=%d", def->bond_params.all_slaves_active);
-    if (def->bond_params.arp_interval)
-        g_string_append_printf(params, "\nARPIntervalSec=%s", def->bond_params.arp_interval);
+    if (def->bond_params.arp_interval) {
+        g_string_append(params, "\nARPIntervalSec=");
+        if (interval_has_suffix(def->bond_params.arp_interval))
+            g_string_append(params, def->bond_params.arp_interval);
+        else
+            g_string_append_printf(params, "%sms", def->bond_params.arp_interval);
+    }
     if (def->bond_params.arp_ip_targets && def->bond_params.arp_ip_targets->len > 0) {
         g_string_append_printf(params, "\nARPIPTargets=");
         for (unsigned i = 0; i < def->bond_params.arp_ip_targets->len; ++i) {
@@ -148,10 +171,20 @@ write_bond_parameters(net_definition* def, GString* s)
         g_string_append_printf(params, "\nARPValidate=%s", def->bond_params.arp_validate);
     if (def->bond_params.arp_all_targets)
         g_string_append_printf(params, "\nARPAllTargets=%s", def->bond_params.arp_all_targets);
-    if (def->bond_params.up_delay)
-        g_string_append_printf(params, "\nUpDelaySec=%s", def->bond_params.up_delay);
-    if (def->bond_params.down_delay)
-        g_string_append_printf(params, "\nDownDelaySec=%s", def->bond_params.down_delay);
+    if (def->bond_params.up_delay) {
+        g_string_append(params, "\nUpDelaySec=");
+        if (interval_has_suffix(def->bond_params.up_delay))
+            g_string_append(params, def->bond_params.up_delay);
+        else
+            g_string_append_printf(params, "%sms", def->bond_params.up_delay);
+    }
+    if (def->bond_params.down_delay) {
+        g_string_append(params, "\nDownDelaySec=");
+        if (interval_has_suffix(def->bond_params.down_delay))
+            g_string_append(params, def->bond_params.down_delay);
+        else
+            g_string_append_printf(params, "%sms", def->bond_params.down_delay);
+    }
     if (def->bond_params.fail_over_mac_policy)
         g_string_append_printf(params, "\nFailOverMACPolicy=%s", def->bond_params.fail_over_mac_policy);
     if (def->bond_params.gratuitious_arp)

--- a/tests/generate.py
+++ b/tests/generate.py
@@ -1479,12 +1479,12 @@ unmanaged-devices+=interface-name:bn0,''')
         lacp-rate: 10
         mii-monitor-interval: 10
         min-links: 10
-        up-delay: 20ms
-        down-delay: 30s
+        up-delay: 20
+        down-delay: 30
         all-slaves-active: true
         transmit-hash-policy: none
         ad-select: none
-        arp-interval: 15m
+        arp-interval: 15
         arp-validate: all
         arp-all-targets: all
         fail-over-mac-policy: none
@@ -1508,18 +1508,50 @@ unmanaged-devices+=interface-name:bn0,''')
                                             'TransmitHashPolicy=none\n'
                                             'AdSelect=none\n'
                                             'AllSlavesActive=1\n'
-                                            'ARPIntervalSec=15m\n'
+                                            'ARPIntervalSec=15ms\n'
                                             'ARPIPTargets=10.10.10.10,20.20.20.20\n'
                                             'ARPValidate=all\n'
                                             'ARPAllTargets=all\n'
                                             'UpDelaySec=20ms\n'
-                                            'DownDelaySec=30s\n'
+                                            'DownDelaySec=30ms\n'
                                             'FailOverMACPolicy=none\n'
                                             'GratuitiousARP=10\n'
                                             'PacketsPerSlave=10\n'
                                             'PrimaryReselectPolicy=none\n'
                                             'ResendIGMP=10\n'
                                             'LearnPacketIntervalSec=10\n',
+                              'bn0.network': ND_DHCP4 % 'bn0',
+                              'eno1.network': '[Match]\nName=eno1\n\n'
+                                              '[Network]\nBond=bn0\nLinkLocalAddressing=no\n',
+                              'switchports.network': '[Match]\nDriver=yayroute\n\n'
+                                                     '[Network]\nBond=bn0\nLinkLocalAddressing=no\n'})
+
+    def test_bond_with_parameters_all_suffix(self):
+        self.generate('''network:
+  version: 2
+  ethernets:
+    eno1: {}
+    switchports:
+      match:
+        driver: yayroute
+  bonds:
+    bn0:
+      parameters:
+        mode: 802.1ad
+        mii-monitor-interval: 10ms
+        up-delay: 20ms
+        down-delay: 30s
+        arp-interval: 15m
+      interfaces: [eno1, switchports]
+      dhcp4: true''')
+
+        self.assert_networkd({'bn0.netdev': '[NetDev]\nName=bn0\nKind=bond\n\n'
+                                            '[Bond]\n'
+                                            'Mode=802.1ad\n'
+                                            'MIIMonitorSec=10ms\n'
+                                            'ARPIntervalSec=15m\n'
+                                            'UpDelaySec=20ms\n'
+                                            'DownDelaySec=30s\n',
                               'bn0.network': ND_DHCP4 % 'bn0',
                               'eno1.network': '[Match]\nName=eno1\n\n'
                                               '[Network]\nBond=bn0\nLinkLocalAddressing=no\n',

--- a/tests/generate.py
+++ b/tests/generate.py
@@ -1479,12 +1479,12 @@ unmanaged-devices+=interface-name:bn0,''')
         lacp-rate: 10
         mii-monitor-interval: 10
         min-links: 10
-        up-delay: 10
-        down-delay: 10
+        up-delay: 20ms
+        down-delay: 30s
         all-slaves-active: true
         transmit-hash-policy: none
         ad-select: none
-        arp-interval: 10
+        arp-interval: 15m
         arp-validate: all
         arp-all-targets: all
         fail-over-mac-policy: none
@@ -1503,17 +1503,17 @@ unmanaged-devices+=interface-name:bn0,''')
                                             '[Bond]\n'
                                             'Mode=802.1ad\n'
                                             'LACPTransmitRate=10\n'
-                                            'MIIMonitorSec=10\n'
+                                            'MIIMonitorSec=10ms\n'
                                             'MinLinks=10\n'
                                             'TransmitHashPolicy=none\n'
                                             'AdSelect=none\n'
                                             'AllSlavesActive=1\n'
-                                            'ARPIntervalSec=10\n'
+                                            'ARPIntervalSec=15m\n'
                                             'ARPIPTargets=10.10.10.10,20.20.20.20\n'
                                             'ARPValidate=all\n'
                                             'ARPAllTargets=all\n'
-                                            'UpDelaySec=10\n'
-                                            'DownDelaySec=10\n'
+                                            'UpDelaySec=20ms\n'
+                                            'DownDelaySec=30s\n'
                                             'FailOverMACPolicy=none\n'
                                             'GratuitiousARP=10\n'
                                             'PacketsPerSlave=10\n'


### PR DESCRIPTION
Linux kernel bond parameter settings are exclusively in millisecond
units, save lp_interval which is in seconds.  Existing configurations and
documentation indicate values for mii-monitor-interval, arp-interval,
up-delay and down-delay are expressed in milliseconds.  Netplan will render
these values as milliseconds in the networkd backend unless a user has
indicated a different time unit by appending a suffix, like 's' for seconds.

LP: #1765833