### PR TITLE
Implement support for advanced authentication options

### DIFF
--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -494,9 +494,9 @@ interfaces, as well as individual wifi networks, by means of the ``auth`` block.
      The following properties can be used if ``key-management`` is ``wpa-eap``
      or ``802.1x``:
 
-     ``eap-method`` (scalar)
-     :    The supported EAP methods are ``tls`` (TLS), ``peap`` (Protected EAP),
-          and ``ttls`` (Tunneled TLS).
+     ``method`` (scalar)
+     :    The EAP method to use. The supported EAP methods are ``tls`` (TLS),
+          ``peap`` (Protected EAP), and ``ttls`` (Tunneled TLS).
 
      ``identity`` (scalar)
      :    The identity to use for EAP.

--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -482,9 +482,9 @@ interfaces, as well as individual wifi networks, by means of the ``auth`` block.
 
      ``key-management`` (scalar)
      :    The supported key management modes are ``none`` (no key management);
-          ``wpa-psk`` (WPA with pre-shared key, common for home wifi);
-          ``wpa-eap`` (WPA with EAP, common for enterprise wifi); and ``802.1x``
-          (used primarily for wired Ethernet connections).
+          ``psk`` (WPA with pre-shared key, common for home wifi); ``eap`` (WPA
+          with EAP, common for enterprise wifi); and ``802.1x`` (used primarily
+          for wired Ethernet connections).
 
      The following properties can be used if ``key-management`` is ``wpa-psk``:
 
@@ -550,7 +550,7 @@ wpasupplicant installed if you let the ``networkd`` renderer handle wifi.
           is equivalent to
 
               auth:
-                key-management: wpa-psk
+                key-management: psk
                 psk: "S3kr1t"
 
      ``mode`` (scalar)

--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -551,7 +551,7 @@ wpasupplicant installed if you let the ``networkd`` renderer handle wifi.
 
               auth:
                 key-management: psk
-                psk: "S3kr1t"
+                password: "S3kr1t"
 
      ``mode`` (scalar)
      :    Possible access point modes are ``infrastructure`` (the default),

--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -475,82 +475,54 @@ interfaces, as well as individual wifi networks, by means of the ``auth`` block.
 
 ``auth`` (mapping)
 
-:    Specifies authentication settings for a device of type ``ethernets:`` or
-     ``wifis:``, or a single wifi ``access-points:`` entry. If ``auth`` blocks
-     are specified on both a wifi device and one of its access points, only the
-     settings in the access point's ``auth`` block are taken into account;
-     however, the ``auth`` block of the wifi device, if present, is used for any
-     ``access-points:`` without their own ``auth`` block.
+:    Specifies authentication settings for a device of type ``ethernets:``, or
+     an ``access-points:`` entry on a ``wifis:`` device.
 
-     Example:
+     The ``auth`` block supports the following properties:
 
-          wifis:
-            wlp1s0:
-              auth:
-                key-mgmt: wpa-psk
-                psk: "d3f4ul7"
-              access-points:
-                office:
-                  auth:
-                    # the authentication settings above are ignored for the
-                    # wifi named "office"
-                    key-mgmt: wpa-eap
-                    eap-method: ttls
-                    anonymous-identity: "@internal.example.com"
-                    identity: "joe@internal.example.com"
-                    password: "v4ryS3kr1t"
-                home:
-                  mode: infrastructure
-                  # the authentication settings above are applied to the wifi
-                  # named "home"
+     ``key-management`` (scalar)
+     :    The supported key management modes are ``none`` (no key management);
+          ``wpa-psk`` (WPA with pre-shared key, common for home wifi);
+          ``wpa-eap`` (WPA with EAP, common for enterprise wifi); and ``802.1x``
+          (used primarily for wired Ethernet connections).
 
-      The ``auth`` block supports the following properties:
+     The following properties can be used if ``key-management`` is ``wpa-psk``:
 
-      ``key-mgmt`` (scalar)
-      :    The supported key management modes are ``none`` (no key management),
-           ``wpa-psk`` (WPA with pre-shared key, common for home wifi),
-           ``wpa-eap`` (WPA with EAP, common for enterprise wifi) and ``8021x``
-           (used primarily for wired Ethernet connections).
+     ``psk`` (scalar)
+     :    The pre-shared key for this connection.
 
-      The following properties can be used if ``key-mgmt`` is ``wpa-psk``:
+     The following properties can be used if ``key-management`` is ``wpa-eap``
+     or ``802.1x``:
 
-      ``psk`` (scalar)
-      :    The pre-shared key for this connection. Useful only if ``key-mgmt``
-           is ``wpa-psk``.
+     ``eap-method`` (scalar)
+     :    The supported EAP methods are ``tls`` (TLS), ``peap`` (Protected EAP),
+          and ``ttls`` (Tunneled TLS).
 
-      ``eap-method`` (scalar)
-      :    The supported EAP methods are ``tls`` (TLS), ``peap`` (Protected EAP)
-           and ``ttls`` (Tunneled TLS). Useful only if ``key-mgmt`` is
-           ``wpa-eap`` or ``8021x``.
+     ``identity`` (scalar)
+     :    The identity to use for EAP.
 
-      The following properties can be used if ``key-mgmt`` is ``wpa-eap`` or
-      ``8021x``:
+     ``anonymous-identity`` (scalar)
+     :    The identity to pass over the unencrypted channel if the chosen EAP
+          method supports passing a different tunnelled identity.
 
-      ``identity`` (scalar)
-      :    The identity to use for EAP.
+     ``password`` (scalar)
+     :    The password string for EAP.
 
-      ``anonymous-identity`` (scalar)
-      :    The identity to pass over the unencrypted channel if the chosen EAP
-           method supports passing a different tunnelled identity.
+     ``ca-certificate`` (scalar)
+     :    Path to a file with one or more trusted certificate authority (CA)
+          certificates.
 
-      ``password`` (scalar)
-      :    The password string for EAP.
+     ``client-certificate`` (scalar)
+     :    Path to a file containing the certificate to be used by the client
+          during authentication.
 
-      ``ca-certificate`` (scalar)
-      :    Path to a file with one or more trusted certificate authority (CA)
-           certificates.
+     ``client-key`` (scalar)
+     :    Path to a file containing the private key corresponding to
+          ``client-certificate``.
 
-      ``client-certificate`` (scalar)
-      :    Path to a file containing the certificate to be used by the client
-           during authentication.
-
-      ``client-key`` (scalar)
-      :    Path to a file containing the private key corresponding to
-           ``client-certificate``.
-
-      ``client-key-password`` (scalar)
-      :    Password to use to decrypt the private key specified in
-           ``client-key`` if it is encrypted.
+     ``client-key-password`` (scalar)
+     :    Password to use to decrypt the private key specified in
+          ``client-key`` if it is encrypted.
 
 
 ## Properties for device type ``ethernets:``
@@ -578,7 +550,7 @@ wpasupplicant installed if you let the ``networkd`` renderer handle wifi.
           is equivalent to
 
               auth:
-                key-mgmt: wpa-psk
+                key-management: wpa-psk
                 psk: "S3kr1t"
 
      ``mode`` (scalar)

--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -469,6 +469,90 @@ These options are available for all types of interfaces.
      :    Match this policy rule based on the type of service number applied to
           the traffic.
 
