### PR TITLE
Add support to override networkd UseMTU setting

### DIFF
--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -347,6 +347,11 @@ that ``dhcp4-overrides`` and ``dhcp6-overrides`` contain the same keys and value
      :    Default: ``true``. When ``true``, the hostname received from the DHCP
           server will be set as the transient hostname of the system.
 
+     ``use-mtu`` (bool)
+     :    Default: ``true``. When ``true``, the MTU received from the DHCP
+          server will be set as the MTU of the network interface. When ``false``,
+          the MTU advertised by the DHCP server will be ignored.
+
      ``hostname`` (scalar)
      :    Use this value for the hostname which is sent to the DHCP server,
           instead of machine's hostname.
@@ -713,9 +718,9 @@ DHCP:
       ethernets:
         eno1:
           dhcp4: true
-          
+
 This is an example of a static-configured interface with multiple IPv4 addresses
-and multiple gateways with networkd, with equal route metric levels, and static 
+and multiple gateways with networkd, with equal route metric levels, and static
 DNS nameservers (Google DNS for this example):
 
     network:
@@ -736,7 +741,7 @@ DNS nameservers (Google DNS for this example):
             metric: 100
           - to: 0.0.0.0/0
             via: 11.0.0.1
-            metric: 100 
+            metric: 100
 
 This is a complex example which shows most available features:
 

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -329,6 +329,10 @@ combine_dhcp_overrides(net_definition* def, dhcp_overrides* combined_dhcp_overri
             g_fprintf(stderr, DHCP_OVERRIDES_ERROR, def->id, "use-hostname");
             exit(1);
         }
