### PR TITLE
7-dns-overrides-for-dhcp-configuration

### DIFF
--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -159,6 +159,27 @@ Virtual devices
     Note that **``rdnssd``**(8) is required to use RDNSS with networkd. No extra
     software is required for NetworkManager.
 
+``dhcp4-overrides`` (mapping)
+
+:   Control additional DHCP properties.
+    These are the supported fields:
+    * `use-dns`
+
+``dhcp6-overrides`` (mapping)
+
+:   Control additional DHCP properties.
+    These are the supported fields:
+    * `use-dns`
+
+``use-dns`` (bool)
+
+:   Enable DHCP4/DHCP6 to provide dns servers. On by default.
+
+    If you are planning to override your DHCP server provided DNS server,
+    set this to `no`.
+    
+    **Note:** networkd does not support disabling dhcp for only one of dhcp4/dhcp6, you will need to disable it for both.
+
 ``link-local`` (sequence of scalars)
 
 :   Configure the link-local addresses to bring up. Valid options are 'ipv4'

--- a/src/nm.c
+++ b/src/nm.c
@@ -424,6 +424,8 @@ write_nm_conf_access_point(net_definition* def, const char* rootdir, const wifi_
             g_string_append_printf(s, "address%i=%s\n", i+1, g_array_index(def->ip4_addresses, char*, i));
     if (def->gateway4)
         g_string_append_printf(s, "gateway=%s\n", def->gateway4);
+    if (!def->use_dns4)
+        g_string_append(s, "ignore-auto-dns=true\n");
     if (def->ip4_nameservers) {
         g_string_append(s, "dns=");
         for (unsigned i = 0; i < def->ip4_nameservers->len; ++i)
@@ -445,6 +447,8 @@ write_nm_conf_access_point(net_definition* def, const char* rootdir, const wifi_
                 g_string_append_printf(s, "address%i=%s\n", i+1, g_array_index(def->ip6_addresses, char*, i));
         if (def->gateway6)
             g_string_append_printf(s, "gateway=%s\n", def->gateway6);
+        if (!def->use_dns6)
+            g_string_append(s, "ignore-auto-dns=true\n");
         if (def->ip6_nameservers) {
             g_string_append(s, "dns=");
             for (unsigned i = 0; i < def->ip6_nameservers->len; ++i)

--- a/src/parse.c
+++ b/src/parse.c
@@ -1265,12 +1265,24 @@ const mapping_entry_handler nameservers_handlers[] = {
     {NULL}
 };
 
+const mapping_entry_handler dhcp4_overrides_handlers[] = {
+    {"use-dns", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(use_dns4)},
+    {NULL}
+};
+
+const mapping_entry_handler dhcp6_overrides_handlers[] = {
+    {"use-dns", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(use_dns6)},
+    {NULL}
+};
+
 const mapping_entry_handler ethernet_def_handlers[] = {
     {"accept-ra", YAML_SCALAR_NODE, handle_accept_ra},
     {"addresses", YAML_SEQUENCE_NODE, handle_addresses},
     {"critical", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(critical)},
     {"dhcp4", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(dhcp4)},
     {"dhcp6", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(dhcp6)},
+    {"dhcp4-overrides", YAML_MAPPING_NODE, NULL, dhcp4_overrides_handlers},
+    {"dhcp6-overrides", YAML_MAPPING_NODE, NULL, dhcp6_overrides_handlers},
     {"dhcp-identifier", YAML_SCALAR_NODE, handle_dhcp_identifier},
     {"gateway4", YAML_SCALAR_NODE, handle_gateway4},
     {"gateway6", YAML_SCALAR_NODE, handle_gateway6},
@@ -1295,6 +1307,8 @@ const mapping_entry_handler wifi_def_handlers[] = {
     {"critical", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(critical)},
     {"dhcp4", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(dhcp4)},
     {"dhcp6", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(dhcp6)},
+    {"dhcp4-overrides", YAML_MAPPING_NODE, NULL, dhcp4_overrides_handlers},
+    {"dhcp6-overrides", YAML_MAPPING_NODE, NULL, dhcp6_overrides_handlers},
     {"dhcp-identifier", YAML_SCALAR_NODE, handle_dhcp_identifier},
     {"gateway4", YAML_SCALAR_NODE, handle_gateway4},
     {"gateway6", YAML_SCALAR_NODE, handle_gateway6},
@@ -1318,6 +1332,8 @@ const mapping_entry_handler bridge_def_handlers[] = {
     {"critical", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(critical)},
     {"dhcp4", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(dhcp4)},
     {"dhcp6", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(dhcp6)},
+    {"dhcp4-overrides", YAML_MAPPING_NODE, NULL, dhcp4_overrides_handlers},
+    {"dhcp6-overrides", YAML_MAPPING_NODE, NULL, dhcp6_overrides_handlers},
     {"dhcp-identifier", YAML_SCALAR_NODE, handle_dhcp_identifier},
     {"gateway4", YAML_SCALAR_NODE, handle_gateway4},
     {"gateway6", YAML_SCALAR_NODE, handle_gateway6},
@@ -1340,6 +1356,8 @@ const mapping_entry_handler bond_def_handlers[] = {
     {"critical", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(critical)},
     {"dhcp4", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(dhcp4)},
     {"dhcp6", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(dhcp6)},
+    {"dhcp4-overrides", YAML_MAPPING_NODE, NULL, dhcp4_overrides_handlers},
+    {"dhcp6-overrides", YAML_MAPPING_NODE, NULL, dhcp6_overrides_handlers},
     {"dhcp-identifier", YAML_SCALAR_NODE, handle_dhcp_identifier},
     {"gateway4", YAML_SCALAR_NODE, handle_gateway4},
     {"gateway6", YAML_SCALAR_NODE, handle_gateway6},
@@ -1362,6 +1380,8 @@ const mapping_entry_handler vlan_def_handlers[] = {
     {"critical", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(critical)},
     {"dhcp4", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(dhcp4)},
     {"dhcp6", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(dhcp6)},
+    {"dhcp4-overrides", YAML_MAPPING_NODE, NULL, dhcp4_overrides_handlers},
+    {"dhcp6-overrides", YAML_MAPPING_NODE, NULL, dhcp6_overrides_handlers},
     {"dhcp-identifier", YAML_SCALAR_NODE, handle_dhcp_identifier},
     {"gateway4", YAML_SCALAR_NODE, handle_gateway4},
     {"gateway6", YAML_SCALAR_NODE, handle_gateway6},
@@ -1478,6 +1498,8 @@ handle_network_type(yaml_document_t* doc, yaml_node_t* node, const void* data, G
             cur_netdef->dhcp_identifier = g_strdup("duid"); /* keep networkd's default */
             /* systemd-networkd defaults to IPv6 LL enabled; keep that default */
             cur_netdef->linklocal.ipv6 = TRUE;
+            cur_netdef->use_dns4 = TRUE;
+            cur_netdef->use_dns6 = TRUE;
             g_hash_table_insert(netdefs, cur_netdef->id, cur_netdef);
         }
 

--- a/src/parse.h
+++ b/src/parse.h
@@ -77,6 +77,9 @@ typedef struct net_definition {
     /* addresses */
     gboolean dhcp4;
     gboolean dhcp6;
+    gboolean use_dns4;
+    gboolean use_dns6;
+
     char* dhcp_identifier;
     ra_mode accept_ra;
     GArray* ip4_addresses;


### PR DESCRIPTION
This PR enables netplan users to suppress dhcp provided dns servers. Note that systemd-networkd doesn't support suppressing only one at a time, this pr forces one to opt into suppressing both...
```
network:
  version: 2
  ethernets:
    engreen:
      dhcp4: yes
      dhcp4-overrides:
        use-dns: no
      dhcp6-overrides:
        use-dns: no
```

## Description
Part of the work for:
https://trello.com/c/Hbz5Jfol/7-dns-overrides-for-dhcp-configuration

## Checklist

- [x] Runs 'make check' successfully.
- [x] Retains 100% code coverage (make check-coverage).
- [x] New/changed keys in YAML format are documented.
- [x] Closes an open bug in Launchpad.
https://bugs.launchpad.net/netplan/+bug/1759014