### PR TITLE
Fixed Date in changelog section

### DIFF
--- a/rpm/netplan.spec
+++ b/rpm/netplan.spec
@@ -112,7 +112,7 @@ make check
 
 
 %changelog
-* Fri Dec 13 2018 Mathieu Trudel-Lapierre <mathieu.trudel-lapierre@canonical.com> - 0.95
+* Fri Dec 14 2018 Mathieu Trudel-Lapierre <mathieu.trudel-lapierre@canonical.com> - 0.95
 - Update to 0.95
 
 * Sat Oct 13 2018 Neal Gompa <ngompa13@gmail.com> - 0.40.3-0


### PR DESCRIPTION
The original Changelog entry of Fri Dec 13 causes a build warning in rpmbuild. Based on the release date of 0.95 I updated the date in the changelog to be Fri Dec 14 which fixes the build warning

ex.
rpmbuild -ba netplan/rpm/netplan.spec 
warning: bogus date in %changelog: Fri Dec 13 2018 Mathieu Trudel-Lapierre <mathieu.trudel-lapierre@canonical.com> - 0.95


## Description


## Checklist

- [ ] Runs `make check` successfully.
- [ ] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Closes an open bug in Launchpad.

