### PR TITLE
Add ability to set interface route metrics

### DIFF
--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -254,6 +254,15 @@ similar to ``gateway*``, and ``search:`` is a list of search domains.
      only, due to interactions with device renaming in udev. Match
      devices by MAC when setting MTU.
 
+``metric`` (scalar)
+
+:    Set the relative priority of routes on this interface. Must be a
+     positive integer value. The default value is 600 for wifi interfaces, and
+     100 for all other interfaces. The same value is used for both IPv4 and IPv6.
+
+     (See also the `metric` key for static routes. Metrics for static routes
+     will take precedence over this metric.)
+
 ``optional`` (bool)
 
 :    An optional device is not required for booting. Normally, networkd will

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -404,7 +404,9 @@ write_network_file(net_definition* def, const char* rootdir, const char* path)
          * not accept MTU, which breaks clouds */
         g_string_append_printf(s, "\n[DHCP]\nUseMTU=true\n");
         /* NetworkManager compatible route metrics */
-        g_string_append_printf(s, "RouteMetric=%i\n", (def->type == ND_WIFI ? 600 : 100));
+	if (def->metric == METRIC_UNSPEC)
+            def->metric = (def->type == ND_WIFI ? 600: 100);
+        g_string_append_printf(s, "RouteMetric=%i\n", def->metric);
         if (g_strcmp0(def->dhcp_identifier, "duid") != 0)
             g_string_append_printf(s, "ClientIdentifier=%s\n", def->dhcp_identifier);
         if (def->critical)

--- a/src/nm.c
+++ b/src/nm.c
@@ -402,6 +402,8 @@ write_nm_conf_access_point(net_definition* def, const char* rootdir, const wifi_
             g_string_append_printf(s, "%s;", g_array_index(def->ip4_nameservers, char*, i));
         g_string_append(s, "\n");
     }
+    if (def->metric != METRIC_UNSPEC)
+        g_string_append_printf(s, "route-metric=%u\n", def->metric);
     write_search_domains(def, s);
     write_routes(def, s, AF_INET);
 
@@ -419,6 +421,9 @@ write_nm_conf_access_point(net_definition* def, const char* rootdir, const wifi_
                 g_string_append_printf(s, "%s;", g_array_index(def->ip6_nameservers, char*, i));
             g_string_append(s, "\n");
         }
+        if (def->metric != METRIC_UNSPEC)
+            g_string_append_printf(s, "route-metric=%u\n", def->metric);
+
         /* nm-settings(5) specifies search-domain for both [ipv4] and [ipv6] --
          * do we really need to repeat it here? */
         write_search_domains(def, s);

