### PR TITLE
Add DHCP behavior override options for networkd.

### DIFF
--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -190,10 +190,15 @@ Virtual devices
     device's MAC address as a unique identifier rather than a RFC4361-compliant
     Client ID. This has no effect when NetworkManager is used as a renderer.
 
- ``dhcp-options`` (mapping)
+ ``dhcp4-overrides`` (mapping)
 
- :  (networkd backend only) Additional DHCP options; see the
-    ``DHCP Options`` section below.
+ :  (networkd backend only) Overrides default DHCP behavior; see the
+    ``DHCP Overrides`` section below.
+
+ ``dhcp6-overrides`` (mapping)
+
+ :  (networkd backend only) Overrides default DHCP behavior; see the
+    ``DHCP Overrides`` section below.
 
 ``accept-ra`` (bool)
 
@@ -299,15 +304,18 @@ similar to ``gateway*``, and ``search:`` is a list of search domains.
 
 :   Configure policy routing for the device; see the ``Routing`` section below.
 
-## DHCP Options
-Several DHCP configuration options are supported via the ``networkd`` backend.
+## DHCP Overrides
+Several DHCP behavior overrides are available. Currently this is only supported
+via the ``networkd`` backend.
 
-These only have an effect if ``dhcp4`` or ``dhcp6`` is set to ``true``.
+Overrides only have an effect if the corresponding ``dhcp4`` or ``dhcp6`` is
+set to ``true``.
 
-``dhcp-options`` (mapping)
+If both ``dhcp4`` and ``dhcp6`` are ``true``, the ``networkd`` backend requires
+that ``dhcp4-overrides`` and ``dhcp6-overrides`` contain the same keys and values.
 
-:    The ``dhcp-options`` block defines additional DHCP configuration for the
-     ``networkd`` backend.
+:    The ``dhcp4-overrides`` and ``dhcp6-overrides`` mappings override the
+     default DHCP behavior.
 
      ``use-dns`` (bool)
      :    Default: ``true``. When ``true``, the DNS servers received from the

--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -190,6 +190,11 @@ Virtual devices
     device's MAC address as a unique identifier rather than a RFC4361-compliant
     Client ID. This has no effect when NetworkManager is used as a renderer.
 
+ ``dhcp-options`` (mapping)
+
+ :  (networkd backend only) Additional DHCP options; see the
+    ``DHCP Options`` section below.
+
 ``accept-ra`` (bool)
 
 :   Accept Router Advertisement that would have the kernel configure IPv6 by itself.
@@ -294,6 +299,37 @@ similar to ``gateway*``, and ``search:`` is a list of search domains.
 
 :   Configure policy routing for the device; see the ``Routing`` section below.
 
+## DHCP Options
+Several DHCP configuration options are supported via the ``networkd`` backend.
+
+These only have an effect if ``dhcp4`` or ``dhcp6`` is set to ``true``.
+
+``dhcp-options`` (mapping)
+
+:    The ``dhcp-options`` block defines additional DHCP configuration for the
+     ``networkd`` backend.
+
+     ``use-dns`` (bool)
+     :    Default: ``true``. When ``true``, the DNS servers received from the
+          DHCP server will be used and take precedence over any statically
+          configured ones.
+
+     ``use-ntp`` (bool)
+     :    Default: ``true``. When ``true``, the NTP servers received from the
+          DHCP server will be used by systemd-timesyncd and take precedence
+          over any statically configured ones.
+
+     ``send-hostname`` (bool)
+     :    Default: ``true``. When ``true``, the machine's hostname will be sent
+          to the DHCP server.
+
+     ``use-hostname`` (bool)
+     :    Default: ``true``. When ``true``, the hostname received from the DHCP
+          server will be set as the transient hostname of the system.
+
+     ``hostname`` (scalar)
+     :    Use this value for the hostname which is sent to the DHCP server,
+          instead of machine's hostname.
 
 ## Routing
 Complex routing is possible with netplan. Standard static routes as well

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -428,6 +428,18 @@ write_network_file(net_definition* def, const char* rootdir, const char* path)
             g_string_append_printf(s, "ClientIdentifier=%s\n", def->dhcp_identifier);
         if (def->critical)
             g_string_append_printf(s, "CriticalConnection=true\n");
