### PR TITLE
integration: create a test runner so our integration tests can be reused

### DIFF
--- a/debian/tests/control
+++ b/debian/tests/control
@@ -1,4 +1,4 @@
-Tests: ethernets.py
+Test-Command: python3 tests/integration/run.py --test=ethernets
 Tests-Directory: tests/integration
 Depends: @,
   systemd,
@@ -6,8 +6,9 @@ Depends: @,
   hostapd,
   dnsmasq-base,
 Restrictions: allow-stderr, needs-root, isolation-machine
+Features: test-name=ethernets
 
-Tests: bridges.py
+Test-Command: python3 tests/integration/run.py --test=bridges
 Tests-Directory: tests/integration
 Depends: @,
   systemd,
@@ -15,8 +16,9 @@ Depends: @,
   hostapd,
   dnsmasq-base,
 Restrictions: allow-stderr, needs-root, isolation-machine
+Features: test-name=bridges
 
-Tests: bonds.py
+Test-Command: python3 tests/integration/run.py --test=bonds
 Tests-Directory: tests/integration
 Depends: @,
   systemd,
@@ -24,8 +26,9 @@ Depends: @,
   hostapd,
   dnsmasq-base,
 Restrictions: allow-stderr, needs-root, isolation-machine
+Features: test-name=bonds
 
-Tests: routing.py
+Test-Command: python3 tests/integration/run.py --test=routing
 Tests-Directory: tests/integration
 Depends: @,
   systemd,
@@ -33,8 +36,9 @@ Depends: @,
   hostapd,
   dnsmasq-base,
 Restrictions: allow-stderr, needs-root, isolation-machine
+Features: test-name=routing
 
-Tests: vlans.py
+Test-Command: python3 tests/integration/run.py --test=vlans
 Tests-Directory: tests/integration
 Depends: @,
   systemd,
@@ -42,8 +46,9 @@ Depends: @,
   hostapd,
   dnsmasq-base,
 Restrictions: allow-stderr, needs-root, isolation-machine
+Features: test-name=vlans
 
-Tests: wifi.py
+Test-Command: python3 tests/integration/run.py --test=wifi
 Tests-Directory: tests/integration
 Depends: @,
   systemd,
@@ -51,8 +56,9 @@ Depends: @,
   hostapd,
   dnsmasq-base,
 Restrictions: allow-stderr, needs-root, isolation-machine
+Features: test-name=wifi
 
-Tests: tunnels.py
+Test-Command: python3 tests/integration/run.py --test=tunnels
 Tests-Directory: tests/integration
 Depends: @,
   systemd,
@@ -60,8 +66,9 @@ Depends: @,
   hostapd,
   dnsmasq-base,
 Restrictions: allow-stderr, needs-root, isolation-machine
+Features: test-name=tunnels
 
-Tests: scenarios.py
+Test-Command: python3 tests/integration/run.py --test=scenarios
 Tests-Directory: tests/integration
 Depends: @,
   systemd,
@@ -69,8 +76,9 @@ Depends: @,
   hostapd,
   dnsmasq-base,
 Restrictions: allow-stderr, needs-root, isolation-machine
+Features: test-name=scenarios
 
-Tests: regressions.py
+Test-Command: python3 tests/integration/run.py --test=regressions
 Tests-Directory: tests/integration
 Depends: @,
   systemd,
@@ -78,6 +86,7 @@ Depends: @,
   hostapd,
   dnsmasq-base,
 Restrictions: allow-stderr, needs-root, isolation-machine
+Features: test-name=regressions
 
 Tests: autostart
 Restrictions: allow-stderr, needs-root, isolation-container

--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -29,6 +29,8 @@ import tempfile
 import unittest
 import shutil
 