+        if (def->dhcp4_overrides.use_mtu != def->dhcp6_overrides.use_mtu) {
+            g_fprintf(stderr, DHCP_OVERRIDES_ERROR, def->id, "use-mtu");
+            exit(1);
+        }
         if (g_strcmp0(def->dhcp4_overrides.hostname, def->dhcp6_overrides.hostname) != 0) {
             g_fprintf(stderr, DHCP_OVERRIDES_ERROR, def->id, "hostname");
             exit(1);
@@ -462,11 +466,8 @@ write_network_file(net_definition* def, const char* rootdir, const char* path)
     }
 
     if (def->dhcp4 || def->dhcp6) {
-        /* isc-dhcp dhclient compatible UseMTU, networkd default is to
-         * not accept MTU, which breaks clouds */
-        g_string_append_printf(s, "\n[DHCP]\nUseMTU=true\n");
         /* NetworkManager compatible route metrics */
-        g_string_append_printf(s, "RouteMetric=%i\n", (def->type == ND_WIFI ? 600 : 100));
+        g_string_append_printf(s, "\n[DHCP]\nRouteMetric=%i\n", (def->type == ND_WIFI ? 600 : 100));
         if (g_strcmp0(def->dhcp_identifier, "duid") != 0)
             g_string_append_printf(s, "ClientIdentifier=%s\n", def->dhcp_identifier);
         if (def->critical)
@@ -474,6 +475,15 @@ write_network_file(net_definition* def, const char* rootdir, const char* path)
 
         dhcp_overrides combined_dhcp_overrides;
         combine_dhcp_overrides(def, &combined_dhcp_overrides);
+
+        /* Only set MTU from DHCP if use-mtu dhcp-override is not false. */
+        if (!combined_dhcp_overrides.use_mtu) {
+            /* isc-dhcp dhclient compatible UseMTU, networkd default is to
+             * not accept MTU, which breaks clouds */
+            g_string_append_printf(s, "UseMTU=false\n");
+        } else {
+            g_string_append_printf(s, "UseMTU=true\n");
+        }
 
         /* Only write DHCP options that differ from the networkd default. */
         if (!combined_dhcp_overrides.use_dns)

--- a/src/parse.c
+++ b/src/parse.c
@@ -1417,6 +1417,7 @@ const mapping_entry_handler nameservers_handlers[] = {
     {"use-ntp", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(overrides.use_ntp)},              \
     {"send-hostname", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(overrides.send_hostname)},  \
     {"use-hostname", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(overrides.use_hostname)},    \
+    {"use-mtu", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(overrides.use_mtu)},              \
     {"hostname", YAML_SCALAR_NODE, handle_netdef_str, NULL, netdef_offset(overrides.hostname)}
 
 const mapping_entry_handler dhcp4_overrides_handlers[] = {
@@ -1549,6 +1550,7 @@ initialize_dhcp_overrides(dhcp_overrides* overrides)
     overrides->use_ntp = TRUE;
     overrides->send_hostname = TRUE;
     overrides->use_hostname = TRUE;
+    overrides->use_mtu = TRUE;
     overrides->hostname = NULL;
 }
 

--- a/src/parse.h
+++ b/src/parse.h
@@ -81,6 +81,7 @@ typedef struct dhcp_overrides {
     gboolean use_ntp;
     gboolean send_hostname;
     gboolean use_hostname;
+    gboolean use_mtu;
     char* hostname;
 } dhcp_overrides;
 

--- a/tests/generator/base.py
+++ b/tests/generator/base.py
@@ -35,10 +35,13 @@ exe_generate = os.path.join(os.path.dirname(os.path.dirname(
 os.environ['G_DEBUG'] = 'fatal-criticals'
 
 # common patterns for expected output
-ND_DHCP4 = '[Match]\nName=%s\n\n[Network]\nDHCP=ipv4\nLinkLocalAddressing=ipv6\n\n[DHCP]\nUseMTU=true\nRouteMetric=100\n'
-ND_WIFI_DHCP4 = '[Match]\nName=%s\n\n[Network]\nDHCP=ipv4\nLinkLocalAddressing=ipv6\n\n[DHCP]\nUseMTU=true\nRouteMetric=600\n'
-ND_DHCP6 = '[Match]\nName=%s\n\n[Network]\nDHCP=ipv6\nLinkLocalAddressing=ipv6\n\n[DHCP]\nUseMTU=true\nRouteMetric=100\n'
-ND_DHCPYES = '[Match]\nName=%s\n\n[Network]\nDHCP=yes\nLinkLocalAddressing=ipv6\n\n[DHCP]\nUseMTU=true\nRouteMetric=100\n'
+ND_DHCP4 = '[Match]\nName=%s\n\n[Network]\nDHCP=ipv4\nLinkLocalAddressing=ipv6\n\n[DHCP]\nRouteMetric=100\nUseMTU=true\n'
+ND_DHCP4_NOMTU = '[Match]\nName=%s\n\n[Network]\nDHCP=ipv4\nLinkLocalAddressing=ipv6\n\n[DHCP]\nRouteMetric=100\nUseMTU=false\n'
+ND_WIFI_DHCP4 = '[Match]\nName=%s\n\n[Network]\nDHCP=ipv4\nLinkLocalAddressing=ipv6\n\n[DHCP]\nRouteMetric=600\nUseMTU=true\n'
+ND_DHCP6 = '[Match]\nName=%s\n\n[Network]\nDHCP=ipv6\nLinkLocalAddressing=ipv6\n\n[DHCP]\nRouteMetric=100\nUseMTU=true\n'
+ND_DHCP6_NOMTU = '[Match]\nName=%s\n\n[Network]\nDHCP=ipv6\nLinkLocalAddressing=ipv6\n\n[DHCP]\nRouteMetric=100\nUseMTU=false\n'
+ND_DHCPYES = '[Match]\nName=%s\n\n[Network]\nDHCP=yes\nLinkLocalAddressing=ipv6\n\n[DHCP]\nRouteMetric=100\nUseMTU=true\n'
+ND_DHCPYES_NOMTU = '[Match]\nName=%s\n\n[Network]\nDHCP=yes\nLinkLocalAddressing=ipv6\n\n[DHCP]\nRouteMetric=100\nUseMTU=false\n'
 UDEV_MAC_RULE = 'SUBSYSTEM=="net", ACTION=="add", DRIVERS=="%s", ATTR{address}=="%s", NAME="%s"\n'
 UDEV_NO_MAC_RULE = 'SUBSYSTEM=="net", ACTION=="add", DRIVERS=="%s", NAME="%s"\n'
 

--- a/tests/generator/test_bonds.py
+++ b/tests/generator/test_bonds.py
@@ -46,8 +46,8 @@ IPv6AcceptRA=yes
 ConfigureWithoutCarrier=yes
 
 [DHCP]
-UseMTU=true
 RouteMetric=100
+UseMTU=true
 ''',
                               'bond0.netdev': '''[NetDev]
 Name=bond0
@@ -79,8 +79,8 @@ LinkLocalAddressing=ipv6
 ConfigureWithoutCarrier=yes
 
 [DHCP]
-UseMTU=true
 RouteMetric=100
+UseMTU=true
 '''})
         self.assert_nm(None, '''[keyfile]
 # devices managed by networkd
@@ -110,8 +110,8 @@ LinkLocalAddressing=ipv6
 ConfigureWithoutCarrier=yes
 
 [DHCP]
-UseMTU=true
 RouteMetric=100
+UseMTU=true
 ''',
                               'eno1.network': '[Match]\nName=eno1\n\n'
                                               '[Network]\nLinkLocalAddressing=no\nBond=bn0\n',
@@ -142,8 +142,8 @@ LinkLocalAddressing=ipv6
 ConfigureWithoutCarrier=yes
 
 [DHCP]
-UseMTU=true
 RouteMetric=100
+UseMTU=true
 ''',
                               'eno1.network': '[Match]\nName=eno1\n\n'
                                               '[Network]\nLinkLocalAddressing=no\nBond=bn0\n',
@@ -215,8 +215,8 @@ LinkLocalAddressing=ipv6
 ConfigureWithoutCarrier=yes
 
 [DHCP]
-UseMTU=true
 RouteMetric=100
+UseMTU=true
 ''',
                               'eno1.network': '[Match]\nName=eno1\n\n'
                                               '[Network]\nLinkLocalAddressing=no\nBond=bn0\n',
@@ -258,8 +258,8 @@ LinkLocalAddressing=ipv6
 ConfigureWithoutCarrier=yes
 
 [DHCP]
-UseMTU=true
 RouteMetric=100
+UseMTU=true
 ''',
                               'eno1.network': '[Match]\nName=eno1\n\n'
                                               '[Network]\nLinkLocalAddressing=no\nBond=bn0\n',
@@ -294,8 +294,8 @@ LinkLocalAddressing=ipv6
 ConfigureWithoutCarrier=yes
 
 [DHCP]
-UseMTU=true
 RouteMetric=100
+UseMTU=true
 ''',
                               'eno1.network': '[Match]\nName=eno1\n\n'
                                               '[Network]\nLinkLocalAddressing=no\nBond=bn0\nPrimarySlave=true\n',
@@ -332,8 +332,8 @@ LinkLocalAddressing=ipv6
 ConfigureWithoutCarrier=yes
 
 [DHCP]
-UseMTU=true
 RouteMetric=100
+UseMTU=true
 ''',
                               'eno1.network': '[Match]\nName=eno1\n\n'
                                               '[Network]\nLinkLocalAddressing=no\nBond=bn0\n',

--- a/tests/generator/test_bridges.py
+++ b/tests/generator/test_bridges.py
@@ -41,8 +41,8 @@ LinkLocalAddressing=ipv6
 ConfigureWithoutCarrier=yes
 
 [DHCP]
-UseMTU=true
 RouteMetric=100
+UseMTU=true
 ''',
                               'br0.netdev': '[NetDev]\nName=br0\nMACAddress=00:01:02:03:04:05\nKind=bridge\n'})
 
@@ -69,8 +69,8 @@ IPv6AcceptRA=no
 ConfigureWithoutCarrier=yes
 
 [DHCP]
-UseMTU=true
 RouteMetric=100
+UseMTU=true
 ''',
                               'br0.netdev': '''[NetDev]
 Name=br0
@@ -102,8 +102,8 @@ LinkLocalAddressing=ipv6
 ConfigureWithoutCarrier=yes
 
 [DHCP]
-UseMTU=true
 RouteMetric=100
+UseMTU=true
 '''})
         self.assert_nm(None, '''[keyfile]
 # devices managed by networkd
@@ -129,8 +129,8 @@ LinkLocalAddressing=ipv6
 ConfigureWithoutCarrier=yes
 
 [DHCP]
-UseMTU=true
 RouteMetric=100
+UseMTU=true
 '''})
         self.assert_nm(None, '''[keyfile]
 # devices managed by networkd
@@ -159,8 +159,8 @@ Address=1.2.3.4/12
 ConfigureWithoutCarrier=yes
 
 [DHCP]
-UseMTU=true
 RouteMetric=100
+UseMTU=true
 '''})
         self.assert_nm(None, '''[keyfile]
 # devices managed by networkd
@@ -191,8 +191,8 @@ LinkLocalAddressing=ipv6
 ConfigureWithoutCarrier=yes
 
 [DHCP]
-UseMTU=true
 RouteMetric=100
+UseMTU=true
 ''',
                               'eno1.network': '[Match]\nName=eno1\n\n'
                                               '[Network]\nLinkLocalAddressing=no\nBridge=br0\n',
@@ -238,8 +238,8 @@ LinkLocalAddressing=ipv6
 ConfigureWithoutCarrier=yes
 
 [DHCP]
-UseMTU=true
 RouteMetric=100
+UseMTU=true
 ''',
                               'eno1.network': '[Match]\nName=eno1\n\n'
                                               '[Network]\nLinkLocalAddressing=no\nBridge=br0\n',
@@ -286,8 +286,8 @@ LinkLocalAddressing=ipv6
 ConfigureWithoutCarrier=yes
 
 [DHCP]
-UseMTU=true
 RouteMetric=100
+UseMTU=true
 ''',
                               'eno1.network': '[Match]\nName=eno1\n\n'
                                               '[Network]\nLinkLocalAddressing=no\nBridge=br0\n\n'

--- a/tests/generator/test_common.py
+++ b/tests/generator/test_common.py
@@ -44,8 +44,8 @@ DHCP=ipv6
 LinkLocalAddressing=ipv6
 
 [DHCP]
-UseMTU=true
 RouteMetric=100
+UseMTU=true
 '''})
         self.assert_networkd_udev(None)
 
@@ -187,8 +187,8 @@ LinkLocalAddressing=ipv6
 IPv6AcceptRA=no
 
 [DHCP]
-UseMTU=true
 RouteMetric=100
+UseMTU=true
 '''})
 
     def test_eth_dhcp6_accept_ra(self):