+## Authentication
+Netplan supports advanced authentication settings for ethernet and wifi
+interfaces, as well as individual wifi networks, by means of the ``auth`` block.
+
+``auth`` (mapping)
+
+:    Specifies authentication settings for a device of type ``ethernets:`` or
+     ``wifis:``, or a single wifi ``access-points:`` entry. If ``auth`` blocks
+     are specified on both a wifi device and one of its access points, only the
+     settings in the access point's ``auth`` block are taken into account;
+     however, the ``auth`` block of the wifi device, if present, is used for any
+     ``access-points:`` without their own ``auth`` block.
+
+     Example:
+
+          wifis:
+            wlp1s0:
+              auth:
+                key-mgmt: wpa-psk
+                psk: "d3f4ul7"
+              access-points:
+                office:
+                  auth:
+                    # the authentication settings above are ignored for the
+                    # wifi named "office"
+                    key-mgmt: wpa-eap
+                    eap-method: ttls
+                    anonymous-identity: "@internal.example.com"
+                    identity: "joe@internal.example.com"
+                    password: "v4ryS3kr1t"
+                home:
+                  mode: infrastructure
+                  # the authentication settings above are applied to the wifi
+                  # named "home"
+
+      The ``auth`` block supports the following properties:
+
+      ``key-mgmt`` (scalar)
+      :    The supported key management modes are ``none`` (no key management),
+           ``wpa-psk`` (WPA with pre-shared key, common for home wifi),
+           ``wpa-eap`` (WPA with EAP, common for enterprise wifi) and ``8021x``
+           (used primarily for wired Ethernet connections).
+
+      The following properties can be used if ``key-mgmt`` is ``wpa-psk``:
+
+      ``psk`` (scalar)
+      :    The pre-shared key for this connection. Useful only if ``key-mgmt``
+           is ``wpa-psk``.
+
+      ``eap-method`` (scalar)
+      :    The supported EAP methods are ``tls`` (TLS), ``peap`` (Protected EAP)
+           and ``ttls`` (Tunneled TLS). Useful only if ``key-mgmt`` is
+           ``wpa-eap`` or ``8021x``.
+
+      The following properties can be used if ``key-mgmt`` is ``wpa-eap`` or
+      ``8021x``:
+
+      ``identity`` (scalar)
+      :    The identity to use for EAP.
+
+      ``anonymous-identity`` (scalar)
+      :    The identity to pass over the unencrypted channel if the chosen EAP
+           method supports passing a different tunnelled identity.
+
+      ``password`` (scalar)
+      :    The password string for EAP.
+
+      ``ca-certificate`` (scalar)
+      :    Path to a file with one or more trusted certificate authority (CA)
+           certificates.
+
+      ``client-certificate`` (scalar)
+      :    Path to a file containing the certificate to be used by the client
+           during authentication.
+
+      ``client-key`` (scalar)
+      :    Path to a file containing the private key corresponding to
+           ``client-certificate``.
+
+      ``client-key-password`` (scalar)
+      :    Password to use to decrypt the private key specified in
+           ``client-key`` if it is encrypted.
+
+
 ## Properties for device type ``ethernets:``
 Ethernet device definitions do not support any specific properties beyond the
 common ones described above.
@@ -485,9 +569,17 @@ wpasupplicant installed if you let the ``networkd`` renderer handle wifi.
      supported properties:
 
      ``password`` (scalar)
-     :    Enable WPA2 authentication and set the passphrase for it. If not
-          given, the network is assumed to be open. Other authentication modes
-          are not currently supported.
+     :    Enable WPA2 authentication and set the passphrase for it. If neither
+          this nor an ``auth`` block are given, the network is assumed to be
+          open. The setting
+
+              password: "S3kr1t"
+
+          is equivalent to
+
+              auth:
+                key-mgmt: wpa-psk
+                psk: "S3kr1t"
 
      ``mode`` (scalar)
      :    Possible access point modes are ``infrastructure`` (the default),

--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -486,12 +486,15 @@ interfaces, as well as individual wifi networks, by means of the ``auth`` block.
           with EAP, common for enterprise wifi); and ``802.1x`` (used primarily
           for wired Ethernet connections).
 
-     The following properties can be used if ``key-management`` is ``wpa-psk``:
+     ``password`` (scalar)
+     :    The password string for EAP, or the pre-shared key for WPA-PSK.
+
+     The following properties can be used if ``key-management`` is ``psk``:
 
      ``psk`` (scalar)
      :    The pre-shared key for this connection.
 
-     The following properties can be used if ``key-management`` is ``wpa-eap``
+     The following properties can be used if ``key-management`` is ``eap``
      or ``802.1x``:
 
      ``method`` (scalar)
@@ -504,9 +507,6 @@ interfaces, as well as individual wifi networks, by means of the ``auth`` block.
      ``anonymous-identity`` (scalar)
      :    The identity to pass over the unencrypted channel if the chosen EAP
           method supports passing a different tunnelled identity.