+test_backends = "networkd NetworkManager" if "NETPLAN_TEST_BACKENDS" not in os.environ else os.environ["NETPLAN_TEST_BACKENDS"]
+
 for program in ['wpa_supplicant', 'hostapd', 'dnsmasq']:
     if subprocess.call(['which', program], stdout=subprocess.PIPE) != 0:
         sys.stderr.write('%s is required for this test suite, but not available. Skipping\n' % program)

--- a/tests/integration/bonds.py
+++ b/tests/integration/bonds.py
@@ -24,7 +24,7 @@ import sys
 import subprocess
 import unittest
 
-from base import IntegrationTestsBase
+from base import IntegrationTestsBase, test_backends
 
 
 class _CommonTests():
@@ -338,6 +338,8 @@ class _CommonTests():
             self.assertEqual(f.read().strip(), '100')
 
 
+@unittest.skipIf("networkd" not in test_backends,
+                     "skipping as networkd backend tests are disabled")
 class TestNetworkd(IntegrationTestsBase, _CommonTests):
     backend = 'networkd'
 
@@ -548,6 +550,8 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
             self.assertEqual(f.read().strip(), 'all 3')
 
 
+@unittest.skipIf("NetworkManager" not in test_backends,
+                     "skipping as NetworkManager backend tests are disabled")
 class TestNetworkManager(IntegrationTestsBase, _CommonTests):
     backend = 'NetworkManager'
 

--- a/tests/integration/bridges.py
+++ b/tests/integration/bridges.py
@@ -25,7 +25,7 @@ import subprocess
 import time
 import unittest
 
-from base import IntegrationTestsBase
+from base import IntegrationTestsBase, test_backends
 
 
 class _CommonTests():
@@ -267,6 +267,8 @@ class _CommonTests():
             self.assertEqual(f.read().strip(), '0')
 
 
+@unittest.skipIf("networkd" not in test_backends,
+                     "skipping as networkd backend tests are disabled")
 class TestNetworkd(IntegrationTestsBase, _CommonTests):
     backend = 'networkd'
 
@@ -379,6 +381,8 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
             self.assertEqual(f.read().strip(), '42')
 
 
+@unittest.skipIf("NetworkManager" not in test_backends,
+                     "skipping as NetworkManager backend tests are disabled")
 class TestNetworkManager(IntegrationTestsBase, _CommonTests):
     backend = 'NetworkManager'
 

--- a/tests/integration/ethernets.py
+++ b/tests/integration/ethernets.py
@@ -25,7 +25,7 @@ import sys
 import subprocess
 import unittest
 
-from base import IntegrationTestsBase, nm_uses_dnsmasq, resolved_in_use
+from base import IntegrationTestsBase, nm_uses_dnsmasq, resolved_in_use, test_backends
 
 
 class _CommonTests():
@@ -189,6 +189,8 @@ class _CommonTests():
         self.assert_iface_up(self.dev_e_client, ['inet6 2600:'], ['inet 192.168'])
 
 
+@unittest.skipIf("networkd" not in test_backends,
+                     "skipping as networkd backend tests are disabled")
 class TestNetworkd(IntegrationTestsBase, _CommonTests):
     backend = 'networkd'
 
@@ -223,6 +225,8 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
         self.assert_iface_up(self.dev_e_client, [], ['inet6 2600:'])
 
 
+@unittest.skipIf("NetworkManager" not in test_backends,
+                     "skipping as NetworkManager backend tests are disabled")
 class TestNetworkManager(IntegrationTestsBase, _CommonTests):
     backend = 'NetworkManager'
 

--- a/tests/integration/regressions.py
+++ b/tests/integration/regressions.py
@@ -24,7 +24,7 @@ import sys
 import subprocess
 import unittest
 
-from base import IntegrationTestsBase
+from base import IntegrationTestsBase, test_backends
 
 
 class _CommonTests():
@@ -35,6 +35,8 @@ class _CommonTests():
         self.generate_and_settle()
 
 
