### PR TITLE
doc: update vlan example to use 'addresses' property

### DIFF
--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -872,7 +872,7 @@ Example:
       en-vpn:
         id: 2
         link: eno1
-        address: ...
+        addresses: ...
 
 
 ## Examples


### PR DESCRIPTION
The example block in "Properties for device type vlans:" on the "Reference"
site contains a key "address:" which doesn't exist. I suspect the key needed
is "addresses:".

LP: #1811802


## Description


## Checklist

- [ ] Runs `make check` successfully.
- [ ] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Closes an open bug in Launchpad.

