### PR TITLE
Initializing self.t to test before self.t.reset

### DIFF
--- a/netplan/cli/commands/try_command.py
+++ b/netplan/cli/commands/try_command.py
@@ -92,7 +92,6 @@ class NetplanTry(utils.NetplanCommand):
             print("\nReverting.")
             self.revert()
         finally:
-            self.t.reset(self.t_settings)
             self.cleanup()
 
     def backup(self):  # pragma: nocover (requires user input)

--- a/netplan/cli/commands/try_command.py
+++ b/netplan/cli/commands/try_command.py
@@ -45,6 +45,7 @@ class NetplanTry(utils.NetplanCommand):
         self.new_interfaces = None
         self._config_manager = None
         self.t_settings = None
+        self.t = None
 
     @property
     def config_manager(self):  # pragma: nocover (called by later commands)
@@ -92,6 +93,8 @@ class NetplanTry(utils.NetplanCommand):
             print("\nReverting.")
             self.revert()
         finally:
+            if self.t is not None:
+                self.t.reset(self.t_settings)
             self.cleanup()
 
     def backup(self):  # pragma: nocover (requires user input)

--- a/netplan/cli/commands/try_command.py
+++ b/netplan/cli/commands/try_command.py
@@ -93,7 +93,7 @@ class NetplanTry(utils.NetplanCommand):
             print("\nReverting.")
             self.revert()
         finally:
-            if self.t is not None:
+            if self.t:
                 self.t.reset(self.t_settings)
             self.cleanup()
 


### PR DESCRIPTION
`self.t` is only defined within the `try` block.  If an exception is thrown and the try bails out, `self.t` is undefined.  This causes the `finally` block to throw its own exception when it tries to call `self.t.reset`, and netplan crashes.


## Description


## Checklist

- [ ] Runs `make check` successfully.
- [ ] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [x] \(Optional\) Closes an open bug in Launchpad.

