### PR TITLE
ip leases: Add error handling when interface is not configured in net…

### DIFF
--- a/netplan/cli/commands/ip.py
+++ b/netplan/cli/commands/ip.py
@@ -21,6 +21,7 @@ import logging
 import os
 import sys
 import subprocess
+from subprocess import CalledProcessError
 
 import netplan.cli.utils as utils
 
@@ -139,7 +140,10 @@ class NetplanIpLeases(utils.NetplanCommand):
 
         # Extract out of the generator our mapping in a dict.
         logging.debug('command ip leases: running %s', argv)
-        out = subprocess.check_output(argv, universal_newlines=True)
+        try:
+            out = subprocess.check_output(argv, universal_newlines=True)
+        except CalledProcessError as e:  # pragma: nocover (better be covered in autopkgtest)
+            sys.exit(1)
         mapping = {}
         mapping_s = out.split(',')
         for keyvalue in mapping_s:


### PR DESCRIPTION
…plan or not set to DHCP.

For the command "netplan ip leases <interface>" to work, each interface needs to
be directly specified in a file under /etc/netplan and set to DHCP.

If the interface doesn't meet the above requirement, the command will
fail and generate a Traceback as follow :

Traceback (most recent call last):
  File "/usr/sbin/netplan", line 23, in <module>
    netplan.main()
  File "/usr/share/netplan/netplan/cli/core.py", line 50, in main
    self.run_command()
  File "/usr/share/netplan/netplan/cli/utils.py", line 130, in run_command
    self.func()
  File "/usr/share/netplan/netplan/cli/commands/ip.py", line 56, in run
    self.run_command()
  File "/usr/share/netplan/netplan/cli/utils.py", line 130, in run_command
    self.func()
  File "/usr/share/netplan/netplan/cli/commands/ip.py", line 75, in run
    self.run_command()
  File "/usr/share/netplan/netplan/cli/utils.py", line 130, in run_command
    self.func()
  File "/usr/share/netplan/netplan/cli/commands/ip.py", line 142, in command_ip_leases
    out = subprocess.check_output(argv, universal_newlines=True)
  File "/usr/lib/python3.6/subprocess.py", line 336, in check_output
    **kwargs).stdout
  File "/usr/lib/python3.6/subprocess.py", line 418, in run
    output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command '['/lib/netplan/generate', '--mapping', 'eth1']' returned non-zero exit status 1.