### PR TITLE
Update netplan.spec

### DIFF
--- a/rpm/netplan.spec
+++ b/rpm/netplan.spec
@@ -21,7 +21,7 @@ Summary:        Network configuration tool using YAML
 Group:          System Environment/Base
 License:        GPLv3
 URL:            http://netplan.io/
-Source0:        https://github.com/CanonicalLtd/%{name}/archive/%{version}/%{name}-%{version}.tar.gz
+Source0:        https://github.com/CanonicalLtd/%{name}/archive/%{version}/%{version}.tar.gz
 
 BuildRequires:  gcc
 BuildRequires:  make


### PR DESCRIPTION
## Description
The source url is incorrect. the file name does not have the package name in it. its just version.tar.gz


## Checklist

- [ ] Runs `make check` successfully.
- [ ] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Closes an open bug in Launchpad.