@@ -207,8 +207,8 @@ LinkLocalAddressing=ipv6
 IPv6AcceptRA=yes
 
 [DHCP]
-UseMTU=true
 RouteMetric=100
+UseMTU=true
 '''})
 
     def test_eth_dhcp6_accept_ra_unset(self):
@@ -225,8 +225,8 @@ DHCP=ipv6
 LinkLocalAddressing=ipv6
 
 [DHCP]
-UseMTU=true
 RouteMetric=100
+UseMTU=true
 '''})
 
     def test_eth_dhcp4_and_6(self):
@@ -274,8 +274,8 @@ Address=192.168.14.2/24
 Address=2001:FFfe::1/64
 
 [DHCP]
-UseMTU=true
 RouteMetric=100
+UseMTU=true
 '''})
 
     def test_dhcp_critical_true(self):
@@ -295,9 +295,9 @@ DHCP=ipv4
 LinkLocalAddressing=ipv6
 
 [DHCP]
-UseMTU=true
 RouteMetric=100
 CriticalConnection=true
+UseMTU=true
 '''})
 
     def test_dhcp_identifier_mac(self):
@@ -317,9 +317,9 @@ DHCP=ipv4
 LinkLocalAddressing=ipv6
 
 [DHCP]
-UseMTU=true
 RouteMetric=100
 ClientIdentifier=mac
