### PR TITLE
Replace stray tabs with spaces.

### DIFF
--- a/src/generate.c
+++ b/src/generate.c
@@ -252,13 +252,13 @@ int main(int argc, char** argv)
         g_debug("Generating output files..");
         g_hash_table_foreach(netdefs, nd_iterator, rootdir);
         write_nm_conf_finish(rootdir);
-	/* We may have written .rules & .link files, thus we must
-	 * invalidate udevd cache of its config as by default it only
-	 * invalidates cache at most every 3 seconds. Not sure if this
-	 * should live in `generate' or `apply', but it is confusing
-	 * when udevd ignores just-in-time created rules files.
-	 */
-	reload_udevd();
+        /* We may have written .rules & .link files, thus we must
+         * invalidate udevd cache of its config as by default it only
+         * invalidates cache at most every 3 seconds. Not sure if this
+         * should live in `generate' or `apply', but it is confusing
+         * when udevd ignores just-in-time created rules files.
+         */
+        reload_udevd();
     }
 
     /* Disable /usr/lib/NetworkManager/conf.d/10-globally-managed-devices.conf

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -357,14 +357,14 @@ write_network_file(net_definition* def, const char* rootdir, const char* path)
 
     if (def->optional || def->optional_addresses) {
         g_string_append(s, "\n[Link]\n");
-	if (def->optional) {
-	    g_string_append(s, "RequiredForOnline=no\n");
-	}
-	for (unsigned i = 0; optional_address_options[i].name != NULL; ++i) {
-	    if (def->optional_addresses & optional_address_options[i].flag) {
-		g_string_append_printf(s, "OptionalAddresses=%s\n", optional_address_options[i].name);
-	    }
-	}
+        if (def->optional) {
+            g_string_append(s, "RequiredForOnline=no\n");
+        }
+        for (unsigned i = 0; optional_address_options[i].name != NULL; ++i) {
+            if (def->optional_addresses & optional_address_options[i].flag) {
+            g_string_append_printf(s, "OptionalAddresses=%s\n", optional_address_options[i].name);
+            }
+        }
     }
 
     g_string_append(s, "\n[Network]\n");

--- a/src/nm.c
+++ b/src/nm.c
@@ -213,7 +213,7 @@ write_bond_parameters(const net_definition* def, GString *s)
     if (def->bond_params.gratuitous_arp) {
         g_string_append_printf(params, "\nnum_grat_arp=%d", def->bond_params.gratuitous_arp);
         /* Work around issue in NM where unset unsolicited_na will overwrite num_grat_arp:
-	 * https://github.com/NetworkManager/NetworkManager/commit/42b0bef33c77a0921590b2697f077e8ea7805166 */
+         * https://github.com/NetworkManager/NetworkManager/commit/42b0bef33c77a0921590b2697f077e8ea7805166 */
         g_string_append_printf(params, "\nnum_unsol_na=%d", def->bond_params.gratuitous_arp);
     }
     if (def->bond_params.packets_per_slave)

--- a/src/parse.c
+++ b/src/parse.c
@@ -592,11 +592,11 @@ handle_wifi_access_points(yaml_document_t* doc, yaml_node_t* node, const void* d
             ret = yaml_error(key, error, "%s: Duplicate access point SSID '%s'", cur_netdef->id, cur_access_point->ssid);
             cur_access_point = NULL;
             return ret;
-	}
+        }
 
         if (!process_mapping(doc, value, wifi_access_point_handlers, error)) {
-	    cur_access_point = NULL;
-	    return FALSE;
+            cur_access_point = NULL;
+            return FALSE;
         }
 
         cur_access_point = NULL;
@@ -758,18 +758,18 @@ handle_optional_addresses(yaml_document_t* doc, yaml_node_t* node, const void* _
     for (yaml_node_item_t *i = node->data.sequence.items.start; i < node->data.sequence.items.top; i++) {
         yaml_node_t *entry = yaml_document_get_node(doc, *i);
         assert_type(entry, YAML_SCALAR_NODE);
-	int found = FALSE;
+        int found = FALSE;
 
-	for (unsigned i = 0; optional_address_options[i].name != NULL; ++i) {
-	    if (g_ascii_strcasecmp(scalar(entry), optional_address_options[i].name) == 0) {
-		cur_netdef->optional_addresses |= optional_address_options[i].flag;
-		found = TRUE;
-		break;
-	    }
-	}
-	if (!found) {
+        for (unsigned i = 0; optional_address_options[i].name != NULL; ++i) {
+            if (g_ascii_strcasecmp(scalar(entry), optional_address_options[i].name) == 0) {
+                cur_netdef->optional_addresses |= optional_address_options[i].flag;
+                found = TRUE;
+                break;
+            }
+        }
+        if (!found) {
             return yaml_error(node, error, "invalid value for optional-addresses: %s", scalar(entry));
-	}
+        }
     }
     return TRUE;
 }
@@ -1338,8 +1338,8 @@ const mapping_entry_handler dhcp6_overrides_handlers[] = {
 
 /* Handlers for physical links */
 #define PHYSICAL_LINK_HANDLERS                                                           \
-    {"match", YAML_MAPPING_NODE, handle_match},						 \
-    {"set-name", YAML_SCALAR_NODE, handle_netdef_str, NULL, netdef_offset(set_name)},	 \
+    {"match", YAML_MAPPING_NODE, handle_match},                                          \
+    {"set-name", YAML_SCALAR_NODE, handle_netdef_str, NULL, netdef_offset(set_name)},    \
     {"wakeonlan", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(wake_on_lan)}
 
 const mapping_entry_handler ethernet_def_handlers[] = {

--- a/tests/validate_docs.sh
+++ b/tests/validate_docs.sh
@@ -18,27 +18,27 @@ for term in $(sed -n 's/[ ]\+{"\([a-z0-9-]\+\)", YAML_[A-Z]\+_NODE.*/\1/p' src/p
     # it can be documented in the following ways.
     # 1. "Properties for device type ``blah:``
     if egrep "## Properties for device type \`\`$term:\`\`" doc/netplan.md > /dev/null; then
-	continue
+        continue
     fi
 
     # 2. "[blah, ]``blah``[, ``blah2``]: (scalar|bool|...)
     if egrep "\`\`$term\`\`.*\((scalar|bool|mapping|sequence of scalars)\)" doc/netplan.md > /dev/null; then
-	continue
+        continue
     fi
 
     # 3. we give a pass to network and version
     if [[ $term = "network" ]] || [[ $term = "version" ]]; then
-	continue
+        continue
     fi
 
     # 4. search doesn't get a full description but it's good enough
     if [[ $term = "search" ]]; then
-	continue
+        continue
     fi
 
     # 5. gratuit_i_ous arp gets a special note
     if [[ $term = "gratuitious-arp" ]]; then
-	continue
+        continue
     fi
 
     echo ERROR: The key "$term" is defined in the parser but not documented.


### PR DESCRIPTION
## Description
In several places tabs were used for indentation instead of spaces, as is the
majority convention in this project.

Formatting only. No functionality changes.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [x] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Closes an open bug in Launchpad.

