### PR TITLE
Fix renaming where interfaces share MAC addresses

### DIFF
--- a/netplan/cli/commands/apply.py
+++ b/netplan/cli/commands/apply.py
@@ -163,11 +163,11 @@ class NetplanApply(utils.NetplanCommand):
         # /sys/class/net/ens3/device -> ../../../virtio0
         # /sys/class/net/ens3/device/driver -> ../../../../bus/virtio/drivers/virtio_net
         for interface in interfaces:
-            if interface not in phy:
+            if interface not in phys:
                 # do not rename  virtual devices
                 logging.debug('Skipping non-physical interface: %s', interface)
                 continue
-            if NetplanApply.is_composite_member(composite_interfaces, phy):
+            if NetplanApply.is_composite_member(composite_interfaces, interface):
                 logging.debug('Skipping composite member %s', interface)
                 # do not rename members of virtual devices. MAC addresses
                 # may be the same for all interface members.

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -1671,6 +1671,47 @@ class TestNetworkd(NetworkTestBase, _CommonTests):
         with open('/sys/class/net/mybond/bonding/arp_validate') as f:
             self.assertEqual(f.read().strip(), 'all 3')
 
+    def test_bond_mac_rename(self):
+        self.setup_eth(None)
+        self.start_dnsmasq(None, self.dev_e2_ap)
+        self.addCleanup(subprocess.call, ['ip', 'link', 'delete', 'mybond'], stderr=subprocess.DEVNULL)
+        with open(self.config, 'w') as f:
+            f.write('''network:
+  renderer: %(r)s
+  ethernets:
+    ethbn1:
+      match: {name: %(ec)s}
+      dhcp4: no
+    ethbn2:
+      match: {name: $(e2c)s}
+      dhcp4: no
+  bonds:
+    mybond:
+      interfaces: [ethbn1, ethbn2]
+      macaddress: 00:0a:f7:72:a7:28
+      mtu: 9000
+      addresses: [ 192.168.5.9/24 ]
+      gateway4: 192.168.5.1
+      parameters:
+        down-delay: 0
+        lacp-rate: fast
+        mii-monitor-interval: 100
+        mode: 802.3ad
+        transmit-hash-policy: layer3+4
+        up-delay: 0
+      ''' % {'r': self.backend, 'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
+        self.generate_and_settle()
+        self.assert_iface_up(self.dev_e_client,
+                             ['master mybond', '00:0a:f7:72:a7:28'],
+                             ['inet '])
+        self.assert_iface_up(self.dev_e2_client,
+                             ['master mybond', '00:0a:f7:72:a7:28'],
+                             ['inet '])
+        self.assert_iface_up('mybond',
+                             ['inet 192.168.5.[0-9]+/24'])
+        with open('/sys/class/net/mybond/bonding/slaves') as f:
+            self.assertIn(self.dev_e_client, f.read().strip())
+
     def test_bridge_anonymous(self):
         self.setup_eth(None)
         self.addCleanup(subprocess.call, ['ip', 'link', 'delete', 'mybr'], stderr=subprocess.DEVNULL)


### PR DESCRIPTION

## Description

Fix renaming where interfaces share MAC addresses.

https://bugs.launchpad.net/ubuntu/+source/netplan.io/+bug/1802322

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [n/a] New/changed keys in YAML format are documented.
- [x] \(Optional\) Closes an open bug in Launchpad.

