### PR TITLE
Fix bug where interface name is wrongly set to ID

### DIFF
--- a/netplan/cli/commands/apply.py
+++ b/netplan/cli/commands/apply.py
@@ -140,9 +140,9 @@ class NetplanApply(utils.NetplanCommand):
             driver = match.get('driver')
             mac = match.get('macaddress')
             if driver:
-                matches['by-driver'][driver] = phy
+                matches['by-driver'][driver] = newname
             if mac:
-                matches['by-mac'][mac] = phy
+                matches['by-mac'][mac] = newname
 
         # /sys/class/net/ens3/device -> ../../../virtio0
         # /sys/class/net/ens3/device/driver -> ../../../../bus/virtio/drivers/virtio_net


### PR DESCRIPTION
The by-mac array should contain the new name (newname variable) instead of the interface ID (phy), so when called in
`new_name = matches['by-mac'][macaddress]` the new name is returned.

Bugs:
https://bugs.launchpad.net/netplan/+bug/1770082
https://bugs.launchpad.net/netplan/+bug/1768827