### PR TITLE
Examples and Documentation for one nic, multiple IPs/gateways

### DIFF
--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -601,6 +601,30 @@ DHCP:
       ethernets:
         eno1:
           dhcp4: true
+          
+This is an example of a static-configured interface with multiple IPv4 addresses
+and multiple gateways with networkd, with equal route metric levels, and static 
+DNS nameservers (Google DNS for this example):
+
+    network:
+      version: 2
+      renderer: networkd
+      ethernets:
+        eno1:
+          addresses:
+          - 10.0.0.10/24
+          - 11.0.0.11/24
+          nameservers:
+            addresses:
+              - 8.8.8.8
+              - 8.8.4.4
+          routes:
+          - to: 0.0.0.0/0
+            via: 10.0.0.1
+            metric: 100
+          - to: 0.0.0.0/0
+            via: 11.0.0.1
+            metric: 100 
 
 This is a complex example which shows most available features:
 

--- a/examples/static_singlenic_multiip_multigateway.yaml
+++ b/examples/static_singlenic_multiip_multigateway.yaml
@@ -1,0 +1,19 @@
+network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    eno1:
+      addresses:
+      - 10.0.0.10/24
+      - 11.0.0.11/24
+      nameservers:
+        addresses:
+          - 8.8.8.8
+          - 8.8.4.4
+      routes:
+      - to: 0.0.0.0/0
+        via: 10.0.0.1
+        metric: 100
+      - to: 0.0.0.0/0
+        via: 11.0.0.1
+        metric: 100


### PR DESCRIPTION
What was missing in the examples and documentation is a common case when trying to use Ubuntu on VPSes.  VPSes get created with a *single* NIC of which all IP addresses assigned to the VPS can be used on.

For some background though, I have a VPS from RamNode that I was installing 18.04 on, and it has a couple of IPs that are all the same gateway, but a couple IPs which aren't because they go through a different circuit at the same datacenter/host.  This all happens on a single NIC, so setting up this type of setup was not documented in existing examples for Netplan.

In typical `ifupdown` fashion (the "old school" way), you'd have to do some manual `ip addr add` and `ip route add` magic to make it work properly, or you'd have to use NIC aliases (`eno1`, `eno1:1`, etc.) to achieve this.  There was no documented example of this for Netplan.

Thanks to cyphermox, however, and some inquiring on how I would achieve this in `#ubuntu-server` on IRC, a working example was provided to me which works.  In [Launchpad bug #1767227 which I had created on this issue of lack of documentation](https://bugs.launchpad.net/netplan/+bug/1767227) it was suggested I write up an example and provide it into the example documentation and the provided example yamls.

If this needs revisions, maintainers here are allowed to make edits/revisions.  I am happy to alter things as needed though, and some of my wording may need standardized for the documentation; if that's needed let me know I'll do my best to accommodate.