### PR TITLE
Spell Gratuitous ARP correctly and make it work

### DIFF
--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -558,12 +558,15 @@ wpasupplicant installed if you let the ``networkd`` renderer handle wifi.
           them to the bond, or how else the system should handle MAC addresses.
           The possible values are ``none``, ``active``, and ``follow``.
 
-     ``gratuitious-arp`` (scalar)
+     ``gratuitous-arp`` (scalar)
      :    Specify how many ARP packets to send after failover. Once a link is
           up on a new slave, a notification is sent and possibly repeated if
           this value is set to a number greater than ``1``. The default value
           is ``1`` and valid values are between ``1`` and ``255``. This only
           affects ``active-backup`` mode.
+
+          For historical reasons, the misspelling ``gratuitious-arp`` is also
+          accepted and has the same function.
 
      ``packets-per-slave`` (scalar)
      :    In ``balance-rr`` mode, specifies the number of packets to transmit

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -187,8 +187,8 @@ write_bond_parameters(net_definition* def, GString* s)
     }
     if (def->bond_params.fail_over_mac_policy)
         g_string_append_printf(params, "\nFailOverMACPolicy=%s", def->bond_params.fail_over_mac_policy);
-    if (def->bond_params.gratuitious_arp)
-        g_string_append_printf(params, "\nGratuitiousARP=%d", def->bond_params.gratuitious_arp);
+    if (def->bond_params.gratuitous_arp)
+        g_string_append_printf(params, "\nGratuitousARP=%d", def->bond_params.gratuitous_arp);
     /* TODO: add unsolicited_na, not documented as supported by NM. */
     if (def->bond_params.packets_per_slave)
         g_string_append_printf(params, "\nPacketsPerSlave=%d", def->bond_params.packets_per_slave);

--- a/src/nm.c
+++ b/src/nm.c
@@ -185,9 +185,12 @@ write_bond_parameters(const net_definition* def, GString *s)
         g_string_append_printf(params, "\ndowndelay=%s", def->bond_params.down_delay);
     if (def->bond_params.fail_over_mac_policy)
         g_string_append_printf(params, "\nfail_over_mac=%s", def->bond_params.fail_over_mac_policy);
-    if (def->bond_params.gratuitious_arp)
-        g_string_append_printf(params, "\nnum_grat_arp=%d", def->bond_params.gratuitious_arp);
-    /* TODO: add unsolicited_na, not documented as supported by NM. */
+    if (def->bond_params.gratuitous_arp) {
+        g_string_append_printf(params, "\nnum_grat_arp=%d", def->bond_params.gratuitous_arp);
+        /* Work around issue in NM where unset unsolicited_na will overwrite num_grat_arp:
+	 * https://github.com/NetworkManager/NetworkManager/commit/42b0bef33c77a0921590b2697f077e8ea7805166 */
+        g_string_append_printf(params, "\nnum_unsol_na=%d", def->bond_params.gratuitous_arp);
+    }
     if (def->bond_params.packets_per_slave)
         g_string_append_printf(params, "\npackets_per_slave=%d", def->bond_params.packets_per_slave);
     if (def->bond_params.primary_reselect_policy)

