### PR TITLE
Defer creation of ConfigManager tmpdir until needed

### DIFF
--- a/netplan/cli/commands/try_command.py
+++ b/netplan/cli/commands/try_command.py
@@ -43,7 +43,13 @@ class NetplanTry(utils.NetplanCommand):
                          leaf=True)
         self.configuration_changed = False
         self.new_interfaces = None
-        self.config_manager = ConfigManager()
+        self._config_manager = None
+
+    @property
+    def config_manager(self):
+        if not self._config_manager:
+            self._config_manager = ConfigManager()
+        return self._config_manager
 
     def run(self):  # pragma: nocover (requires user input)
         self.parser.add_argument('--config-file',


### PR DESCRIPTION
The ConfigManager object creates a tempdir upon instatiation, but due to how commands are loaded, the cleanup method isn't called for commands outside of 'try'.  Resolve this by deferring the tmpdir creation by use of @property allowing the first caller of config_manager to trigger the initialization.

LP: #1767464