-
-     ``password`` (scalar)
-     :    The password string for EAP.
 
      ``ca-certificate`` (scalar)
      :    Path to a file with one or more trusted certificate authority (CA)

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -633,20 +633,20 @@ write_rules_file(net_definition* def, const char* rootdir)
 static void
 append_wpa_auth_conf(GString* s, const authentication_settings* auth)
 {
-    switch (auth->key_mgmt) {
-        case KEYMGMT_NONE:
+    switch (auth->key_management) {
+        case KEY_MANAGEMENT_NONE:
             g_string_append(s, "  key_mgmt=NONE\n");
             break;
 
-        case KEYMGMT_WPA_PSK:
+        case KEY_MANAGEMENT_WPA_PSK:
             g_string_append(s, "  key_mgmt=WPA-PSK\n");
             break;
 
-        case KEYMGMT_WPA_EAP:
+        case KEY_MANAGEMENT_WPA_EAP:
             g_string_append(s, "  key_mgmt=WPA-EAP\n");
             break;
 
-        case KEYMGMT_8021X:
+        case KEY_MANAGEMENT_8021X:
             g_string_append(s, "  key_mgmt=IEEE8021X\n");
             break;
     }
@@ -724,9 +724,6 @@ write_wpa_conf(net_definition* def, const char* rootdir)
             /* wifi auth trumps netdef auth */
             if (ap->has_auth) {
                 append_wpa_auth_conf(s, &ap->auth);
-            }
-            else if (def->has_auth) {
-                append_wpa_auth_conf(s, &def->auth);
             }
 	    else {
                 g_string_append(s, "  key_mgmt=NONE\n");

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -651,10 +651,6 @@ append_wpa_auth_conf(GString* s, const authentication_settings* auth)
             break;
     }
 
-    if (auth->psk) {
-        g_string_append_printf(s, "  psk=\"%s\"\n", auth->psk);
-    }
-
     switch (auth->eap_method) {
         case EAP_NONE:
             break;
@@ -679,7 +675,11 @@ append_wpa_auth_conf(GString* s, const authentication_settings* auth)
         g_string_append_printf(s, "  anonymous_identity=\"%s\"\n", auth->anonymous_identity);
     }
     if (auth->password) {
-        g_string_append_printf(s, "  password=\"%s\"\n", auth->password);
+        if (auth->key_management == KEY_MANAGEMENT_WPA_PSK) {
+            g_string_append_printf(s, "  psk=\"%s\"\n", auth->password);
+        } else {
+            g_string_append_printf(s, "  password=\"%s\"\n", auth->password);
+        }
     }
     if (auth->ca_certificate) {
         g_string_append_printf(s, "  ca_cert=\"%s\"\n", auth->ca_certificate);

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -725,9 +725,9 @@ write_wpa_conf(net_definition* def, const char* rootdir)
             if (ap->has_auth) {
                 append_wpa_auth_conf(s, &ap->auth);
             }
-	    else {
+            else {
                 g_string_append(s, "  key_mgmt=NONE\n");
-	    }
+            }
             g_string_append(s, "}\n");
         }
     }

--- a/src/nm.c
+++ b/src/nm.c
@@ -304,7 +304,7 @@ write_dot1x_auth_parameters(const authentication_settings* auth, GString *s)
     if (auth->anonymous_identity) {
         g_string_append_printf(s, "anonymous-identity=%s\n", auth->anonymous_identity);
     }
-    if (auth->password) {
+    if (auth->password && auth->key_management != KEY_MANAGEMENT_WPA_PSK) {
         g_string_append_printf(s, "password=%s\n", auth->password);
     }
     if (auth->ca_certificate) {
@@ -334,6 +334,9 @@ write_wifi_auth_parameters(const authentication_settings* auth, GString *s)
         case KEY_MANAGEMENT_NONE: break; // LCOV_EXCL_LINE
         case KEY_MANAGEMENT_WPA_PSK:
             g_string_append(s, "key-mgmt=wpa-psk\n");
+            if (auth->password) {
+                g_string_append_printf(s, "psk=%s\n", auth->password);
+            }
             break;
         case KEY_MANAGEMENT_WPA_EAP:
             g_string_append(s, "key-mgmt=wpa-eap\n");
@@ -341,10 +344,6 @@ write_wifi_auth_parameters(const authentication_settings* auth, GString *s)
         case KEY_MANAGEMENT_8021X:
             g_string_append(s, "key-mgmt=ieee8021x\n");
             break;
-    }
-
-    if (auth->psk) {
-        g_string_append_printf(s, "psk=%s\n", auth->psk);
     }
 
     write_dot1x_auth_parameters(auth, s);

--- a/src/nm.c
+++ b/src/nm.c
@@ -324,21 +324,21 @@ write_dot1x_auth_parameters(const authentication_settings* auth, GString *s)
 static void
 write_wifi_auth_parameters(const authentication_settings* auth, GString *s)
 {
-    if (auth->key_mgmt == KEYMGMT_NONE) {
+    if (auth->key_management == KEY_MANAGEMENT_NONE) {
         return;
     }
 
     g_string_append(s, "\n[wifi-security]\n");
 
-    switch (auth->key_mgmt) {
-        case KEYMGMT_NONE: break; // LCOV_EXCL_LINE
-        case KEYMGMT_WPA_PSK:
+    switch (auth->key_management) {
+        case KEY_MANAGEMENT_NONE: break; // LCOV_EXCL_LINE
+        case KEY_MANAGEMENT_WPA_PSK:
             g_string_append(s, "key-mgmt=wpa-psk\n");
             break;
-        case KEYMGMT_WPA_EAP:
+        case KEY_MANAGEMENT_WPA_EAP:
             g_string_append(s, "key-mgmt=wpa-eap\n");
             break;
-        case KEYMGMT_8021X:
+        case KEY_MANAGEMENT_8021X:
             g_string_append(s, "key-mgmt=ieee8021x\n");
             break;
     }
@@ -586,9 +586,6 @@ write_nm_conf_access_point(net_definition* def, const char* rootdir, const wifi_
         g_string_append_printf(s, "\n[wifi]\nssid=%s\nmode=%s\n", ap->ssid, wifi_mode_str(ap->mode));
         if (ap->has_auth) {
             write_wifi_auth_parameters(&ap->auth, s);
-        }
-        else if (def->has_auth) {
-            write_wifi_auth_parameters(&def->auth, s);
         }
     } else {
         conf_path = g_strjoin(NULL, "run/NetworkManager/system-connections/netplan-", def->id, NULL);

--- a/src/parse.c
+++ b/src/parse.c
@@ -643,7 +643,7 @@ handle_auth_key_management(yaml_document_t* doc, yaml_node_t* node, const void* 
 }
 
 static gboolean
-handle_auth_eap_method(yaml_document_t* doc, yaml_node_t* node, const void* _, GError** error)
+handle_auth_method(yaml_document_t* doc, yaml_node_t* node, const void* _, GError** error)
 {
     g_assert(cur_auth);
     if (strcmp(scalar(node), "tls") == 0)
@@ -660,7 +660,7 @@ handle_auth_eap_method(yaml_document_t* doc, yaml_node_t* node, const void* _, G
 const mapping_entry_handler auth_handlers[] = {
     {"key-management", YAML_SCALAR_NODE, handle_auth_key_management},
     {"psk", YAML_SCALAR_NODE, handle_auth_str, NULL, auth_offset(psk)},
-    {"eap-method", YAML_SCALAR_NODE, handle_auth_eap_method},
+    {"method", YAML_SCALAR_NODE, handle_auth_method},
     {"identity", YAML_SCALAR_NODE, handle_auth_str, NULL, auth_offset(identity)},
     {"anonymous-identity", YAML_SCALAR_NODE, handle_auth_str, NULL, auth_offset(anonymous_identity)},
     {"password", YAML_SCALAR_NODE, handle_auth_str, NULL, auth_offset(password)},

--- a/src/parse.c
+++ b/src/parse.c
@@ -631,9 +631,9 @@ handle_auth_key_management(yaml_document_t* doc, yaml_node_t* node, const void* 
     g_assert(cur_auth);
     if (strcmp(scalar(node), "none") == 0)
         cur_auth->key_management = KEY_MANAGEMENT_NONE;
-    else if (strcmp(scalar(node), "wpa-psk") == 0)
+    else if (strcmp(scalar(node), "psk") == 0)
         cur_auth->key_management = KEY_MANAGEMENT_WPA_PSK;
-    else if (strcmp(scalar(node), "wpa-eap") == 0)
+    else if (strcmp(scalar(node), "eap") == 0)
         cur_auth->key_management = KEY_MANAGEMENT_WPA_EAP;
     else if (strcmp(scalar(node), "802.1x") == 0)
         cur_auth->key_management = KEY_MANAGEMENT_8021X;

--- a/src/parse.c
+++ b/src/parse.c
@@ -1737,6 +1737,7 @@ const mapping_entry_handler wifi_def_handlers[] = {
     COMMON_LINK_HANDLERS,
     PHYSICAL_LINK_HANDLERS,
     {"access-points", YAML_MAPPING_NODE, handle_wifi_access_points},
+    {"auth", YAML_MAPPING_NODE, handle_auth},
     {NULL}
 };
 

--- a/src/parse.c
+++ b/src/parse.c
@@ -659,7 +659,6 @@ handle_auth_method(yaml_document_t* doc, yaml_node_t* node, const void* _, GErro
 
 const mapping_entry_handler auth_handlers[] = {
     {"key-management", YAML_SCALAR_NODE, handle_auth_key_management},
-    {"psk", YAML_SCALAR_NODE, handle_auth_str, NULL, auth_offset(psk)},
     {"method", YAML_SCALAR_NODE, handle_auth_method},
     {"identity", YAML_SCALAR_NODE, handle_auth_str, NULL, auth_offset(identity)},
     {"anonymous-identity", YAML_SCALAR_NODE, handle_auth_str, NULL, auth_offset(anonymous_identity)},
@@ -693,8 +692,8 @@ handle_access_point_password(yaml_document_t* doc, yaml_node_t* node, const void
     /* shortcut for WPA-PSK */
     cur_access_point->has_auth = TRUE;
     cur_access_point->auth.key_management = KEY_MANAGEMENT_WPA_PSK;
-    g_free(cur_access_point->auth.psk);
-    cur_access_point->auth.psk = g_strdup(scalar(node));
+    g_free(cur_access_point->auth.password);
+    cur_access_point->auth.password = g_strdup(scalar(node));
     return TRUE;
 }
 

--- a/src/parse.c
+++ b/src/parse.c
@@ -626,17 +626,17 @@ handle_auth_str(yaml_document_t* doc, yaml_node_t* node, const void* data, GErro
 }
 
 static gboolean
-handle_auth_key_mgmt(yaml_document_t* doc, yaml_node_t* node, const void* _, GError** error)
+handle_auth_key_management(yaml_document_t* doc, yaml_node_t* node, const void* _, GError** error)
 {
     g_assert(cur_auth);
     if (strcmp(scalar(node), "none") == 0)
-        cur_auth->key_mgmt = KEYMGMT_NONE;
+        cur_auth->key_management = KEY_MANAGEMENT_NONE;
     else if (strcmp(scalar(node), "wpa-psk") == 0)
-        cur_auth->key_mgmt = KEYMGMT_WPA_PSK;
+        cur_auth->key_management = KEY_MANAGEMENT_WPA_PSK;
     else if (strcmp(scalar(node), "wpa-eap") == 0)
-        cur_auth->key_mgmt = KEYMGMT_WPA_EAP;
-    else if (strcmp(scalar(node), "8021x") == 0)
-        cur_auth->key_mgmt = KEYMGMT_8021X;
+        cur_auth->key_management = KEY_MANAGEMENT_WPA_EAP;
+    else if (strcmp(scalar(node), "802.1x") == 0)
+        cur_auth->key_management = KEY_MANAGEMENT_8021X;
     else
         return yaml_error(node, error, "unknown key management type '%s'", scalar(node));
     return TRUE;
@@ -658,7 +658,7 @@ handle_auth_eap_method(yaml_document_t* doc, yaml_node_t* node, const void* _, G
 }
 
 const mapping_entry_handler auth_handlers[] = {
-    {"key-mgmt", YAML_SCALAR_NODE, handle_auth_key_mgmt},
+    {"key-management", YAML_SCALAR_NODE, handle_auth_key_management},
     {"psk", YAML_SCALAR_NODE, handle_auth_str, NULL, auth_offset(psk)},
     {"eap-method", YAML_SCALAR_NODE, handle_auth_eap_method},
     {"identity", YAML_SCALAR_NODE, handle_auth_str, NULL, auth_offset(identity)},
@@ -692,7 +692,7 @@ handle_access_point_password(yaml_document_t* doc, yaml_node_t* node, const void
     g_assert(cur_access_point);
     /* shortcut for WPA-PSK */
     cur_access_point->has_auth = TRUE;
-    cur_access_point->auth.key_mgmt = KEYMGMT_WPA_PSK;
+    cur_access_point->auth.key_management = KEY_MANAGEMENT_WPA_PSK;
     g_free(cur_access_point->auth.psk);
     cur_access_point->auth.psk = g_strdup(scalar(node));
     return TRUE;

--- a/src/parse.h
+++ b/src/parse.h
@@ -111,10 +111,37 @@ struct optional_address_option {
 
 extern struct optional_address_option optional_address_options[];
 
+typedef enum {
+    KEYMGMT_NONE,
+    KEYMGMT_WPA_PSK,
+    KEYMGMT_WPA_EAP,
+    KEYMGMT_8021X,
+} auth_keymgmt_type;
+
+typedef enum {
+    EAP_NONE,
+    EAP_TLS,
+    EAP_PEAP,
+    EAP_TTLS,
+} auth_eap_method;
+
 typedef struct missing_node {
     char* netdef_id;
     const yaml_node_t* node;
 } missing_node;
+
+typedef struct authentication_settings {
+    auth_keymgmt_type key_mgmt;
+    char* psk;
+    auth_eap_method eap_method;
+    char* identity;
+    char* anonymous_identity;
+    char* password;
+    char* ca_certificate;
+    char* client_certificate;
+    char* client_key;
+    char* client_key_password;
+} authentication_settings;
 
 /* Fields below are valid for dhcp4 and dhcp6 unless otherwise noted. */
 typedef struct dhcp_overrides {
@@ -236,6 +263,9 @@ typedef struct net_definition {
         char *input_key;
         char *output_key;
     } tunnel;
+
+    authentication_settings auth;
+    gboolean has_auth;
 } net_definition;
 
 typedef enum {
@@ -247,7 +277,9 @@ typedef enum {
 typedef struct {
     wifi_mode mode;
     char* ssid;
-    char* password;
+
+    authentication_settings auth;
+    gboolean has_auth;
 } wifi_access_point;
 
 #define METRIC_UNSPEC G_MAXUINT

--- a/src/parse.h
+++ b/src/parse.h
@@ -112,11 +112,11 @@ struct optional_address_option {
 extern struct optional_address_option optional_address_options[];
 
 typedef enum {
-    KEYMGMT_NONE,
-    KEYMGMT_WPA_PSK,
-    KEYMGMT_WPA_EAP,
-    KEYMGMT_8021X,
-} auth_keymgmt_type;
+    KEY_MANAGEMENT_NONE,
+    KEY_MANAGEMENT_WPA_PSK,
+    KEY_MANAGEMENT_WPA_EAP,
+    KEY_MANAGEMENT_8021X,
+} auth_key_management_type;
 
 typedef enum {
     EAP_NONE,
@@ -131,7 +131,7 @@ typedef struct missing_node {
 } missing_node;
 
 typedef struct authentication_settings {
-    auth_keymgmt_type key_mgmt;
+    auth_key_management_type key_management;
     char* psk;
     auth_eap_method eap_method;
     char* identity;

--- a/src/parse.h
+++ b/src/parse.h
@@ -132,7 +132,6 @@ typedef struct missing_node {
 
 typedef struct authentication_settings {
     auth_key_management_type key_management;
-    char* psk;
     auth_eap_method eap_method;
     char* identity;
     char* anonymous_identity;

--- a/tests/generator/base.py
+++ b/tests/generator/base.py
@@ -53,6 +53,7 @@ class TestBase(unittest.TestCase):
         self.confdir = os.path.join(self.workdir.name, 'etc', 'netplan')
         self.nm_enable_all_conf = os.path.join(
             self.workdir.name, 'run', 'NetworkManager', 'conf.d', '10-globally-managed-devices.conf')
+        self.maxDiff = None
 
     def generate(self, yaml, expect_fail=False, extra_args=[], confs=None):
         '''Call generate with given YAML string as configuration

--- a/tests/generator/test_auth.py
+++ b/tests/generator/test_auth.py
@@ -36,7 +36,7 @@ class TestNetworkd(TestBase):
         "Luke's Home":
           auth:
             key-management: psk
-            psk: "4lsos3kr1t"
+            password: "4lsos3kr1t"
         workplace:
           auth:
             key-management: eap
@@ -188,7 +188,7 @@ class TestNetworkManager(TestBase):
         "Luke's Home":
           auth:
             key-management: psk
-            psk: "4lsos3kr1t"
+            password: "4lsos3kr1t"
         workplace:
           auth:
             key-management: eap

--- a/tests/generator/test_auth.py
+++ b/tests/generator/test_auth.py
@@ -35,25 +35,25 @@ class TestNetworkd(TestBase):
           password: "s3kr1t"
         "Luke's Home":
           auth:
-            key-management: wpa-psk
+            key-management: psk
             psk: "4lsos3kr1t"
         workplace:
           auth:
-            key-management: wpa-eap
+            key-management: eap
             method: ttls
             anonymous-identity: "@internal.example.com"
             identity: "joe@internal.example.com"
             password: "v3ryS3kr1t"
         workplace2:
           auth:
-            key-management: wpa-eap
+            key-management: eap
             method: peap
             identity: "joe@internal.example.com"
             password: "v3ryS3kr1t"
             ca-certificate: /etc/ssl/work2-cacrt.pem
         customernet:
           auth:
-            key-management: wpa-eap
+            key-management: eap
             method: tls
             anonymous-identity: "@cust.example.com"
             identity: "cert-joe@cust.example.com"
@@ -187,18 +187,18 @@ class TestNetworkManager(TestBase):
           password: "s3kr1t"
         "Luke's Home":
           auth:
-            key-management: wpa-psk
+            key-management: psk
             psk: "4lsos3kr1t"
         workplace:
           auth:
-            key-management: wpa-eap
+            key-management: eap
             method: ttls
             anonymous-identity: "@internal.example.com"
             identity: "joe@internal.example.com"
             password: "v3ryS3kr1t"
         workplace2:
           auth:
-            key-management: wpa-eap
+            key-management: eap
             method: peap
             identity: "joe@internal.example.com"
             password: "v3ryS3kr1t"
@@ -443,8 +443,8 @@ class TestConfigErrors(TestBase):
   ethernets:
     eth0:
       auth:
-        key-management: wpa-bogus''', expect_fail=True)
-        self.assertIn("unknown key management type 'wpa-bogus'", err)
+        key-management: bogus''', expect_fail=True)
+        self.assertIn("unknown key management type 'bogus'", err)
 
     def test_auth_invalid_eap_method(self):
         err = self.generate('''network:

--- a/tests/generator/test_auth.py
+++ b/tests/generator/test_auth.py
@@ -1,0 +1,520 @@
+#
+# Tests for network authentication config generated via netplan
+#
+# Copyright (C) 2018 Canonical, Ltd.
+# Author: Mathieu Trudel-Lapierre <mathieu.trudel.lapierre@canonical.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import stat
+import sys
+
+from .base import TestBase, ND_DHCP4, ND_WIFI_DHCP4
+
+
+class TestNetworkd(TestBase):
+
+    def test_auth_wifi_detailed(self):
+        self.generate('''network:
+  version: 2
+  wifis:
+    wl0:
+      auth:
+        key-mgmt: wpa-psk
+        psk: "d3f4ul7"
+      access-points:
+        "Joe's Home":
+          password: "s3kr1t"
+        "Luke's Home":
+          auth:
+            key-mgmt: wpa-psk
+            psk: "4lsos3kr1t"
+        workplace:
+          auth:
+            key-mgmt: wpa-eap
+            eap-method: ttls
+            anonymous-identity: "@internal.example.com"
+            identity: "joe@internal.example.com"
+            password: "v3ryS3kr1t"
+        workplace2:
+          auth:
+            key-mgmt: wpa-eap
+            eap-method: peap
+            identity: "joe@internal.example.com"
+            password: "v3ryS3kr1t"
+            ca-certificate: /etc/ssl/work2-cacrt.pem
+        customernet:
+          auth:
+            key-mgmt: wpa-eap
+            eap-method: tls
+            anonymous-identity: "@cust.example.com"
+            identity: "cert-joe@cust.example.com"
+            ca-certificate: /etc/ssl/cust-cacrt.pem
+            client-certificate: /etc/ssl/cust-crt.pem
+            client-key: /etc/ssl/cust-key.pem
+            client-key-password: "d3cryptPr1v4t3K3y"
+        opennet:
+          auth:
+            key-mgmt: none
+        peer2peer:
+          mode: adhoc
+          auth: {}
+        inheritplace: {}
+        inherit2place: {}
+      dhcp4: yes
+      ''')
+
+        self.assert_networkd({'wl0.network': ND_WIFI_DHCP4 % 'wl0'})
+        self.assert_nm(None, '''[keyfile]
+# devices managed by networkd
+unmanaged-devices+=interface-name:wl0,''')
+        self.assert_nm_udev(None)
+
+        # generates wpa config and enables wpasupplicant unit
+        with open(os.path.join(self.workdir.name, 'run/netplan/wpa-wl0.conf')) as f:
+            self.assertEqual(f.read(), '''ctrl_interface=/run/wpa_supplicant
+
+network={
+  ssid="opennet"
+  key_mgmt=NONE
+}
+network={
+  ssid="Luke's Home"
+  key_mgmt=WPA-PSK
+  psk="4lsos3kr1t"
+}
+network={
+  ssid="peer2peer"
+  mode=1
+  key_mgmt=NONE
+}
+network={
+  ssid="customernet"
+  key_mgmt=WPA-EAP
+  eap=TLS
+  identity="cert-joe@cust.example.com"
+  anonymous_identity="@cust.example.com"
+  ca_cert="/etc/ssl/cust-cacrt.pem"
+  client_cert="/etc/ssl/cust-crt.pem"
+  private_key="/etc/ssl/cust-key.pem"
+  private_key_passwd="d3cryptPr1v4t3K3y"
+}
+network={
+  ssid="Joe's Home"
+  key_mgmt=WPA-PSK
+  psk="s3kr1t"
+}
+network={
+  ssid="workplace2"
+  key_mgmt=WPA-EAP
+  eap=PEAP
+  identity="joe@internal.example.com"
+  password="v3ryS3kr1t"
+  ca_cert="/etc/ssl/work2-cacrt.pem"
+}
+network={
+  ssid="inherit2place"
+  key_mgmt=WPA-PSK
+  psk="d3f4ul7"
+}
+network={
+  ssid="workplace"
+  key_mgmt=WPA-EAP
+  eap=TTLS
+  identity="joe@internal.example.com"
+  anonymous_identity="@internal.example.com"
+  password="v3ryS3kr1t"
+}
+network={
+  ssid="inheritplace"
+  key_mgmt=WPA-PSK
+  psk="d3f4ul7"
+}
+''')
+            self.assertEqual(stat.S_IMODE(os.fstat(f.fileno()).st_mode), 0o600)
+        self.assertTrue(os.path.islink(os.path.join(
+            self.workdir.name, 'run/systemd/system/multi-user.target.wants/netplan-wpa@wl0.service')))
+
+    def test_auth_wired(self):
+        self.generate('''network:
+  version: 2
+  ethernets:
+    eth0:
+      auth:
+        key-mgmt: 8021x
+        eap-method: tls
+        anonymous-identity: "@cust.example.com"
+        identity: "cert-joe@cust.example.com"
+        ca-certificate: /etc/ssl/cust-cacrt.pem
+        client-certificate: /etc/ssl/cust-crt.pem
+        client-key: /etc/ssl/cust-key.pem
+        client-key-password: "d3cryptPr1v4t3K3y"
+      dhcp4: yes
+      ''')
+
+        self.assert_networkd({'eth0.network': ND_DHCP4 % 'eth0'})
+        self.assert_nm(None, '''[keyfile]
+# devices managed by networkd
+unmanaged-devices+=interface-name:eth0,''')
+        self.assert_nm_udev(None)
+
+        # generates wpa config and enables wpasupplicant unit
+        with open(os.path.join(self.workdir.name, 'run/netplan/wpa-eth0.conf')) as f:
+            self.assertEqual(f.read(), '''ctrl_interface=/run/wpa_supplicant
+
+network={
+  key_mgmt=IEEE8021X
+  eap=TLS
+  identity="cert-joe@cust.example.com"
+  anonymous_identity="@cust.example.com"
+  ca_cert="/etc/ssl/cust-cacrt.pem"
+  client_cert="/etc/ssl/cust-crt.pem"
+  private_key="/etc/ssl/cust-key.pem"
+  private_key_passwd="d3cryptPr1v4t3K3y"
+}
+''')
+            self.assertEqual(stat.S_IMODE(os.fstat(f.fileno()).st_mode), 0o600)
+        self.assertTrue(os.path.islink(os.path.join(
+            self.workdir.name, 'run/systemd/system/multi-user.target.wants/netplan-wpa@eth0.service')))
+
+
+class TestNetworkManager(TestBase):
+
+    def test_auth_wifi_detailed(self):
+        self.generate('''network:
+  version: 2
+  renderer: NetworkManager
+  wifis:
+    wl0:
+      auth:
+        key-mgmt: wpa-psk
+        psk: "d3f4ul7"
+      access-points:
+        "Joe's Home":
+          password: "s3kr1t"
+        "Luke's Home":
+          auth:
+            key-mgmt: wpa-psk
+            psk: "4lsos3kr1t"
+        workplace:
+          auth:
+            key-mgmt: wpa-eap
+            eap-method: ttls
+            anonymous-identity: "@internal.example.com"
+            identity: "joe@internal.example.com"
+            password: "v3ryS3kr1t"
+        workplace2:
+          auth:
+            key-mgmt: wpa-eap
+            eap-method: peap
+            identity: "joe@internal.example.com"
+            password: "v3ryS3kr1t"
+            ca-certificate: /etc/ssl/work2-cacrt.pem
+        customernet:
+          auth:
+            key-mgmt: 8021x
+            eap-method: tls
+            anonymous-identity: "@cust.example.com"
+            identity: "cert-joe@cust.example.com"
+            ca-certificate: /etc/ssl/cust-cacrt.pem
+            client-certificate: /etc/ssl/cust-crt.pem
+            client-key: /etc/ssl/cust-key.pem
+            client-key-password: "d3cryptPr1v4t3K3y"
+        opennet:
+          auth:
+            key-mgmt: none
+        peer2peer:
+          mode: adhoc
+          auth: {}
+        inheritplace: {}
+        inherit2place: {}
+      dhcp4: yes
+      ''')
+
+        self.assert_networkd({})
+        self.assert_nm({'wl0-Joe%27s%20Home': '''[connection]
+id=netplan-wl0-Joe's Home
+type=wifi
+interface-name=wl0
+
+[ethernet]
+wake-on-lan=0
+
+[ipv4]
+method=auto
+
+[ipv6]
+method=ignore
+
+[wifi]
+ssid=Joe's Home
+mode=infrastructure
+
+[wifi-security]
+key-mgmt=wpa-psk
+psk=s3kr1t
+''',
+                        'wl0-Luke%27s%20Home': '''[connection]
+id=netplan-wl0-Luke's Home
+type=wifi
+interface-name=wl0
+
+[ethernet]
+wake-on-lan=0
+
+[ipv4]
+method=auto
+
+[ipv6]
+method=ignore
+
+[wifi]
+ssid=Luke's Home
+mode=infrastructure
+
+[wifi-security]
+key-mgmt=wpa-psk
+psk=4lsos3kr1t
+''',
+                        'wl0-workplace': '''[connection]
+id=netplan-wl0-workplace
+type=wifi
+interface-name=wl0
+
+[ethernet]
+wake-on-lan=0
+
+[ipv4]
+method=auto
+
+[ipv6]
+method=ignore
+
+[wifi]
+ssid=workplace
+mode=infrastructure
+
+[wifi-security]
+key-mgmt=wpa-eap
+
+[802-1x]
+eap=ttls
+identity=joe@internal.example.com
+anonymous-identity=@internal.example.com
+password=v3ryS3kr1t
+''',
+                        'wl0-workplace2': '''[connection]
+id=netplan-wl0-workplace2
+type=wifi
+interface-name=wl0
+
+[ethernet]
+wake-on-lan=0
+
+[ipv4]
+method=auto
+
+[ipv6]
+method=ignore
+
+[wifi]
+ssid=workplace2
+mode=infrastructure
+
+[wifi-security]
+key-mgmt=wpa-eap
+
+[802-1x]
+eap=peap
+identity=joe@internal.example.com
+password=v3ryS3kr1t
+ca-cert=/etc/ssl/work2-cacrt.pem
+''',
+                        'wl0-customernet': '''[connection]
+id=netplan-wl0-customernet
+type=wifi
+interface-name=wl0
+
+[ethernet]
+wake-on-lan=0
+
+[ipv4]
+method=auto
+
+[ipv6]
+method=ignore
+
+[wifi]
+ssid=customernet
+mode=infrastructure
+
+[wifi-security]
+key-mgmt=ieee8021x
+
+[802-1x]
+eap=tls
+identity=cert-joe@cust.example.com
+anonymous-identity=@cust.example.com
+ca-cert=/etc/ssl/cust-cacrt.pem
+client-cert=/etc/ssl/cust-crt.pem
+private-key=/etc/ssl/cust-key.pem
+private-key-password=d3cryptPr1v4t3K3y
+''',
+                        'wl0-opennet': '''[connection]
+id=netplan-wl0-opennet
+type=wifi
+interface-name=wl0
+
+[ethernet]
+wake-on-lan=0
+
+[ipv4]
+method=auto
+
+[ipv6]
+method=ignore
+
+[wifi]
+ssid=opennet
+mode=infrastructure
+''',
+                        'wl0-peer2peer': '''[connection]
+id=netplan-wl0-peer2peer
+type=wifi
+interface-name=wl0
+
+[ethernet]
+wake-on-lan=0
+
+[ipv4]
+method=auto
+
+[ipv6]
+method=ignore
+
+[wifi]
+ssid=peer2peer
+mode=adhoc
+''',
+                        'wl0-inheritplace': '''[connection]
+id=netplan-wl0-inheritplace
+type=wifi
+interface-name=wl0
+
+[ethernet]
+wake-on-lan=0
+
+[ipv4]
+method=auto
+
+[ipv6]
+method=ignore
+
+[wifi]
+ssid=inheritplace
+mode=infrastructure
+
+[wifi-security]
+key-mgmt=wpa-psk
+psk=d3f4ul7
+''',
+                        'wl0-inherit2place': '''[connection]
+id=netplan-wl0-inherit2place
+type=wifi
+interface-name=wl0
+
+[ethernet]
+wake-on-lan=0
+
+[ipv4]
+method=auto
+
+[ipv6]
+method=ignore
+
+[wifi]
+ssid=inherit2place
+mode=infrastructure
+
+[wifi-security]
+key-mgmt=wpa-psk
+psk=d3f4ul7
+'''})
+        self.assert_nm_udev(None)
+
+
+    def test_auth_wired(self):
+        self.generate('''network:
+  version: 2
+  renderer: NetworkManager
+  ethernets:
+    eth0:
+      auth:
+        key-mgmt: 8021x
+        eap-method: tls
+        anonymous-identity: "@cust.example.com"
+        identity: "cert-joe@cust.example.com"
+        ca-certificate: /etc/ssl/cust-cacrt.pem
+        client-certificate: /etc/ssl/cust-crt.pem
+        client-key: /etc/ssl/cust-key.pem
+        client-key-password: "d3cryptPr1v4t3K3y"
+      dhcp4: yes
+      ''')
+
+        self.assert_nm({'eth0': '''[connection]
+id=netplan-eth0
+type=ethernet
+interface-name=eth0
+
+[ethernet]
+wake-on-lan=0
+
+[ipv4]
+method=auto
+
+[ipv6]
+method=ignore
+
+[802-1x]
+eap=tls
+identity=cert-joe@cust.example.com
+anonymous-identity=@cust.example.com
+ca-cert=/etc/ssl/cust-cacrt.pem
+client-cert=/etc/ssl/cust-crt.pem
+private-key=/etc/ssl/cust-key.pem
+private-key-password=d3cryptPr1v4t3K3y
+'''})
+        self.assert_networkd({})
+        self.assert_nm_udev(None)
+
+
+class TestConfigErrors(TestBase):
+
+    def test_auth_invalid_key_mgmt(self):
+        err = self.generate('''network:
+  version: 2
+  ethernets:
+    eth0:
+      auth:
+        key-mgmt: wpa-bogus''', expect_fail=True)
+        self.assertIn("unknown key management type 'wpa-bogus'", err)
+
+    def test_auth_invalid_eap_method(self):
+        err = self.generate('''network:
+  version: 2
+  ethernets:
+    eth0:
+      auth:
+        eap-method: bogus''', expect_fail=True)
+        self.assertIn("unknown EAP method 'bogus'", err)

--- a/tests/generator/test_auth.py
+++ b/tests/generator/test_auth.py
@@ -40,21 +40,21 @@ class TestNetworkd(TestBase):
         workplace:
           auth:
             key-management: wpa-eap
-            eap-method: ttls
+            method: ttls
             anonymous-identity: "@internal.example.com"
             identity: "joe@internal.example.com"
             password: "v3ryS3kr1t"
         workplace2:
           auth:
             key-management: wpa-eap
-            eap-method: peap
+            method: peap
             identity: "joe@internal.example.com"
             password: "v3ryS3kr1t"
             ca-certificate: /etc/ssl/work2-cacrt.pem
         customernet:
           auth:
             key-management: wpa-eap
-            eap-method: tls
+            method: tls
             anonymous-identity: "@cust.example.com"
             identity: "cert-joe@cust.example.com"
             ca-certificate: /etc/ssl/cust-cacrt.pem
@@ -138,7 +138,7 @@ network={
     eth0:
       auth:
         key-management: 802.1x
-        eap-method: tls
+        method: tls
         anonymous-identity: "@cust.example.com"
         identity: "cert-joe@cust.example.com"
         ca-certificate: /etc/ssl/cust-cacrt.pem
@@ -192,21 +192,21 @@ class TestNetworkManager(TestBase):
         workplace:
           auth:
             key-management: wpa-eap
-            eap-method: ttls
+            method: ttls
             anonymous-identity: "@internal.example.com"
             identity: "joe@internal.example.com"
             password: "v3ryS3kr1t"
         workplace2:
           auth:
             key-management: wpa-eap
-            eap-method: peap
+            method: peap
             identity: "joe@internal.example.com"
             password: "v3ryS3kr1t"
             ca-certificate: /etc/ssl/work2-cacrt.pem
         customernet:
           auth:
             key-management: 802.1x
-            eap-method: tls
+            method: tls
             anonymous-identity: "@cust.example.com"
             identity: "cert-joe@cust.example.com"
             ca-certificate: /etc/ssl/cust-cacrt.pem
@@ -398,7 +398,7 @@ mode=adhoc
     eth0:
       auth:
         key-management: 802.1x
-        eap-method: tls
+        method: tls
         anonymous-identity: "@cust.example.com"
         identity: "cert-joe@cust.example.com"
         ca-certificate: /etc/ssl/cust-cacrt.pem
@@ -452,5 +452,5 @@ class TestConfigErrors(TestBase):
   ethernets:
     eth0:
       auth:
-        eap-method: bogus''', expect_fail=True)
+        method: bogus''', expect_fail=True)
         self.assertIn("unknown EAP method 'bogus'", err)

--- a/tests/generator/test_auth.py
+++ b/tests/generator/test_auth.py
@@ -30,33 +30,30 @@ class TestNetworkd(TestBase):
   version: 2
   wifis:
     wl0:
-      auth:
-        key-mgmt: wpa-psk
-        psk: "d3f4ul7"
       access-points:
         "Joe's Home":
           password: "s3kr1t"
         "Luke's Home":
           auth:
-            key-mgmt: wpa-psk
+            key-management: wpa-psk
             psk: "4lsos3kr1t"
         workplace:
           auth:
-            key-mgmt: wpa-eap
+            key-management: wpa-eap
             eap-method: ttls
             anonymous-identity: "@internal.example.com"
             identity: "joe@internal.example.com"
             password: "v3ryS3kr1t"
         workplace2:
           auth:
-            key-mgmt: wpa-eap
+            key-management: wpa-eap
             eap-method: peap
             identity: "joe@internal.example.com"
             password: "v3ryS3kr1t"
             ca-certificate: /etc/ssl/work2-cacrt.pem
         customernet:
           auth:
-            key-mgmt: wpa-eap
+            key-management: wpa-eap
             eap-method: tls
             anonymous-identity: "@cust.example.com"
             identity: "cert-joe@cust.example.com"
@@ -66,12 +63,10 @@ class TestNetworkd(TestBase):
             client-key-password: "d3cryptPr1v4t3K3y"
         opennet:
           auth:
-            key-mgmt: none
+            key-management: none
         peer2peer:
           mode: adhoc
           auth: {}
-        inheritplace: {}
-        inherit2place: {}
       dhcp4: yes
       ''')
 
@@ -86,8 +81,9 @@ unmanaged-devices+=interface-name:wl0,''')
             self.assertEqual(f.read(), '''ctrl_interface=/run/wpa_supplicant
 
 network={
-  ssid="opennet"
-  key_mgmt=NONE
+  ssid="Joe's Home"
+  key_mgmt=WPA-PSK
+  psk="s3kr1t"
 }
 network={
   ssid="Luke's Home"
@@ -95,9 +91,16 @@ network={
   psk="4lsos3kr1t"
 }
 network={
-  ssid="peer2peer"
-  mode=1
+  ssid="opennet"
   key_mgmt=NONE
+}
+network={
+  ssid="workplace"
+  key_mgmt=WPA-EAP
+  eap=TTLS
+  identity="joe@internal.example.com"
+  anonymous_identity="@internal.example.com"
+  password="v3ryS3kr1t"
 }
 network={
   ssid="customernet"
@@ -111,11 +114,6 @@ network={
   private_key_passwd="d3cryptPr1v4t3K3y"
 }
 network={
-  ssid="Joe's Home"
-  key_mgmt=WPA-PSK
-  psk="s3kr1t"
-}
-network={
   ssid="workplace2"
   key_mgmt=WPA-EAP
   eap=PEAP
@@ -124,22 +122,9 @@ network={
   ca_cert="/etc/ssl/work2-cacrt.pem"
 }
 network={
-  ssid="inherit2place"
-  key_mgmt=WPA-PSK
-  psk="d3f4ul7"
-}
-network={
-  ssid="workplace"
-  key_mgmt=WPA-EAP
-  eap=TTLS
-  identity="joe@internal.example.com"
-  anonymous_identity="@internal.example.com"
-  password="v3ryS3kr1t"
-}
-network={
-  ssid="inheritplace"
-  key_mgmt=WPA-PSK
-  psk="d3f4ul7"
+  ssid="peer2peer"
+  mode=1
+  key_mgmt=NONE
 }
 ''')
             self.assertEqual(stat.S_IMODE(os.fstat(f.fileno()).st_mode), 0o600)
@@ -152,7 +137,7 @@ network={
   ethernets:
     eth0:
       auth:
-        key-mgmt: 8021x
+        key-management: 802.1x
         eap-method: tls
         anonymous-identity: "@cust.example.com"
         identity: "cert-joe@cust.example.com"
@@ -197,33 +182,30 @@ class TestNetworkManager(TestBase):
   renderer: NetworkManager
   wifis:
     wl0:
-      auth:
-        key-mgmt: wpa-psk
-        psk: "d3f4ul7"
       access-points:
         "Joe's Home":
           password: "s3kr1t"
         "Luke's Home":
           auth:
-            key-mgmt: wpa-psk
+            key-management: wpa-psk
             psk: "4lsos3kr1t"
         workplace:
           auth:
-            key-mgmt: wpa-eap
+            key-management: wpa-eap
             eap-method: ttls
             anonymous-identity: "@internal.example.com"
             identity: "joe@internal.example.com"
             password: "v3ryS3kr1t"
         workplace2:
           auth:
-            key-mgmt: wpa-eap
+            key-management: wpa-eap
             eap-method: peap
             identity: "joe@internal.example.com"
             password: "v3ryS3kr1t"
             ca-certificate: /etc/ssl/work2-cacrt.pem
         customernet:
           auth:
-            key-mgmt: 8021x
+            key-management: 802.1x
             eap-method: tls
             anonymous-identity: "@cust.example.com"
             identity: "cert-joe@cust.example.com"
@@ -233,12 +215,10 @@ class TestNetworkManager(TestBase):
             client-key-password: "d3cryptPr1v4t3K3y"
         opennet:
           auth:
-            key-mgmt: none
+            key-management: none
         peer2peer:
           mode: adhoc
           auth: {}
-        inheritplace: {}
-        inherit2place: {}
       dhcp4: yes
       ''')
 
@@ -406,50 +386,6 @@ method=ignore
 [wifi]
 ssid=peer2peer
 mode=adhoc
-''',
-                        'wl0-inheritplace': '''[connection]
-id=netplan-wl0-inheritplace
-type=wifi
-interface-name=wl0
-
-[ethernet]
-wake-on-lan=0
-
-[ipv4]
-method=auto
-
-[ipv6]
-method=ignore
-
-[wifi]
-ssid=inheritplace
-mode=infrastructure
-
-[wifi-security]
-key-mgmt=wpa-psk
-psk=d3f4ul7
-''',
-                        'wl0-inherit2place': '''[connection]
-id=netplan-wl0-inherit2place
-type=wifi
-interface-name=wl0
-
-[ethernet]
-wake-on-lan=0
-
-[ipv4]
-method=auto
-
-[ipv6]
-method=ignore
-
-[wifi]
-ssid=inherit2place
-mode=infrastructure
-
-[wifi-security]
-key-mgmt=wpa-psk
-psk=d3f4ul7
 '''})
         self.assert_nm_udev(None)
 
@@ -461,7 +397,7 @@ psk=d3f4ul7
   ethernets:
     eth0:
       auth:
-        key-mgmt: 8021x
+        key-management: 802.1x
         eap-method: tls
         anonymous-identity: "@cust.example.com"
         identity: "cert-joe@cust.example.com"
@@ -507,7 +443,7 @@ class TestConfigErrors(TestBase):
   ethernets:
     eth0:
       auth:
-        key-mgmt: wpa-bogus''', expect_fail=True)
+        key-management: wpa-bogus''', expect_fail=True)
         self.assertIn("unknown key management type 'wpa-bogus'", err)
 
     def test_auth_invalid_eap_method(self):

--- a/tests/generator/test_wifis.py
+++ b/tests/generator/test_wifis.py
@@ -51,16 +51,18 @@ unmanaged-devices+=interface-name:wl0,''')
 
 network={
   ssid="Joe's Home"
+  key_mgmt=WPA-PSK
   psk="s3kr1t"
 }
 network={
   ssid="workplace"
+  key_mgmt=WPA-PSK
   psk="c0mpany"
 }
 network={
   ssid="peer2peer"
-  key_mgmt=NONE
   mode=1
+  key_mgmt=NONE
 }
 ''')
             self.assertEqual(stat.S_IMODE(os.fstat(f.fileno()).st_mode), 0o600)


### PR DESCRIPTION
Greetings,

we are currently preparing to deploy 802.1X authentication on our wired network. Since Ubuntu Bionic uses netplan for network configuration, support for additional authentication options is interesting for us.

The changes allow authentication options to be set using an `auth` block on an `ethernet` interface, `wifi` interface, or `wifi` `access-point`:

    network:
      version: 2
      ethernets:
        eth0:
          dhcp4: yes
          auth:
            key-mgmt: 8021x
            eap-method: ttls
            anonymous-identity: "@internal.example.com"
            identity: "joe@internal.example.com"
            password: "v3ryS3kr1t"

An `auth` block on a `wifi` interface is taken as a default for any descendant `access-points` that don't have their own `auth` block.

At this stage, this pull request is a proof of concept and request for comments. (Does the structure make sense? Should some of the option names be changed?) The set of supported authentication options is not yet as complete as that of NetworkManager (feature parity should be a realistic goal) and the functionality might have to be expanded to additional interface types.

Thanks in advance!