--- a/src/parse.c
+++ b/src/parse.c
@@ -1217,7 +1217,9 @@ const mapping_entry_handler bond_params_handlers[] = {
     {"up-delay", YAML_SCALAR_NODE, handle_netdef_str, NULL, netdef_offset(bond_params.up_delay)},
     {"down-delay", YAML_SCALAR_NODE, handle_netdef_str, NULL, netdef_offset(bond_params.down_delay)},
     {"fail-over-mac-policy", YAML_SCALAR_NODE, handle_netdef_str, NULL, netdef_offset(bond_params.fail_over_mac_policy)},
-    {"gratuitious-arp", YAML_SCALAR_NODE, handle_netdef_guint, NULL, netdef_offset(bond_params.gratuitious_arp)},
+    {"gratuitous-arp", YAML_SCALAR_NODE, handle_netdef_guint, NULL, netdef_offset(bond_params.gratuitous_arp)},
+    /* Handle the old misspelling */
+    {"gratuitious-arp", YAML_SCALAR_NODE, handle_netdef_guint, NULL, netdef_offset(bond_params.gratuitous_arp)},
     /* TODO: unsolicited_na */
     {"packets-per-slave", YAML_SCALAR_NODE, handle_netdef_guint, NULL, netdef_offset(bond_params.packets_per_slave)},
     {"primary-reselect-policy", YAML_SCALAR_NODE, handle_netdef_str, NULL, netdef_offset(bond_params.primary_reselect_policy)},

--- a/src/parse.h
+++ b/src/parse.h
@@ -136,7 +136,7 @@ typedef struct net_definition {
         char* up_delay;
         char* down_delay;
         char* fail_over_mac_policy;
-        guint gratuitious_arp;
+        guint gratuitous_arp;
         /* TODO: unsolicited_na */
         guint packets_per_slave;
         char* primary_reselect_policy;

--- a/tests/generate.py
+++ b/tests/generate.py
@@ -1714,7 +1714,7 @@ RouteMetric=100
                                             'UpDelaySec=20ms\n'
                                             'DownDelaySec=30ms\n'
                                             'FailOverMACPolicy=none\n'
-                                            'GratuitiousARP=10\n'
+                                            'GratuitousARP=10\n'
                                             'PacketsPerSlave=10\n'
                                             'PrimaryReselectPolicy=none\n'
                                             'ResendIGMP=10\n'
@@ -1812,6 +1812,44 @@ RouteMetric=100
 ''',
                               'eno1.network': '[Match]\nName=eno1\n\n'
                                               '[Network]\nLinkLocalAddressing=no\nBond=bn0\nPrimarySlave=true\n',
+                              'switchports.network': '[Match]\nDriver=yayroute\n\n'
+                                                     '[Network]\nLinkLocalAddressing=no\nBond=bn0\n'})
+
+    def test_bond_with_gratuitous_spelling(self):
+        """Validate that the correct spelling of gratuitous also works"""
+        self.generate('''network:
+  version: 2
+  ethernets:
+    eno1: {}
+    switchports:
+      match:
+        driver: yayroute
+  bonds:
+    bn0:
+      parameters:
+        mode: active-backup
+        gratuitous-arp: 10
+      interfaces: [eno1, switchports]
+      dhcp4: true''')
+
+        self.assert_networkd({'bn0.netdev': '[NetDev]\nName=bn0\nKind=bond\n\n'
+                                            '[Bond]\n'
+                                            'Mode=active-backup\n'
+                                            'GratuitousARP=10\n',
+                              'bn0.network': '''[Match]
+Name=bn0
+
+[Network]
+DHCP=ipv4
+LinkLocalAddressing=ipv6
+ConfigureWithoutCarrier=yes
+
+[DHCP]
+UseMTU=true
+RouteMetric=100
+''',
+                              'eno1.network': '[Match]\nName=eno1\n\n'
+                                              '[Network]\nLinkLocalAddressing=no\nBond=bn0\n',
                               'switchports.network': '[Match]\nDriver=yayroute\n\n'
                                                      '[Network]\nLinkLocalAddressing=no\nBond=bn0\n'})
 
@@ -3607,6 +3645,7 @@ updelay=10
 downdelay=10
 fail_over_mac=none
 num_grat_arp=10
+num_unsol_na=10
 packets_per_slave=10
 primary_reselect=none
 resend_igmp=10

--- a/tests/validate_docs.sh
+++ b/tests/validate_docs.sh
@@ -35,7 +35,12 @@ for term in $(sed -n 's/[ ]\+{"\([a-z0-9-]\+\)", YAML_[A-Z]\+_NODE.*/\1/p' src/p
     if [[ $term = "search" ]]; then
 	continue
     fi
-    
+
+    # 5. gratuit_i_ous arp gets a special note
+    if [[ $term = "gratuitious-arp" ]]; then
+	continue
+    fi
+
     echo ERROR: The key "$term" is defined in the parser but not documented.
     exit 1
 done


### PR DESCRIPTION
## Description

[LP: #1756701](https://bugs.launchpad.net/netplan/+bug/1756701)

Throughout the codebase, gratuitous has an extra 'i' (gratuit_i_ous).

This includes the output for networkd. This misspelling causes the
value to have no effect - regardless of the setting, I only see 1
gratuitous ARP in active-backup mode.

It also causes the following message to be printed to syslog:

/run/systemd/network/10-netplan-bond0.netdev:9: Unknown lvalue 'GratuitiousARP' in section 'Bond'

Changing the networkd code to spit out the correct spelling causes
the correct behaviour.

The NM parameter is num_grat_arp, which is not affected by the broader
misspelling. However, NM is affected by a different bug which fixes the
number of gratuitous arps to 1. This has been fixed upstream but not
backported yet:
https://github.com/NetworkManager/NetworkManager/commit/42b0bef33c77a0921590b2697f077e8ea7805166

The workaround is trivial - just set num_unsol_na to the same value:
they map to the same kernel parameter internally anyway. So implement
the workaround.

 - Use the correct spelling in the code
 - Accept both new and old spellings in config files
 - Update the documents and tests appropriately

Signed-off-by: Daniel Axtens <dja@axtens.net>


## Checklist

- [Y] Runs 'make check' successfully.
- [Y] Retains 100% code coverage (make check-coverage).
- [Y] New/changed keys in YAML format are documented.
- [Y] Closes an open bug in Launchpad.

## Note
It seems this has never worked so will need to be backported. It should be fairly trivial but I'm happy to help if it gets messy anywhere.