+UseMTU=true
 '''})
 
     def test_dhcp_identifier_duid(self):
@@ -340,8 +340,8 @@ DHCP=ipv4
 LinkLocalAddressing=ipv6
 
 [DHCP]
-UseMTU=true
 RouteMetric=100
+UseMTU=true
 '''})
 
     def test_eth_ipv6_privacy(self):
@@ -360,8 +360,8 @@ LinkLocalAddressing=ipv6
 IPv6PrivacyExtensions=yes
 
 [DHCP]
-UseMTU=true
 RouteMetric=100
+UseMTU=true
 '''})
 
     def test_gateway(self):
@@ -435,8 +435,8 @@ DHCP=yes
 LinkLocalAddressing=yes
 
 [DHCP]
-UseMTU=true
 RouteMetric=100
+UseMTU=true
 '''})
 
     def test_link_local_ipv4(self):
@@ -457,8 +457,8 @@ DHCP=yes
 LinkLocalAddressing=ipv4
 
 [DHCP]
-UseMTU=true
 RouteMetric=100
+UseMTU=true
 '''})
 
     def test_link_local_ipv6(self):
@@ -479,8 +479,8 @@ DHCP=yes
 LinkLocalAddressing=ipv6
 
 [DHCP]
-UseMTU=true
 RouteMetric=100
+UseMTU=true
 '''})
 
     def test_link_local_disabled(self):