+
+        /* Only write DHCP options that differ from the networkd default. */
+        if (!def->dhcp_options.use_dns)
+            g_string_append_printf(s, "UseDNS=false\n");
+        if (!def->dhcp_options.use_ntp)
+            g_string_append_printf(s, "UseNTP=false\n");
+        if (!def->dhcp_options.send_hostname)
+            g_string_append_printf(s, "SendHostname=false\n");
+        if (!def->dhcp_options.use_hostname)
+            g_string_append_printf(s, "UseHostname=false\n");
+        if (def->dhcp_options.hostname)
+            g_string_append_printf(s, "Hostname=%s\n", def->dhcp_options.hostname);
     }
 
     /* these do not contain secrets and need to be readable by

--- a/src/parse.c
+++ b/src/parse.c
@@ -1296,6 +1296,15 @@ const mapping_entry_handler nameservers_handlers[] = {
     {NULL}
 };
 
+const mapping_entry_handler dhcp_options_handlers[] = {
+    {"use-dns", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(dhcp_options.use_dns)},
+    {"use-ntp", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(dhcp_options.use_ntp)},
+    {"send-hostname", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(dhcp_options.send_hostname)},
+    {"use-hostname", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(dhcp_options.use_hostname)},
+    {"hostname", YAML_SCALAR_NODE, handle_netdef_str, NULL, netdef_offset(dhcp_options.hostname)},
+    {NULL}
+};
+
 /* Handlers shared by all link types */
 #define COMMON_LINK_HANDLERS                                                             \
     {"accept-ra", YAML_SCALAR_NODE, handle_accept_ra},                                   \
