### PR TITLE
Generate output files in dependency order

### DIFF
--- a/src/generate.c
+++ b/src/generate.c
@@ -51,7 +51,7 @@ reload_udevd(void)
 };
 
 static void
-nd_iterator(gpointer key, gpointer value, gpointer user_data)
+nd_iterator_list(gpointer value, gpointer user_data)
 {
     if (write_networkd_conf((net_definition*) value, (const char*) user_data))
         any_networkd = TRUE;
@@ -250,7 +250,7 @@ int main(int argc, char** argv)
     /* Generate backend specific configuration files from merged data. */
     if (netdefs) {
         g_debug("Generating output files..");
-        g_hash_table_foreach(netdefs, nd_iterator, rootdir);
+        g_list_foreach (netdefs_ordered, nd_iterator_list, rootdir);
         write_nm_conf_finish(rootdir);
         /* We may have written .rules & .link files, thus we must
          * invalidate udevd cache of its config as by default it only

--- a/src/parse.c
+++ b/src/parse.c
@@ -48,6 +48,10 @@ netdef_backend backend_global, backend_cur_type;
 
 /* Global ID → net_definition* map for all parsed config files */
 GHashTable* netdefs;
+
+/* Contains the same objects as 'netdefs' but ordered by dependency */
+GList* netdefs_ordered;
+
 /* Set of IDs in currently parsed YAML file, for being able to detect
  * "duplicate ID within one file" vs. allowing a drop-in to override/amend an
  * existing definition */
@@ -1599,6 +1603,7 @@ handle_network_type(yaml_document_t* doc, yaml_node_t* node, const void* data, G
             /* systemd-networkd defaults to IPv6 LL enabled; keep that default */
             cur_netdef->linklocal.ipv6 = TRUE;
             g_hash_table_insert(netdefs, cur_netdef->id, cur_netdef);
+            netdefs_ordered = g_list_append(netdefs_ordered, cur_netdef);
 
             /* DHCP override defaults */
             initialize_dhcp_overrides(&cur_netdef->dhcp4_overrides);

--- a/src/parse.h
+++ b/src/parse.h
@@ -239,6 +239,7 @@ typedef struct {
 
 /* Written/updated by parse_yaml(): char* id →  net_definition */
 extern GHashTable* netdefs;
+extern GList* netdefs_ordered;
 
 /****************************************************
  * Functions


### PR DESCRIPTION
Hello,

I am currently working on a new backend for netplan. This backend will add support for ifupdown2 configuration file generation (https://github.com/CumulusNetworks/ifupdown2/tree/master-next). 

While working on this I faced several challenges. ifupdown2 like other network manager builds its configuration by creating a dependency graph of the desired configuration. 

The goal of this PR is to make sure that the backends are called with netdef according to their dependencies and not iterating through the main netdef hashtable in not specific order. 

After the check list bellow i've added more details and logs to make my case (this is also part of the commit introducing the change). 

I hope that this PR can be accepted before submitting my main PR adding the ifupdown2 backend. I intentionally didn't include this code in the ifupdown2-backend PR because other (future) backends can benefit from this change of behavior and this is not an ifupdown2 specific change.

Please review it and let me know if you have any questions. 

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).

## Commit detail

Today, to generate the various output files, netplan iterates through it's
netdef hash-table without considering any interfaces dependencies. This may
cause issues for some backend that are "dependency sensitive", like ifupdown2.

Considering the following example file from the netplan repository:

```
$ cat /etc/netplan/bonding_router.yaml
network:
  version: 2
  renderer: networkd
  ethernets:
    enp1s0:
      dhcp4: no
    enp2s0:
      dhcp4: no
    enp3s0:
      dhcp4: no
      optional: true
    enp4s0:
      dhcp4: no
      optional: true
    enp5s0:
      dhcp4: no
      optional: true
    enp6s0:
      dhcp4: no
      optional: true
  bonds:
    bond-lan:
      interfaces: [enp2s0, enp3s0]
      addresses: [192.168.93.2/24]
      parameters:
        mode: 802.3ad
        mii-monitor-interval: 1
    bond-wan:
      interfaces: [enp1s0, enp4s0]
      addresses: [192.168.1.252/24]
      gateway4: 192.168.1.1
      nameservers:
        search: [local]
        addresses: [8.8.8.8, 8.8.4.4]
      parameters:
        mode: active-backup
        mii-monitor-interval: 1
        gratuitious-arp: 5
    bond-conntrack:
      interfaces: [enp5s0, enp6s0]
      addresses: [192.168.254.2/24]
      parameters:
        mode: balance-rr
        mii-monitor-interval: 1
$
```

Please review the following netplan output, to make my point I took the liberty
to add a printf statement in the nd_iterator function (from generate.c). When
running "netplan generate" we can see that there isn't any specific ordering:

```
$ netplan generate
nd_iterator generate interface: enp4s0
nd_iterator generate interface: bond-wan
nd_iterator generate interface: enp5s0
nd_iterator generate interface: enp6s0
nd_iterator generate interface: enp1s0
nd_iterator generate interface: bond-lan
nd_iterator generate interface: enp2s0
nd_iterator generate interface: bond-conntrack
nd_iterator generate interface: enp3s0
$
```

Introducing ifupdown2 a network manager using the "ifupdown" syntax. It creates
a "stanza" for each interface. We store the final configuration in /etc/network/interfaces.
An example bond config looks like this:

```
auto bond42
iface bond42
	bond-slaves swp42 swp84
	bond-mode 802.3ad
	address 42.42.42.42/32
```

Unlike other network manager like networkd, you can see here that the bond
interface is dependent on it's slaves.
The current netplan implemention is great but we believe that some of it's
limitation (like the dependency ordering) should be addressed so more backend
could be added. Today when the ifupdown2 backend is called with the "netdef"
bond42, the bond doesn't have any knowledge of it's slaves. Thus making it
hard for the backend to generate the proper stanzas.

If the output file generation would be moved to a dependency-ordered
generation, ifupdown2 backend would store the master-slaves relationships
internally thus avoiding iterating through the whole hash-table for every
interfaces, and output the correct stanza for each interface.

In the following logs I used the same printf statement as before to output the
new behavior of "nd_iterator_list" to show that interfaces are generated in a
dependency order fashion:

```
$ netplan/generate
nd_iterator_list generate interface: enp1s0
nd_iterator_list generate interface: enp2s0
nd_iterator_list generate interface: enp3s0
nd_iterator_list generate interface: enp4s0
nd_iterator_list generate interface: enp5s0
nd_iterator_list generate interface: enp6s0
nd_iterator_list generate interface: bond-lan
nd_iterator_list generate interface: bond-wan
nd_iterator_list generate interface: bond-conntrack
$
```

Signed-off-by: Julien Fortin <julien@cumulusnetworks.com>