### PR TITLE
Fix double slash in yaml path file

### DIFF
--- a/src/generate.c
+++ b/src/generate.c
@@ -195,9 +195,9 @@ int main(int argc, char** argv)
          * To do that, we put all found files in a hash table, then sort it by
          * file name, and add the entries from /run after the ones from /etc
          * and those after the ones from /lib. */
-        g_autofree char* glob_etc = g_strjoin(NULL, rootdir ?: "", G_DIR_SEPARATOR_S, "/etc/netplan/*.yaml", NULL);
-        g_autofree char* glob_run = g_strjoin(NULL, rootdir ?: "", G_DIR_SEPARATOR_S, "/run/netplan/*.yaml", NULL);
-        g_autofree char* glob_lib = g_strjoin(NULL, rootdir ?: "", G_DIR_SEPARATOR_S, "/lib/netplan/*.yaml", NULL);
+        g_autofree char* glob_etc = g_strjoin(NULL, rootdir ?: "", G_DIR_SEPARATOR_S, "etc/netplan/*.yaml", NULL);
+        g_autofree char* glob_run = g_strjoin(NULL, rootdir ?: "", G_DIR_SEPARATOR_S, "run/netplan/*.yaml", NULL);
+        g_autofree char* glob_lib = g_strjoin(NULL, rootdir ?: "", G_DIR_SEPARATOR_S, "lib/netplan/*.yaml", NULL);
         glob_t gl;
         int rc;
         /* keys are strdup()ed, free them; values point into the glob_t, don't free them */


### PR DESCRIPTION
When performing "netplan try" or "netplan apply" on
a network definition with errors, netplan error out
a message as follow :

$ netplan try
Error in network definition //etc/netplan/50-cloud-init.yaml line 6 column 4: unknown key xversion

An error occured: the configuration could not be generated

$ netplan apply
Error in network definition //etc/netplan/50-cloud-init.yaml line 6 column 4: unknown key xversion

That is due to the combination of G_DIR_SEPARATOR_S "/" and "/etc/netplan/*/yaml which once joined
together generate "//etc/netplan/*.yaml".

Bug: https://bugs.launchpad.net/bugs/1771440