### PR TITLE
Support IPv6 Privacy Extensions

### DIFF
--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -159,6 +159,12 @@ Virtual devices
     Note that **``rdnssd``**(8) is required to use RDNSS with networkd. No extra
     software is required for NetworkManager.
 
+``ipv6-privacy`` (bool)
+
+:   Enable IPv6 Privacy Extensions (RFC 4941) for the specified interface, and
+    prefer temporary addresses. Defaults to false - no privacy extensions. There
+    is currently no way to have a private address but prefer the public address.
+
 ``link-local`` (sequence of scalars)
 
 :   Configure the link-local addresses to bring up. Valid options are 'ipv4'

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -358,6 +358,8 @@ write_network_file(net_definition* def, const char* rootdir, const char* path)
         g_string_append_printf(s, "IPv6AcceptRA=yes\n");
     else if (def->accept_ra == ACCEPT_RA_DISABLED)
         g_string_append_printf(s, "IPv6AcceptRA=no\n");
+    if (def->ip6_privacy)
+        g_string_append(s, "IPv6PrivacyExtensions=yes\n");
     if (def->gateway4)
         g_string_append_printf(s, "Gateway=%s\n", def->gateway4);
     if (def->gateway6)

--- a/src/nm.c
+++ b/src/nm.c
@@ -443,6 +443,8 @@ write_nm_conf_access_point(net_definition* def, const char* rootdir, const wifi_
         if (def->ip6_addresses)
             for (unsigned i = 0; i < def->ip6_addresses->len; ++i)
                 g_string_append_printf(s, "address%i=%s\n", i+1, g_array_index(def->ip6_addresses, char*, i));
+        if (def->ip6_privacy)
+            g_string_append(s, "ip6-privacy=2\n");
         if (def->gateway6)
             g_string_append_printf(s, "gateway=%s\n", def->gateway6);
         if (def->ip6_nameservers) {

--- a/src/parse.c
+++ b/src/parse.c
@@ -1297,23 +1297,24 @@ const mapping_entry_handler nameservers_handlers[] = {
 };
 
 /* Handlers shared by all link types */
-#define COMMON_LINK_HANDLERS                                                             \
-    {"accept-ra", YAML_SCALAR_NODE, handle_accept_ra},                                   \
-    {"addresses", YAML_SEQUENCE_NODE, handle_addresses},                                 \
-    {"critical", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(critical)},   \
-    {"dhcp4", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(dhcp4)},         \
-    {"dhcp6", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(dhcp6)},         \
-    {"dhcp-identifier", YAML_SCALAR_NODE, handle_dhcp_identifier},                       \
-    {"gateway4", YAML_SCALAR_NODE, handle_gateway4},                                     \
-    {"gateway6", YAML_SCALAR_NODE, handle_gateway6},                                     \
-    {"link-local", YAML_SEQUENCE_NODE, handle_link_local},                               \
-    {"macaddress", YAML_SCALAR_NODE, handle_netdef_mac, NULL, netdef_offset(set_mac)},   \
-    {"mtu", YAML_SCALAR_NODE, handle_netdef_guint, NULL, netdef_offset(mtubytes)},       \
-    {"nameservers", YAML_MAPPING_NODE, NULL, nameservers_handlers},                      \
-    {"optional", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(optional)},   \
-    {"optional-addresses", YAML_SEQUENCE_NODE, handle_optional_addresses},               \
-    {"renderer", YAML_SCALAR_NODE, handle_netdef_renderer},                              \
-    {"routes", YAML_SEQUENCE_NODE, handle_routes},                                       \
+#define COMMON_LINK_HANDLERS                                                                  \
+    {"accept-ra", YAML_SCALAR_NODE, handle_accept_ra},                                        \
+    {"addresses", YAML_SEQUENCE_NODE, handle_addresses},                                      \
+    {"critical", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(critical)},        \
+    {"dhcp4", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(dhcp4)},              \
+    {"dhcp6", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(dhcp6)},              \
+    {"dhcp-identifier", YAML_SCALAR_NODE, handle_dhcp_identifier},                            \
+    {"gateway4", YAML_SCALAR_NODE, handle_gateway4},                                          \
+    {"gateway6", YAML_SCALAR_NODE, handle_gateway6},                                          \
+    {"ipv6-privacy", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(ip6_privacy)}, \
+    {"link-local", YAML_SEQUENCE_NODE, handle_link_local},                                    \
+    {"macaddress", YAML_SCALAR_NODE, handle_netdef_mac, NULL, netdef_offset(set_mac)},        \
+    {"mtu", YAML_SCALAR_NODE, handle_netdef_guint, NULL, netdef_offset(mtubytes)},            \
+    {"nameservers", YAML_MAPPING_NODE, NULL, nameservers_handlers},                           \
+    {"optional", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(optional)},        \
+    {"optional-addresses", YAML_SEQUENCE_NODE, handle_optional_addresses},                    \
+    {"renderer", YAML_SCALAR_NODE, handle_netdef_renderer},                                   \
+    {"routes", YAML_SEQUENCE_NODE, handle_routes},                                            \
     {"routing-policy", YAML_SEQUENCE_NODE, handle_ip_rules}
 
 /* Handlers for physical links */

--- a/src/parse.h
+++ b/src/parse.h
@@ -97,6 +97,7 @@ typedef struct net_definition {
     ra_mode accept_ra;
     GArray* ip4_addresses;
     GArray* ip6_addresses;
+    gboolean ip6_privacy;
     char* gateway4;
     char* gateway6;
     GArray* ip4_nameservers;

--- a/tests/generate.py
+++ b/tests/generate.py
@@ -1311,6 +1311,26 @@ Gateway=2001:beef:feed::1
 Metric=1024
 '''})
 
+    def test_eth_ipv6_privacy(self):
+        self.generate('''network:
+  version: 2
+  ethernets:
+    eth0:
+      dhcp6: true
+      ipv6-privacy: true''')
+        self.assert_networkd({'eth0.network': '''[Match]
+Name=eth0
+
+[Network]
+DHCP=ipv6
+LinkLocalAddressing=ipv6
+IPv6PrivacyExtensions=yes
+
+[DHCP]
+UseMTU=true
+RouteMetric=100
+'''})
+
     def test_wifi(self):
         self.generate('''network:
   version: 2
@@ -2804,6 +2824,28 @@ address1=192.168.14.2/24
 [ipv6]
 method=manual
 address1=2001:FFfe::1/64
+'''})
+
+    def test_eth_ipv6_privacy(self):
+        self.generate('''network:
+  version: 2
+  renderer: NetworkManager
+  ethernets:
+    eth0: {dhcp6: true, ipv6-privacy: true}''')
+        self.assert_nm({'eth0': '''[connection]
+id=netplan-eth0
+type=ethernet
+interface-name=eth0
+
+[ethernet]
+wake-on-lan=0
+
+[ipv4]
+method=link-local
+
+[ipv6]
+method=auto
+ip6-privacy=2
 '''})
 
     def test_route_v4_single(self):


### PR DESCRIPTION
[LP: #1750392](https://bugs.launchpad.net/ubuntu/+source/nplan/+bug/1750392)

Add 'ip6-privacy' as a boolean key, add docs, and wire it up for
systemd-networkd and NetworkManager.

Test procedure and results are in the LP bug.

Signed-off-by: Daniel Axtens <dja@axtens.net>

## Checklist

- [👍] Runs 'make check' successfully.
- [💯] Retains 100% code coverage (make check-coverage).
- [👍] New/changed keys in YAML format are documented.
- [👍] Closes an open bug in Launchpad.

