### PR TITLE
Update man pages for deletion of replug code

### DIFF
--- a/doc/netplan-apply.md
+++ b/doc/netplan-apply.md
@@ -47,17 +47,14 @@ see **netplan**(5).
 
 # KNOWN ISSUES
 
-**netplan apply** looks for interfaces that are down after the first
-pass and may unbind these interfaces from the drivers and rebind
-them. While helpful for matches by name, this process is not always
-robust and may lead to devices disappearing or being unexpectedly
-renamed.
-
-**netplan apply** will also not remove virtual devices such as bridges
+**netplan apply** will not remove virtual devices such as bridges
 and bonds that have been created, even if they are no longer described
 in the netplan configuration.
 
-In both of these cases the problems can be avoided or resolved by rebooting.
+This can be resolved by manually removing the virtual device (for
+example ``ip link delete dev bond0``) and then running **netplan
+apply**, or by rebooting.
+
 
 # SEE ALSO
 

--- a/doc/netplan-try.md
+++ b/doc/netplan-try.md
@@ -45,9 +45,7 @@ network configuration error.
 # KNOWN ISSUES
 
 **netplan try** uses similar procedures to **netplan apply**, so some
-of the same caveats apply. In particular, the unbinding and rebinding
-procedures may cause some network devices to be unexpectedly renamed,
-or to disappear entirely.
+of the same caveats apply around virtual devices.
 
 There are also some known bugs: if **netplan try** times out or is
 cancelled, make sure to verify if the network configuration has in


### PR DESCRIPTION
No longer need to warn about the side effect of replug.

Fixes: 77ab99dbd420 ("Detect and apply interface naming changes on 'netplan apply'")
Signed-off-by: Daniel Axtens <dja@axtens.net>

## Checklist

- [Y] Runs 'make check' successfully.
- [Y] Retains 100% code coverage (make check-coverage).
- [N/A] New/changed keys in YAML format are documented.
- [N] (Optional) Closes an open bug in Launchpad.

