### PR TITLE
Doc fixups and test script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ check: default linting
 	tests/generate.py
 	tests/cli.py
 	nosetests3 -v --with-coverage
+	tests/validate_docs.sh
 
 linting:
 	$(PYFLAKES3) $(PYCODE)

--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -225,13 +225,12 @@ similar to ``gateway*``, and ``search:`` is a list of search domains.
      only, due to interactions with device renaming in udev. Match
      devices by MAC when setting MTU.
 
-``optional`` (boolean)
+``optional`` (bool)
 
-: An optional device is not required for booting. Normally, networkd
-will wait some time for device to become configured before proceeding
-with booting. However, if a device is marked as optional, networkd
-will not wait for it. This is *only* supported by networkd, and the
-default is false.
+:    An optional device is not required for booting. Normally, networkd will
+     wait some time for device to become configured before proceeding with
+     booting. However, if a device is marked as optional, networkd will not wait
+     for it. This is *only* supported by networkd, and the default is false.
 
     Example:
 

--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -326,7 +326,7 @@ These options are available for all types of interfaces.
           in which routing rules are processed. A higher number means lower
           priority: rules are processed in order by increasing priority number.
 
-     ``fwmark`` (scalar)
+     ``mark`` (scalar)
      :    Have this routing policy rule match on traffic that has been marked
           by the iptables firewall with this value. Allowed values are positive
           integers starting from 1.

--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -216,6 +216,15 @@ similar to ``gateway*``, and ``search:`` is a list of search domains.
             [...]
             macaddress: 52:54:00:6b:3c:59
 
+``mtu`` (scalar)
+
+:    Set the Maximum Transmission Unit for the interface. The default is 1500.
+     Valid values depend on your network interface.
+
+     **Note:** This will not work reliably for devices matched by name
+     only, due to interactions with device renaming in udev. Match
+     devices by MAC when setting MTU.
+
 ``optional`` (boolean)
 
 : An optional device is not required for booting. Normally, networkd

--- a/tests/validate_docs.sh
+++ b/tests/validate_docs.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# find everything that looks like
+#     {"driver", YAML_SCALAR_NODE,...,
+# extract the thing in quotes.
+
+# sanity check: make sure none have disappeared, as might happen from a reformat.
+count=$(sed -n 's/[ ]\+{"\([a-z0-9-]\+\)", YAML_[A-Z]\+_NODE.*/\1/p' src/parse.c | sort | uniq | wc -l)
+# 71 is based on the 0.36.1 definititions, and should be updated periodically.
+if [ $count -lt 71 ]; then
+    echo "ERROR: fewer YAML keys defined in src/parse.c than expected!"
+    echo "       Has the file been reformatted or refactored? If so, modify"
+    echo "       validate_docs.sh appropriately."
+    exit 1
+fi
+
+# iterate through the keys
+for term in $(sed -n 's/[ ]\+{"\([a-z0-9-]\+\)", YAML_[A-Z]\+_NODE.*/\1/p' src/parse.c | sort | uniq); do
+    # it can be documented in the following ways.
+    # 1. "Properties for device type ``blah:``
+    if egrep "## Properties for device type \`\`$term:\`\`" doc/netplan.md > /dev/null; then
+	continue
+    fi
+
+    # 2. "[blah, ]``blah``[, ``blah2``]: (scalar|bool|...)
+    if egrep "\`\`$term\`\`.*\((scalar|bool|mapping|sequence of scalars)\)" doc/netplan.md > /dev/null; then
+	continue
+    fi
+
+    # 3. we give a pass to network and version
+    if [[ $term = "network" ]] || [[ $term = "version" ]]; then
+	continue
+    fi
+
+    # 4. search doesn't get a full description but it's good enough
+    if [[ $term = "search" ]]; then
+	continue
+    fi
+    
+    echo ERROR: The key "$term" is defined in the parser but not documented.
+    exit 1
+done


### PR DESCRIPTION
I went to document the fact that setting the MTU on a device works reliably only if you match by MAC, but found that MTU wasn't documented at all! So I documented it.

The lack of documentation of MTU was a bit of a shock because I just recently attempted to go through and manually check everything was documented. (I documented resend-igmp and optional at that point.) So I was surprised I had missed something so obvious! I decided that therefore it was probably a good idea to do this automatically, so I wrote a shell script that goes through parse.c, extracts keys from mappings and makes sure they're all documented. In the process I caught:
 - `mark` being documented as `fwmark` and
 - my optional docs being subtly different in format from the rest of the file.

The new check runs during `make check` and is very fast and requires no dependencies beyond `bash`, `sed` and `grep`.