@@ -1304,6 +1313,7 @@ const mapping_entry_handler nameservers_handlers[] = {
     {"dhcp4", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(dhcp4)},         \
     {"dhcp6", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(dhcp6)},         \
     {"dhcp-identifier", YAML_SCALAR_NODE, handle_dhcp_identifier},                       \
+    {"dhcp-options", YAML_MAPPING_NODE, NULL, dhcp_options_handlers},                    \
     {"gateway4", YAML_SCALAR_NODE, handle_gateway4},                                     \
     {"gateway6", YAML_SCALAR_NODE, handle_gateway6},                                     \
     {"link-local", YAML_SEQUENCE_NODE, handle_link_local},                               \
@@ -1457,6 +1467,12 @@ handle_network_type(yaml_document_t* doc, yaml_node_t* node, const void* data, G
             /* systemd-networkd defaults to IPv6 LL enabled; keep that default */
             cur_netdef->linklocal.ipv6 = TRUE;
             g_hash_table_insert(netdefs, cur_netdef->id, cur_netdef);
+
+            /* Default DHCP options. */
+            cur_netdef->dhcp_options.use_dns = TRUE;
+            cur_netdef->dhcp_options.use_ntp = TRUE;
+            cur_netdef->dhcp_options.send_hostname = TRUE;
+            cur_netdef->dhcp_options.use_hostname = TRUE;
         }
 
         // XXX: breaks multi-pass parsing.

--- a/src/parse.h
+++ b/src/parse.h
@@ -75,6 +75,15 @@ typedef struct missing_node {
     const yaml_node_t* node;
 } missing_node;
 
+/* Fields below are valid for dhcp4 and dhcp6 unless otherwise noted. */
+typedef struct dhcp_overrides {
+    gboolean use_dns;
+    gboolean use_ntp;
+    gboolean send_hostname;
+    gboolean use_hostname;
+    char* hostname;
+} dhcp_overrides;
+
 /**
  * Represent a configuration stanza
  */
@@ -94,13 +103,8 @@ typedef struct net_definition {
     gboolean dhcp4;
     gboolean dhcp6;
     char* dhcp_identifier;
-    struct {
-        gboolean use_dns;
-        gboolean use_ntp;
-        gboolean send_hostname;
-        gboolean use_hostname;
-        char* hostname;
-    } dhcp_options;
+    dhcp_overrides dhcp4_overrides;
+    dhcp_overrides dhcp6_overrides;
     ra_mode accept_ra;
     GArray* ip4_addresses;
     GArray* ip6_addresses;

--- a/src/parse.h
+++ b/src/parse.h
@@ -94,6 +94,13 @@ typedef struct net_definition {
     gboolean dhcp4;
     gboolean dhcp6;
     char* dhcp_identifier;
+    struct {
+        gboolean use_dns;
+        gboolean use_ntp;
+        gboolean send_hostname;
+        gboolean use_hostname;
+        char* hostname;
+    } dhcp_options;
     ra_mode accept_ra;
     GArray* ip4_addresses;
     GArray* ip6_addresses;

--- a/tests/generate.py
+++ b/tests/generate.py
@@ -933,6 +933,118 @@ UseMTU=true
 RouteMetric=100
 '''})
 
+    def test_dhcp_options_use_dns(self):
+        # This option should be silently ignored, since it's the default
+        self.generate('''network:
+  version: 2
+  ethernets:
+    engreen:
+      dhcp4: yes
+      dhcp-options:
+        use-dns: yes
+''')
+
+        self.assert_networkd({'engreen.network': ND_DHCP4 % 'engreen'})
+
+    def test_dhcp_options_no_use_dns(self):
+        self.generate('''network:
+  version: 2
+  ethernets:
+    engreen:
+      dhcp4: yes
+      dhcp-options:
+        use-dns: no
+''')
+
+        self.assert_networkd({'engreen.network': ND_DHCP4 % 'engreen' + "UseDNS=false\n"})
+
+    def test_dhcp_options_use_ntp(self):
+        # This option should be silently ignored, since it's the default
+        self.generate('''network:
+  version: 2
+  ethernets:
+    engreen:
+      dhcp4: yes
+      dhcp-options:
+        use-ntp: yes
+''')
+
+        self.assert_networkd({'engreen.network': ND_DHCP4 % 'engreen'})
+
+    def test_dhcp_options_no_use_ntp(self):
+        self.generate('''network:
+  version: 2
+  ethernets:
+    engreen:
+      dhcp4: yes
+      dhcp-options:
+        use-ntp: no
+''')
+
+        self.assert_networkd({'engreen.network': ND_DHCP4 % 'engreen' + "UseNTP=false\n"})
+
+    def test_dhcp_options_send_hostname(self):
+        # This option should be silently ignored, since it's the default
+        self.generate('''network:
+  version: 2
+  ethernets:
+    engreen:
+      dhcp4: yes
+      dhcp-options:
+        send-hostname: yes
+''')
+
+        self.assert_networkd({'engreen.network': ND_DHCP4 % 'engreen'})
+
+    def test_dhcp_options_no_send_hostname(self):
+        self.generate('''network:
+  version: 2
+  ethernets:
+    engreen:
+      dhcp4: yes
+      dhcp-options:
+        send-hostname: no
+''')
+
+        self.assert_networkd({'engreen.network': ND_DHCP4 % 'engreen' + "SendHostname=false\n"})
+
+    def test_dhcp_options_use_hostname(self):
+        # This option should be silently ignored, since it's the default
+        self.generate('''network:
+  version: 2
+  ethernets:
+    engreen:
+      dhcp4: yes
+      dhcp-options:
+        use-hostname: yes
+''')
+
+        self.assert_networkd({'engreen.network': ND_DHCP4 % 'engreen'})
+
+    def test_dhcp_options_no_use_hostname(self):
+        self.generate('''network:
+  version: 2
+  ethernets:
+    engreen:
+      dhcp4: yes
+      dhcp-options:
+        use-hostname: no
+''')
+
+        self.assert_networkd({'engreen.network': ND_DHCP4 % 'engreen' + "UseHostname=false\n"})
+
+    def test_dhcp_options_hostname(self):
+        self.generate('''network:
+  version: 2
+  ethernets:
+    engreen:
+      dhcp4: yes
+      dhcp-options:
+        hostname: my-host
+''')
+
+        self.assert_networkd({'engreen.network': ND_DHCP4 % 'engreen' + "Hostname=my-host\n"})
+
     def test_route_v4_single(self):
         self.generate('''network:
   version: 2


### PR DESCRIPTION
## Description

Adds dhcp4-overrides and dhcp6-overrides. These mappings override
specific DHCP behaviors.

Example usage:

```
network:
  version: 2
  ethernets:
    eth0:
      dhcp4: yes
      dhcp4-overrides:
        use-dns: no
```
The available options added in this commit are:

-   `use-dns`
-   `use-ntp`
-   `send-hostname`
-   `use-hostname`
-   `hostname`

This fixes launchpad bug [#1759014](https://bugs.launchpad.net/netplan/+bug/1759014).

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [x] New/changed keys in YAML format are documented.
- [x] \(Optional\) Closes an open bug in Launchpad.

