### PR TITLE
networkd: Workaround matching interaction bug with networkd

### DIFF
--- a/tests/generator/test_common.py
+++ b/tests/generator/test_common.py
@@ -912,14 +912,40 @@ LinkLocalAddressing=no
 ConfigureWithoutCarrier=yes
 Bridge=br0
 ''',
-                              'eth0.link': '[Match]\nMACAddress=00:01:02:03:04:05\n\n'
-                                           '[Link]\nName=eth0\nWakeOnLan=off\n',
-                              'eth0.network': '[Match]\nMACAddress=00:01:02:03:04:05\nName=eth0\n\n'
-                                              '[Network]\nLinkLocalAddressing=no\nBond=bond0\n',
-                              'eth1.link': '[Match]\nMACAddress=02:01:02:03:04:05\n\n'
-                                           '[Link]\nName=eth1\nWakeOnLan=off\n',
-                              'eth1.network': '[Match]\nMACAddress=02:01:02:03:04:05\nName=eth1\n\n'
-                                              '[Network]\nLinkLocalAddressing=no\nBond=bond0\n'})
+                              'eth0.link': '''[Match]
+MACAddress=00:01:02:03:04:05
+Type=!vlan bond bridge
+
+[Link]
+Name=eth0
+WakeOnLan=off
+''',
+                              'eth0.network': '''[Match]
+MACAddress=00:01:02:03:04:05
+Name=eth0
+Type=!vlan bond bridge
+
+[Network]
+LinkLocalAddressing=no
+Bond=bond0
+''',
+                              'eth1.link': '''[Match]
+MACAddress=02:01:02:03:04:05
+Type=!vlan bond bridge
+
+[Link]
+Name=eth1
+WakeOnLan=off
+''',
+                              'eth1.network': '''[Match]
+MACAddress=02:01:02:03:04:05
+Name=eth1
+Type=!vlan bond bridge
+
+[Network]
+LinkLocalAddressing=no
+Bond=bond0
+'''})
 
     def test_fwdecl_feature_blend(self):
         self.generate('''network:
@@ -1005,14 +1031,40 @@ LinkLocalAddressing=no
 ConfigureWithoutCarrier=yes
 Bond=bond0
 ''',
-                              'eth0.link': '[Match]\nMACAddress=00:01:02:03:04:05\n\n'
-                                           '[Link]\nName=eth0\nWakeOnLan=off\n',
-                              'eth0.network': '[Match]\nMACAddress=00:01:02:03:04:05\nName=eth0\n\n'
-                                              '[Network]\nLinkLocalAddressing=no\nBond=bond0\n',
-                              'eth1.link': '[Match]\nMACAddress=02:01:02:03:04:05\n\n'
-                                           '[Link]\nName=eth1\nWakeOnLan=off\n',
-                              'eth1.network': '[Match]\nMACAddress=02:01:02:03:04:05\nName=eth1\n\n'
-                                              '[Network]\nLinkLocalAddressing=no\nBridge=br1\n'})
+                              'eth0.link': '''[Match]
+MACAddress=00:01:02:03:04:05
+Type=!vlan bond bridge
+
+[Link]
+Name=eth0
+WakeOnLan=off
+''',
+                              'eth0.network': '''[Match]
+MACAddress=00:01:02:03:04:05
+Name=eth0
+Type=!vlan bond bridge
+
+[Network]
+LinkLocalAddressing=no
+Bond=bond0
+''',
+                              'eth1.link': '''[Match]
+MACAddress=02:01:02:03:04:05
+Type=!vlan bond bridge
+
+[Link]
+Name=eth1
+WakeOnLan=off
+''',
+                              'eth1.network': '''[Match]
+MACAddress=02:01:02:03:04:05
+Name=eth1
+Type=!vlan bond bridge
+
+[Network]
+LinkLocalAddressing=no
+Bridge=br1
+'''})
 
 
 class TestMerging(TestBase):


### PR DESCRIPTION
## Description

Some installation services generate netplan configuration that is a little
verbose, including default values for fields that are really optional.

These would potentially be fine, if misguided, if networkd was to do a better
job at matching -- however, it can't really do so, since it's also not given
additional matching criteria.

We're not given that matching criteria either, but while things get sorted
out in the various installation services, attempt to workaround this
scenario by defining the match for this particular case (bonds using the
MAC address of a member phy, defined as such in the config) to try
and catch only the ethernet devices. As those don't have DEVTYPE, do
some further fuzzy matching by excluding vlans, bridges and bonds.

To be clear: IT IS NOT RECOMMENDED to rely on this behavior. If you want
to match on something, make sure to be clear as to what the matching
criteria are; and if a field is optional, do not specify it unless you
REALLY know what you're doing.

Bug-Ubuntu: https://bugs.launchpad.net/netplan/+bug/1804861

Signed-off-by: Mathieu Trudel-Lapierre <mathieu.trudel-lapierre@canonical.com>

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [n/a] New/changed keys in YAML format are documented.
- [x] \(Optional\) Closes an open bug in Launchpad.