--- a/src/parse.c
+++ b/src/parse.c
@@ -1080,7 +1080,7 @@ handle_routes(yaml_document_t* doc, yaml_node_t* node, const void* _, GError** e
         cur_route = g_new0(ip_route, 1);
         cur_route->type = g_strdup("unicast");
         cur_route->family = G_MAXUINT; /* 0 is a valid family ID */
-        cur_route->metric = G_MAXUINT; /* 0 is a valid metric */
+        cur_route->metric = METRIC_UNSPEC; /* 0 is a valid metric */
 
         if (process_mapping(doc, entry, routes_handlers, error)) {
             if (!cur_netdef->routes) {
@@ -1269,6 +1269,7 @@ const mapping_entry_handler ethernet_def_handlers[] = {
     {"link-local", YAML_SEQUENCE_NODE, handle_link_local},
     {"macaddress", YAML_SCALAR_NODE, handle_netdef_mac, NULL, netdef_offset(set_mac)},
     {"match", YAML_MAPPING_NODE, handle_match},
+    {"metric", YAML_SCALAR_NODE, handle_netdef_guint, NULL, netdef_offset(metric)},
     {"mtu", YAML_SCALAR_NODE, handle_netdef_guint, NULL, netdef_offset(mtubytes)},
     {"nameservers", YAML_MAPPING_NODE, NULL, nameservers_handlers},
     {"renderer", YAML_SCALAR_NODE, handle_netdef_renderer},
@@ -1293,6 +1294,7 @@ const mapping_entry_handler wifi_def_handlers[] = {
     {"link-local", YAML_SEQUENCE_NODE, handle_link_local},
     {"macaddress", YAML_SCALAR_NODE, handle_netdef_mac, NULL, netdef_offset(set_mac)},
     {"match", YAML_MAPPING_NODE, handle_match},
+    {"metric", YAML_SCALAR_NODE, handle_netdef_guint, NULL, netdef_offset(metric)},
     {"mtu", YAML_SCALAR_NODE, handle_netdef_guint, NULL, netdef_offset(mtubytes)},
     {"nameservers", YAML_MAPPING_NODE, NULL, nameservers_handlers},
     {"renderer", YAML_SCALAR_NODE, handle_netdef_renderer},
@@ -1316,6 +1318,7 @@ const mapping_entry_handler bridge_def_handlers[] = {
     {"interfaces", YAML_SEQUENCE_NODE, handle_bridge_interfaces, NULL, NULL},
     {"link-local", YAML_SEQUENCE_NODE, handle_link_local},
     {"macaddress", YAML_SCALAR_NODE, handle_netdef_mac, NULL, netdef_offset(set_mac)},
+    {"metric", YAML_SCALAR_NODE, handle_netdef_guint, NULL, netdef_offset(metric)},
     {"mtu", YAML_SCALAR_NODE, handle_netdef_guint, NULL, netdef_offset(mtubytes)},
     {"nameservers", YAML_MAPPING_NODE, NULL, nameservers_handlers},
     {"parameters", YAML_MAPPING_NODE, handle_bridge},
@@ -1338,6 +1341,7 @@ const mapping_entry_handler bond_def_handlers[] = {
     {"interfaces", YAML_SEQUENCE_NODE, handle_bond_interfaces, NULL, NULL},
     {"link-local", YAML_SEQUENCE_NODE, handle_link_local},
     {"macaddress", YAML_SCALAR_NODE, handle_netdef_mac, NULL, netdef_offset(set_mac)},
+    {"metric", YAML_SCALAR_NODE, handle_netdef_guint, NULL, netdef_offset(metric)},
     {"mtu", YAML_SCALAR_NODE, handle_netdef_guint, NULL, netdef_offset(mtubytes)},
     {"nameservers", YAML_MAPPING_NODE, NULL, nameservers_handlers},
     {"parameters", YAML_MAPPING_NODE, handle_bonding},
@@ -1362,6 +1366,7 @@ const mapping_entry_handler vlan_def_handlers[] = {
     {"link-local", YAML_SEQUENCE_NODE, handle_link_local},
     {"nameservers", YAML_MAPPING_NODE, NULL, nameservers_handlers},
     {"macaddress", YAML_SCALAR_NODE, handle_netdef_mac, NULL, netdef_offset(set_mac)},
+    {"metric", YAML_SCALAR_NODE, handle_netdef_guint, NULL, netdef_offset(metric)},
     {"mtu", YAML_SCALAR_NODE, handle_netdef_guint, NULL, netdef_offset(mtubytes)},
     {"renderer", YAML_SCALAR_NODE, handle_netdef_renderer},
     {"routes", YAML_SEQUENCE_NODE, handle_routes},
@@ -1467,6 +1472,7 @@ handle_network_type(yaml_document_t* doc, yaml_node_t* node, const void* data, G
             cur_netdef->backend = backend_cur_type ?: BACKEND_NONE;
             cur_netdef->id = g_strdup(scalar(key));
             cur_netdef->vlan_id = G_MAXUINT; /* 0 is a valid ID */
+            cur_netdef->metric = METRIC_UNSPEC; /* 0 is a valid metric */
             cur_netdef->dhcp_identifier = g_strdup("duid"); /* keep networkd's default */
             /* systemd-networkd defaults to IPv6 LL enabled; keep that default */
             cur_netdef->linklocal.ipv6 = TRUE;

--- a/src/parse.h
+++ b/src/parse.h
@@ -92,6 +92,7 @@ typedef struct net_definition {
         gboolean ipv4;
         gboolean ipv6;
     } linklocal;
+    guint metric;
 
     /* master ID for slave devices */
     char* bridge;


### PR DESCRIPTION
[LP: #1771834](https://bugs.launchpad.net/netplan/+bug/1771834)

Currently, we set a route metric of 600 for routes on a wifi device
and 100 on other devices. We allow static routes to set their own
metric, but have no way to set the metric for routes that come from
DHCP, or the route to the subnet. Add this ability through a 'metric'
key on an interface.

This is particularly useful for systems with multiple DHCP interfaces
where one should be preferred.

Add a 'metric' key to interfaces, plumb it through, document it,
add tests.

Signed-off-by: Daniel Axtens <dja@axtens.net>

## Checklist

- [Y] Runs 'make check' successfully.
- [Y] Retains 100% code coverage (make check-coverage).
- [Y] New/changed keys in YAML format are documented.
- [Y]  Closes an open bug in Launchpad.