+@unittest.skipIf("networkd" not in test_backends,
+                     "skipping as networkd backend tests are disabled")
 class TestNetworkd(IntegrationTestsBase, _CommonTests):
     backend = 'networkd'
 
@@ -80,6 +82,8 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
             self.assertIn(self.dev_e_client, f.read().strip())
 
 
+@unittest.skipIf("NetworkManager" not in test_backends,
+                     "skipping as NetworkManager backend tests are disabled")
 class TestNetworkManager(IntegrationTestsBase, _CommonTests):
     backend = 'NetworkManager'
 

--- a/tests/integration/routing.py
+++ b/tests/integration/routing.py
@@ -24,7 +24,7 @@ import sys
 import subprocess
 import unittest
 
-from base import IntegrationTestsBase
+from base import IntegrationTestsBase, test_backends
 
 
 class _CommonTests():
@@ -103,6 +103,8 @@ class _CommonTests():
 
 
 
+@unittest.skipIf("networkd" not in test_backends,
+                     "skipping as networkd backend tests are disabled")
 class TestNetworkd(IntegrationTestsBase, _CommonTests):
     backend = 'networkd'
 
@@ -203,6 +205,8 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
                       subprocess.check_output(['ip', 'route', 'show', 'table', '99']))
 
 
+@unittest.skipIf("NetworkManager" not in test_backends,
+                     "skipping as NetworkManager backend tests are disabled")
 class TestNetworkManager(IntegrationTestsBase, _CommonTests):
     backend = 'NetworkManager'
 

--- a/tests/integration/run.py
+++ b/tests/integration/run.py
@@ -1,0 +1,79 @@
+#!/usr/bin/python3
+#
+# Test runner for netplan integration tests.
+#
+# These need to be run in a VM and do change the system
+# configuration.
+#
+# Copyright (C) 2018 Canonical, Ltd.
+# Author: Mathieu Trudel-Lapierre <mathieu.trudel-lapierre@canonical.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import argparse
+import glob
+import os
+import subprocess
+import textwrap
+
+tests_dir = os.path.dirname(os.path.abspath(__file__))
+
+default_backends = [ 'networkd', 'NetworkManager' ]
+fixtures = [ "__init__.py", "base.py", "run.py" ]
+
+possible_tests = []
+testfiles = glob.glob(os.path.join(tests_dir, "*.py"))
+for pyfile in testfiles:
+    filename = os.path.basename(pyfile)
+    if filename not in fixtures:
+        possible_tests.append(filename.split('.')[0])
+
+def dedupe(duped_list):
+    deduped = set()
+    for item in duped_list:
+        real_items = item.split(",")
+        for real_item in real_items:
+            deduped.add(real_item)
+    return deduped
+
+# XXX: omg, this is ugly :)
+parser = argparse.ArgumentParser(formatter_class=argparse.RawDescriptionHelpFormatter,
+                                 description=textwrap.dedent("""
+Test runner for netplan integration tests
+
+Available tests:
+{}
+""".format("\n".join("    - {}".format(x) for x in sorted(possible_tests)))))
+
+parser.add_argument('--test', action='append', help="List of tests to be run")
+parser.add_argument('--backend', action='append', help="List of backends to test (NetworkManager, networkd)")
+
+args = parser.parse_args()
+
+requested_tests = set()
+backends = set()
+
+if args.test is not None:
+    requested_tests = dedupe(args.test)
+else:
+    requested_tests.update(possible_tests)
+
+if args.backend is not None:
+    backends = dedupe(args.backend)
+else:
+    backends.update(default_backends)
+
+os.environ["NETPLAN_TEST_BACKENDS"] = ",".join(backends)
+
+for test in requested_tests:
+    subprocess.call(['python3', os.path.join(tests_dir, "{}.py".format(test))])

--- a/tests/integration/scenarios.py
+++ b/tests/integration/scenarios.py
@@ -25,7 +25,7 @@ import sys
 import subprocess
 import unittest
 