@@ -501,8 +501,8 @@ DHCP=yes
 LinkLocalAddressing=no
 
 [DHCP]
-UseMTU=true
 RouteMetric=100
+UseMTU=true
 '''})
 
 
@@ -900,8 +900,8 @@ LinkLocalAddressing=ipv6
 ConfigureWithoutCarrier=yes
 
 [DHCP]
-UseMTU=true
 RouteMetric=100
+UseMTU=true
 ''',
                               'bond0.netdev': '[NetDev]\nName=bond0\nKind=bond\n',
                               'bond0.network': '''[Match]
@@ -968,8 +968,8 @@ LinkLocalAddressing=ipv6
 ConfigureWithoutCarrier=yes
 
 [DHCP]
-UseMTU=true
 RouteMetric=100
+UseMTU=true
 ''',
                               'br0.netdev': '[NetDev]\nName=br0\nKind=bridge\n\n'
                                             '[Bridge]\nSTP=true\n',
@@ -1117,8 +1117,8 @@ LinkLocalAddressing=ipv6
 ConfigureWithoutCarrier=yes
 
 [DHCP]
-UseMTU=true
 RouteMetric=100
+UseMTU=true
 ''',
                               'eno1.network': '[Match]\nName=eno1\n\n'
                                               '[Network]\nLinkLocalAddressing=no\nBridge=br0\n',

--- a/tests/generator/test_ethernets.py
+++ b/tests/generator/test_ethernets.py
@@ -110,8 +110,8 @@ DHCP=ipv4
 LinkLocalAddressing=ipv6
 
 [DHCP]
-UseMTU=true
 RouteMetric=100
+UseMTU=true
 '''})
         self.assert_networkd_udev(None)
         self.assert_nm_udev('ACTION=="add|change", SUBSYSTEM=="net", ENV{ID_NET_DRIVER}=="ixgbe", ENV{NM_UNMANAGED}="1"\n')
@@ -192,7 +192,7 @@ unmanaged-devices+=interface-name:*,''')
       dhcp4: true''')
 
         self.assert_networkd({'def1.network': '[Match]\n\n[Network]\nDHCP=ipv4\nLinkLocalAddressing=ipv6\n\n'
-                                              '[DHCP]\nUseMTU=true\nRouteMetric=100\n'})
+                                              '[DHCP]\nRouteMetric=100\nUseMTU=true\n'})
         self.assert_networkd_udev(None)
         self.assert_nm(None, '''[keyfile]
 # devices managed by networkd
@@ -217,8 +217,8 @@ DHCP=ipv4
 LinkLocalAddressing=ipv6
 
 [DHCP]
-UseMTU=true
 RouteMetric=100
+UseMTU=true
 '''})
         self.assert_nm(None, '''[keyfile]
 # devices managed by networkd

--- a/tests/generator/test_vlans.py
+++ b/tests/generator/test_vlans.py
@@ -96,8 +96,8 @@ LinkLocalAddressing=ipv6
 ConfigureWithoutCarrier=yes
 
 [DHCP]
-UseMTU=true
 RouteMetric=100
+UseMTU=true
 '''})
         self.assert_nm(None, '''[keyfile]
 # devices managed by networkd

--- a/tests/generator/test_wifis.py
+++ b/tests/generator/test_wifis.py
@@ -92,8 +92,8 @@ Destination=10.10.10.0/24
 Gateway=8.8.8.8
 
 [DHCP]
-UseMTU=true
 RouteMetric=600
+UseMTU=true
 '''})
 
         self.assert_nm(None, '''[keyfile]


### PR DESCRIPTION
Currently, there is no way to override networkd's
UseMTU flag via Netplan. This is useful to have
as a dhcp-override option similar to the other
dhcp-override options.
If the 'use-mtu' key is set to false in the netplan
config file, then set 'UseMTU' as false in networkd's
config.

Signed-off-by: Shashank Ram <shashank08@gmail.com>


## Description


## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [x] New/changed keys in YAML format are documented.
- [x] \(Optional\) Closes an open bug in Launchpad.

