### PR TITLE
Generate udev rules files to rename devices

### DIFF
--- a/src/networkd.c
+++ b/src/networkd.c
@@ -395,6 +395,47 @@ write_network_file(net_definition* def, const char* rootdir, const char* path)
 }
 
 static void
+write_rules_file(net_definition* def, const char* rootdir)
+{
+    GString* s = NULL;
+    g_autofree char* path = g_strjoin(NULL, "run/udev/rules.d/70-netplan-", def->id, ".rules", NULL);
+
+    /* do we need to write a .rules file?
+     * It's only required for reliably setting the name of a physical device
+     * until systemd issue #9006 is resolved. */
+    if (def->type >= ND_VIRTUAL)
+        return;
+
+    /* Matching by name does not work.
+     *
+     * As far as I can tell, if you match by the name coming out of
+     * initrd, systemd complains that a link file is matching on a
+     * renamed name. If you match by the unstable kernel name, the
+     * device no longer has that name when udevd reads the file, so
+     * the rule doesn't fire. So only support mac and driver. */
+    if (!def->set_name || (!def->match.mac && !def->match.driver))
+        return;
+
+    /* build file contents */
+    s = g_string_sized_new(200);
+
+    g_string_append(s, "SUBSYSTEM==\"net\", ACTION==\"add\", ");
+
+    if (def->match.driver) {
+        g_string_append_printf(s,"DRIVERS==\"%s\", ", def->match.driver);
+    } else {
+        g_string_append(s, "DRIVERS==\"?*\", ");
+    }
+
+    if (def->match.mac)
+        g_string_append_printf(s, "ATTR{address}==\"%s\", ", def->match.mac);
+
+    g_string_append_printf(s, "NAME=\"%s\"\n", def->set_name);
+
+    g_string_free_to_file(s, rootdir, path, NULL);
+}
+
+static void
 write_wpa_conf(net_definition* def, const char* rootdir)
 {
     GHashTableIter iter;
@@ -443,9 +484,10 @@ write_networkd_conf(net_definition* def, const char* rootdir)
 {
     g_autofree char* path_base = g_strjoin(NULL, "run/systemd/network/10-netplan-", def->id, NULL);
 
-    /* We want this for all backends when renaming, as *.link files are
+    /* We want this for all backends when renaming, as *.link and *.rules files are
      * evaluated by udev, not networkd itself or NetworkManager. */
     write_link_file(def, rootdir, path_base);
+    write_rules_file(def, rootdir);
 
     if (def->backend != BACKEND_NETWORKD) {
         g_debug("networkd: definition %s is not for us (backend %i)", def->id, def->backend);

--- a/tests/generate.py
+++ b/tests/generate.py
@@ -115,7 +115,7 @@ class TestBase(unittest.TestCase):
             if os.path.exists(con_dir):
                 self.assertEqual(os.listdir(con_dir), [])
 
-    def assert_udev(self, contents):
+    def assert_nm_udev(self, contents):
         rule_path = os.path.join(self.workdir.name, 'run/udev/rules.d/90-netplan.rules')
         if contents is None:
             self.assertFalse(os.path.exists(rule_path))
@@ -130,19 +130,19 @@ class TestConfigArgs(TestBase):
     def test_no_files(self):
         subprocess.check_call([exe_generate, '--root-dir', self.workdir.name])
         self.assertEqual(os.listdir(self.workdir.name), [])
-        self.assert_udev(None)
+        self.assert_nm_udev(None)
 
     def test_no_configs(self):
         self.generate('network:\n  version: 2')
         # should not write any files
         self.assertEqual(os.listdir(self.workdir.name), ['etc'])
-        self.assert_udev(None)
+        self.assert_nm_udev(None)
 
     def test_empty_config(self):
         self.generate('')
         # should not write any files
         self.assertEqual(os.listdir(self.workdir.name), ['etc'])
-        self.assert_udev(None)
+        self.assert_nm_udev(None)
 
     def test_file_args(self):
         conf = os.path.join(self.workdir.name, 'config')
@@ -309,7 +309,7 @@ RouteMetric=100
         self.assert_nm(None, '''[keyfile]
 # devices managed by networkd
 unmanaged-devices+=interface-name:eth0,''')
-        self.assert_udev(None)
+        self.assert_nm_udev(None)
         # should not allow NM to manage everything
         self.assertFalse(os.path.exists(self.nm_enable_all_conf))
 
@@ -360,7 +360,7 @@ unmanaged-devices+=interface-name:eth0,''')
         self.assert_networkd({'def1.link': '[Match]\nDriver=ixgbe\n\n[Link]\nName=lom1\nWakeOnLan=off\n'})
         # NM cannot match by driver, so blacklisting needs to happen via udev
         self.assert_nm(None, None)
-        self.assert_udev('ACTION=="add|change", SUBSYSTEM=="net", ENV{ID_NET_DRIVER}=="ixgbe", ENV{NM_UNMANAGED}="1"\n')
+        self.assert_nm_udev('ACTION=="add|change", SUBSYSTEM=="net", ENV{ID_NET_DRIVER}=="ixgbe", ENV{NM_UNMANAGED}="1"\n')
 
     def test_eth_match_by_mac_rename(self):
         self.generate('''network:
@@ -375,7 +375,7 @@ unmanaged-devices+=interface-name:eth0,''')
         self.assert_nm(None, '''[keyfile]
 # devices managed by networkd
 unmanaged-devices+=mac:11:22:33:44:55:66,''')
-        self.assert_udev(None)
+        self.assert_nm_udev(None)
 
     def test_eth_implicit_name_match_dhcp4(self):
         self.generate('''network:
@@ -405,7 +405,7 @@ DHCP=ipv4
 UseMTU=true
 RouteMetric=100
 '''})
-        self.assert_udev('ACTION=="add|change", SUBSYSTEM=="net", ENV{ID_NET_DRIVER}=="ixgbe", ENV{NM_UNMANAGED}="1"\n')
+        self.assert_nm_udev('ACTION=="add|change", SUBSYSTEM=="net", ENV{ID_NET_DRIVER}=="ixgbe", ENV{NM_UNMANAGED}="1"\n')
 
     def test_eth_match_name(self):
         self.generate('''network:
@@ -420,7 +420,7 @@ RouteMetric=100
         self.assert_nm(None, '''[keyfile]
 # devices managed by networkd
 unmanaged-devices+=interface-name:green,''')
-        self.assert_udev(None)
+        self.assert_nm_udev(None)
 
     def test_eth_set_mac(self):
         self.generate('''network:
@@ -465,7 +465,7 @@ unmanaged-devices+=interface-name:blue,''')
         self.assert_nm(None, '''[keyfile]
 # devices managed by networkd
 unmanaged-devices+=interface-name:*,''')
-        self.assert_udev(None)
+        self.assert_nm_udev(None)
 
     def test_eth_match_all(self):
         self.generate('''network:
@@ -480,7 +480,7 @@ unmanaged-devices+=interface-name:*,''')
         self.assert_nm(None, '''[keyfile]
 # devices managed by networkd
 unmanaged-devices+=type:ethernet,''')
-        self.assert_udev(None)
+        self.assert_nm_udev(None)
 
     def test_match_multiple(self):
         self.generate('''network:
@@ -518,7 +518,7 @@ unmanaged-devices+=mac:00:11:22:33:44:55,''')
         self.assert_nm(None, '''[keyfile]
 # devices managed by networkd
 unmanaged-devices+=interface-name:eth0,''')
-        self.assert_udev(None)
+        self.assert_nm_udev(None)
         # should not allow NM to manage everything
         self.assertFalse(os.path.exists(self.nm_enable_all_conf))
 
@@ -537,7 +537,7 @@ unmanaged-devices+=interface-name:eth0,''')
 unmanaged-devices+=interface-name:eth0,''')
         # should allow NM to manage everything else
         self.assertTrue(os.path.exists(self.nm_enable_all_conf))
-        self.assert_udev(None)
+        self.assert_nm_udev(None)
 
     def test_bridge_set_mac(self):
         self.generate('''network:
@@ -564,7 +564,7 @@ unmanaged-devices+=interface-name:eth0,''')
         self.assert_nm(None, '''[keyfile]
 # devices managed by networkd
 unmanaged-devices+=interface-name:eth0,''')
-        self.assert_udev(None)
+        self.assert_nm_udev(None)
 
     def test_eth_dhcp6(self):
         self.generate('''network:
@@ -1195,7 +1195,7 @@ Metric=1024
         self.assert_nm(None, '''[keyfile]
 # devices managed by networkd
 unmanaged-devices+=interface-name:wl0,''')
-        self.assert_udev(None)
+        self.assert_nm_udev(None)
 
         # generates wpa config and enables wpasupplicant unit
         with open(os.path.join(self.workdir.name, 'run/netplan/wpa-wl0.conf')) as f:
@@ -1250,7 +1250,7 @@ RouteMetric=600
         self.assert_nm(None, '''[keyfile]
 # devices managed by networkd
 unmanaged-devices+=interface-name:wl0,''')
-        self.assert_udev(None)
+        self.assert_nm_udev(None)
 
     def test_wifi_match(self):
         err = self.generate('''network:
@@ -1289,7 +1289,7 @@ unmanaged-devices+=interface-name:wl0,''')
         self.assert_nm(None, '''[keyfile]
 # devices managed by networkd
 unmanaged-devices+=interface-name:br0,''')
-        self.assert_udev(None)
+        self.assert_nm_udev(None)
 
     def test_bridge_type_renderer(self):
         self.generate('''network:
@@ -1305,7 +1305,7 @@ unmanaged-devices+=interface-name:br0,''')
         self.assert_nm(None, '''[keyfile]
 # devices managed by networkd
 unmanaged-devices+=interface-name:br0,''')
-        self.assert_udev(None)
+        self.assert_nm_udev(None)
 
     def test_bridge_def_renderer(self):
         self.generate('''network:
@@ -1333,7 +1333,7 @@ RouteMetric=100
         self.assert_nm(None, '''[keyfile]
 # devices managed by networkd
 unmanaged-devices+=interface-name:br0,''')
-        self.assert_udev(None)
+        self.assert_nm_udev(None)
 
     def test_bridge_forward_declaration(self):
         self.generate('''network:
@@ -1442,7 +1442,7 @@ unmanaged-devices+=interface-name:eth42,interface-name:eth43,interface-name:mybr
         self.assert_nm(None, '''[keyfile]
 # devices managed by networkd
 unmanaged-devices+=interface-name:bn0,''')
-        self.assert_udev(None)
+        self.assert_nm_udev(None)
 
     def test_bond_components(self):
         self.generate('''network:
@@ -1679,7 +1679,7 @@ Domains=lab kitchen
         self.assert_nm(None, '''[keyfile]
 # devices managed by networkd
 unmanaged-devices+=interface-name:engreen,interface-name:en1,interface-name:enblue,interface-name:enred,''')
-        self.assert_udev(None)
+        self.assert_nm_udev(None)
 
     def test_ip_rule_table(self):
         self.generate('''network:
@@ -1796,7 +1796,7 @@ method=ignore
         # should allow NM to manage everything else
         self.assertTrue(os.path.exists(self.nm_enable_all_conf))
         self.assert_networkd({'eth0.link': '[Match]\nOriginalName=eth0\n\n[Link]\nWakeOnLan=magic\n'})
-        self.assert_udev(None)
+        self.assert_nm_udev(None)
 
     def test_eth_mtu(self):
         self.generate('''network:
@@ -1966,7 +1966,7 @@ method=link-local
 [ipv6]
 method=ignore
 '''})
-        self.assert_udev(None)
+        self.assert_nm_udev(None)
 
     def test_eth_match_by_mac_rename(self):
         self.generate('''network:
@@ -1993,7 +1993,7 @@ method=link-local
 [ipv6]
 method=ignore
 '''})
-        self.assert_udev(None)
+        self.assert_nm_udev(None)
 
     def test_eth_implicit_name_match_dhcp4(self):
         self.generate('''network:
@@ -2072,7 +2072,7 @@ method=auto
 method=ignore
 '''})
         self.assert_networkd({})
-        self.assert_udev(None)
+        self.assert_nm_udev(None)
 
     def test_eth_match_name_rename(self):
         self.generate('''network:
@@ -2102,7 +2102,7 @@ method=ignore
 '''})
         # ... while udev renames it
         self.assert_networkd({'def1.link': '[Match]\nOriginalName=green\n\n[Link]\nName=blue\nWakeOnLan=off\n'})
-        self.assert_udev(None)
+        self.assert_nm_udev(None)
 
     def test_eth_match_name_glob(self):
         err = self.generate('''network:
@@ -2169,7 +2169,7 @@ method=auto
 method=ignore
 '''})
         self.assert_networkd({})
-        self.assert_udev(None)
+        self.assert_nm_udev(None)
 
     def test_eth_global_renderer(self):
         self.generate('''network:
@@ -2194,7 +2194,7 @@ method=auto
 method=ignore
 '''})
         self.assert_networkd({})
-        self.assert_udev(None)
+        self.assert_nm_udev(None)
 
     def test_eth_type_renderer(self):
         self.generate('''network:
@@ -2220,7 +2220,7 @@ method=auto
 method=ignore
 '''})
         self.assert_networkd({})
-        self.assert_udev(None)
+        self.assert_nm_udev(None)
 
     def test_eth_def_renderer(self):
         self.generate('''network:
@@ -2246,7 +2246,7 @@ method=link-local
 method=ignore
 '''})
         self.assert_networkd({})
-        self.assert_udev(None)
+        self.assert_nm_udev(None)
 
     def test_global_renderer_only(self):
         self.generate(None, confs={'01-default-nm.yaml': 'network: {version: 2, renderer: NetworkManager}'})
@@ -2255,7 +2255,7 @@ method=ignore
         # but not configure anything else
         self.assert_nm(None, None)
         self.assert_networkd({})
-        self.assert_udev(None)
+        self.assert_nm_udev(None)
 
     def test_eth_dhcp6(self):
         self.generate('''network:
@@ -2328,7 +2328,7 @@ method=manual
 address1=2001:FFfe::1/64
 '''})
         self.assert_networkd({})
-        self.assert_udev(None)
+        self.assert_nm_udev(None)
 
     def test_eth_manual_addresses_dhcp(self):
         self.generate('''network:
@@ -2588,7 +2588,7 @@ key-mgmt=wpa-psk
 psk=c0mpany
 '''})
         self.assert_networkd({})
-        self.assert_udev(None)
+        self.assert_nm_udev(None)
 
     def test_wifi_match_mac(self):
         self.generate('''network:
@@ -2684,7 +2684,7 @@ key-mgmt=wpa-psk
 psk=s3cret
 '''})
         self.assert_networkd({})
-        self.assert_udev(None)
+        self.assert_nm_udev(None)
 
     def test_wifi_adhoc(self):
         self.generate('''network:
@@ -2735,7 +2735,7 @@ method=auto
 method=ignore
 '''})
         self.assert_networkd({})
-        self.assert_udev(None)
+        self.assert_nm_udev(None)
 
     def test_bridge_type_renderer(self):
         self.generate('''network:
@@ -2758,7 +2758,7 @@ method=auto
 method=ignore
 '''})
         self.assert_networkd({})
-        self.assert_udev(None)
+        self.assert_nm_udev(None)
 
     def test_bridge_set_mac(self):
         self.generate('''network:
@@ -2808,7 +2808,7 @@ address1=1.2.3.4/12
 method=ignore
 '''})
         self.assert_networkd({})
-        self.assert_udev(None)
+        self.assert_nm_udev(None)
 
     def test_bridge_forward_declaration(self):
         self.generate('''network:
@@ -2869,7 +2869,7 @@ method=auto
 method=ignore
 '''})
         self.assert_networkd({})
-        self.assert_udev(None)
+        self.assert_nm_udev(None)
 
     def test_bridge_components(self):
         self.generate('''network:
@@ -2929,7 +2929,7 @@ method=auto
 method=ignore
 '''})
         self.assert_networkd({})
-        self.assert_udev(None)
+        self.assert_nm_udev(None)
 
     def test_bridge_params(self):
         self.generate('''network:
@@ -3012,7 +3012,7 @@ method=auto
 method=ignore
 '''})
         self.assert_networkd({})
-        self.assert_udev(None)
+        self.assert_nm_udev(None)
 
     def test_bond_empty(self):
         self.generate('''network:
@@ -3092,7 +3092,7 @@ method=auto
 method=ignore
 '''})
         self.assert_networkd({})
-        self.assert_udev(None)
+        self.assert_nm_udev(None)
 
     def test_bond_empty_params(self):
         self.generate('''network:
@@ -3153,7 +3153,7 @@ method=auto
 method=ignore
 '''})
         self.assert_networkd({})
-        self.assert_udev(None)
+        self.assert_nm_udev(None)
 
     def test_bond_with_params(self):
         self.generate('''network:
@@ -3256,7 +3256,7 @@ method=auto
 method=ignore
 '''})
         self.assert_networkd({})
-        self.assert_udev(None)
+        self.assert_nm_udev(None)
 
     def test_bond_primary_slave(self):
         self.generate('''network:
@@ -3323,7 +3323,7 @@ method=auto
 method=ignore
 '''})
         self.assert_networkd({})
-        self.assert_udev(None)
+        self.assert_nm_udev(None)
 
     def test_gateway(self):
         self.generate('''network:
@@ -3464,7 +3464,7 @@ method=link-local
 [ipv6]
 method=auto
 '''})
-        self.assert_udev(None)
+        self.assert_nm_udev(None)
 
     def test_vlan_parent_match(self):
         self.generate('''network:
@@ -3517,7 +3517,7 @@ method=auto
 [ipv6]
 method=ignore
 ''' % uuid})
-        self.assert_udev(None)
+        self.assert_nm_udev(None)
 
 
 class TestConfigErrors(TestBase):
@@ -4440,7 +4440,7 @@ class TestMerging(TestBase):
         self.assert_nm(None, '''[keyfile]
 # devices managed by networkd
 unmanaged-devices+=interface-name:engreen,''')
-        self.assert_udev(None)
+        self.assert_nm_udev(None)
 
     def test_add_def(self):
         self.generate('''network:
@@ -4459,7 +4459,7 @@ unmanaged-devices+=interface-name:engreen,''')
         self.assert_nm(None, '''[keyfile]
 # devices managed by networkd
 unmanaged-devices+=interface-name:enblue,interface-name:engreen,''')
-        self.assert_udev(None)
+        self.assert_nm_udev(None)
 
     def test_change_def(self):
         self.generate('''network:
@@ -4499,7 +4499,7 @@ unmanaged-devices+=interface-name:enblue,interface-name:engreen,''')
         self.assert_nm(None, '''[keyfile]
 # devices managed by networkd
 unmanaged-devices+=interface-name:engreen,''')
-        self.assert_udev(None)
+        self.assert_nm_udev(None)
 
     def test_ref(self):
         self.generate('''network:


### PR DESCRIPTION
Due to a systemd issue[1], using link files to rename interfaces doesn't work as expected. Link files will not rename an interface if it was already renamed, and interfaces are renamed in initrd, so set-name will often not work as expected when rebooting.

However, rules files will cause a renaming, even if the interface has been renamed in initrd.

So, while we sort out whether the systemd-udev behaviour is broken or not, we can simply generate udev rules files with appropriate renaming info in /run/udev/rules.d/70-netplan-<interface>.rules

A file will be created for non-virtual interfaces with both a `set-name` and a `driver` or a `macaddress` in the match stanza. (Renaming from name to name doesn't work.)

This is at least a temporary fix to [LP: #1770082](https://bugs.launchpad.net/netplan/+bug/1770082).

As far as testing goes, test successful `set-name:` generations, and a few cases where we expect no files to be generated.

[1] https://github.com/systemd/systemd#9006