### PR TITLE
Add support for WPA2 Enterprise via wpa_supplicant

### DIFF
--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -379,15 +379,25 @@ wpasupplicant installed if you let the ``networkd`` renderer handle wifi.
      supported properties:
 
      ``password`` (scalar)
-     :    Enable WPA2 authentication and set the passphrase for it. If not
-          given, the network is assumed to be open. Other authentication modes
-          are not currently supported.
+     :    Sets the passphrase for WPA2 Personal and Enterprise networks. If not
+          given, the network is assumed to be open.
 
      ``mode`` (scalar)
      :    Possible access point modes are ``infrastructure`` (the default),
           ``ap`` (create an access point to which other devices can connect),
           and ``adhoc`` (peer to peer networks without a central access point).
           ``ap`` is only supported with NetworkManager.
+
+     ``key_mgmt`` (scalar)
+     :    Set this to WPA-EAP to connect to WPA2 Enterprise WiFi
+          networks. Optional for WPA2 Personal (WPA-PSK).  Possible key_mgmt
+          values are WPA-PSK and WPA-EAP. Defaults to WPA-PSK if password is
+          provided.
+
+     ``identity`` (scalar)
+     :    Provides the identity for authenticating with WPA2 Enterprise
+          (WPA-EAP). Not needed for WPA2 Personal.
+
 
 ## Properties for device type ``bridges:``
 

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -468,10 +468,16 @@ write_wpa_conf(net_definition* def, const char* rootdir)
     g_hash_table_iter_init(&iter, def->access_points);
     while (g_hash_table_iter_next(&iter, NULL, (gpointer) &ap)) {
         g_string_append_printf(s, "network={\n  ssid=\"%s\"\n", ap->ssid);
-        if (ap->password)
+        if (ap->identity)
+            g_string_append_printf(s, "  identity=\"%s\"\n", ap->identity);
+        if (!ap->key_mgmt && ap->password)
             g_string_append_printf(s, "  psk=\"%s\"\n", ap->password);
-        else
-            g_string_append(s, "  key_mgmt=NONE\n");
+        else if (ap->password)
+            g_string_append_printf(s, "  password=%s\n", ap->password);
+        if (!ap->key_mgmt && !ap->password)
+            ap->key_mgmt = "NONE";
+        if (ap->key_mgmt)
+            g_string_append_printf(s, "  key_mgmt=%s\n", ap->key_mgmt);
         switch (ap->mode) {
             case WIFI_MODE_INFRASTRUCTURE:
                 /* default in wpasupplicant */

--- a/src/parse.c
+++ b/src/parse.c
@@ -420,6 +420,22 @@ handle_access_point_password(yaml_document_t* doc, yaml_node_t* node, const void
 }
 
 static gboolean
+handle_access_point_identity(yaml_document_t* doc, yaml_node_t* node, const void* _, GError** error)
+{
+    g_assert(cur_access_point);
+    cur_access_point->identity = g_strdup(scalar(node));
+    return TRUE;
+}
+
+static gboolean
+handle_access_point_key_mgmt(yaml_document_t* doc, yaml_node_t* node, const void* _, GError** error)
+{
+    g_assert(cur_access_point);
+    cur_access_point->key_mgmt = g_strdup(scalar(node));
+    return TRUE;
+}
+
+static gboolean
 handle_access_point_mode(yaml_document_t* doc, yaml_node_t* node, const void* _, GError** error)
 {
     g_assert(cur_access_point);
@@ -437,6 +453,8 @@ handle_access_point_mode(yaml_document_t* doc, yaml_node_t* node, const void* _,
 const mapping_entry_handler wifi_access_point_handlers[] = {
     {"mode", YAML_SCALAR_NODE, handle_access_point_mode},
     {"password", YAML_SCALAR_NODE, handle_access_point_password},
+    {"identity", YAML_SCALAR_NODE, handle_access_point_identity},
+    {"key_mgmt", YAML_SCALAR_NODE, handle_access_point_key_mgmt},
     {NULL}
 };
 
@@ -592,11 +610,11 @@ handle_wifi_access_points(yaml_document_t* doc, yaml_node_t* node, const void* d
             ret = yaml_error(key, error, "%s: Duplicate access point SSID '%s'", cur_netdef->id, cur_access_point->ssid);
             cur_access_point = NULL;
             return ret;
-	}
+        }
 
         if (!process_mapping(doc, value, wifi_access_point_handlers, error)) {
-	    cur_access_point = NULL;
-	    return FALSE;
+            cur_access_point = NULL;
+            return FALSE;
         }
 
         cur_access_point = NULL;

--- a/src/parse.h
+++ b/src/parse.h
@@ -169,6 +169,8 @@ typedef struct {
     wifi_mode mode;
     char* ssid;
     char* password;
+    char* identity;
+    char* key_mgmt;
 } wifi_access_point;
 
 #define METRIC_UNSPEC G_MAXUINT

--- a/tests/generate.py
+++ b/tests/generate.py
@@ -3049,6 +3049,34 @@ psk=s3cret
         self.assert_networkd({})
         self.assert_nm_udev(None)
 
+    def test_wifi_ap_8021x(self):
+        self.generate('''network:
+  version: 2
+  renderer: networkd
+  wifis:
+    wl0:
+      access-points:
+        worknet:
+          key_mgmt: WPA-EAP
+          identity: foo@example.com
+          password: hash:s3cret''')
+
+        #self.assert_nm({})
+        self.assert_networkd({})
+        self.assert_nm_udev(None)
+
+        # generates wpa config and enables wpasupplicant unit
+        with open(os.path.join(self.workdir.name, 'run/netplan/wpa-wl0.conf')) as f:
+            self.assertEqual(f.read(), '''ctrl_interface=/run/wpa_supplicant
+
+network={
+  ssid="worknet"
+  identity="foo@example.com"
+  password=hash:s3cret
+  key_mgmt=WPA-EAP
+}
+''')
+
     def test_wifi_adhoc(self):
         self.generate('''network:
   version: 2


### PR DESCRIPTION
## Description

Adds support for access point key_mgmt and identity so that netplan can generate wpa_supplicant configuration files that work with WPA2 Enterprise.

Fixes bug 1739578

## Checklist

- [x ] Runs 'make check' successfully.
- [x ] Retains 100% code coverage (make check-coverage).
- [x ] New/changed keys in YAML format are documented.
- [x ] \(Optional\) Closes an open bug in Launchpad.