-from base import IntegrationTestsBase
+from base import IntegrationTestsBase, test_backends
 
 
 class _CommonTests():
@@ -117,10 +117,14 @@ class _CommonTests():
                              ['master br0'])
 
 
+@unittest.skipIf("networkd" not in test_backends,
+                     "skipping as networkd backend tests are disabled")
 class TestNetworkd(IntegrationTestsBase, _CommonTests):
     backend = 'networkd'
 
 
+@unittest.skipIf("NetworkManager" not in test_backends,
+                     "skipping as NetworkManager backend tests are disabled")
 class TestNetworkManager(IntegrationTestsBase, _CommonTests):
     backend = 'NetworkManager'
 

--- a/tests/integration/tunnels.py
+++ b/tests/integration/tunnels.py
@@ -24,8 +24,7 @@ import sys
 import subprocess
 import unittest
 
-from base import IntegrationTestsBase
-
+from base import IntegrationTestsBase, test_backends
 
 class _CommonTests():
 
@@ -72,6 +71,8 @@ class _CommonTests():
         self.assert_iface('tun0', ['tun0@NONE', 'link.* 192.168.5.1 peer 99.99.99.99'])
 
 
+@unittest.skipIf("networkd" not in test_backends,
+                     "skipping as networkd backend tests are disabled")
 class TestNetworkd(IntegrationTestsBase, _CommonTests):
     backend = 'networkd'
 
@@ -162,6 +163,8 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
         self.assert_iface('tun0', ['tun0@NONE', 'link.* fe80::1 brd 2001:dead:beef::2'])
 
 
+@unittest.skipIf("NetworkManager" not in test_backends,
+                     "skipping as NetworkManager backend tests are disabled")
 class TestNetworkManager(IntegrationTestsBase, _CommonTests):
     backend = 'NetworkManager'
 

--- a/tests/integration/vlans.py
+++ b/tests/integration/vlans.py
@@ -24,7 +24,7 @@ import sys
 import subprocess
 import unittest
 
-from base import IntegrationTestsBase
+from base import IntegrationTestsBase, test_backends
 
 
 class _CommonTests():
@@ -88,10 +88,14 @@ class _CommonTests():
             self.assertEqual(f.read().strip(), 'aa:bb:cc:dd:ee:22')
 
 
+@unittest.skipIf("networkd" not in test_backends,
+                     "skipping as networkd backend tests are disabled")
 class TestNetworkd(IntegrationTestsBase, _CommonTests):
     backend = 'networkd'
 
 
+@unittest.skipIf("NetworkManager" not in test_backends,
+                     "skipping as NetworkManager backend tests are disabled")
 class TestNetworkManager(IntegrationTestsBase, _CommonTests):
     backend = 'NetworkManager'
 

--- a/tests/integration/wifi.py
+++ b/tests/integration/wifi.py
@@ -24,7 +24,7 @@ import sys
 import subprocess
 import unittest
 
-from base import IntegrationTestsBase
+from base import IntegrationTestsBase, test_backends
 
 
 class _CommonTests():
@@ -123,10 +123,14 @@ wpa_passphrase=12345678
             self.assertRegex(out, 'DNS.*192.168.5.1')
 
 
+@unittest.skipIf("networkd" not in test_backends,
+                     "skipping as networkd backend tests are disabled")
 class TestNetworkd(IntegrationTestsBase, _CommonTests):
     backend = 'networkd'
 
 
+@unittest.skipIf("NetworkManager" not in test_backends,
+                     "skipping as NetworkManager backend tests are disabled")
 class TestNetworkManager(IntegrationTestsBase, _CommonTests):
     backend = 'NetworkManager'
 


### PR DESCRIPTION
## Description

Just making the integration tests a little easier to run and control.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [n/a] New/changed keys in YAML format are documented.
- [n/a] \(Optional\) Closes an open bug in Launchpad.

