### PR TITLE
Enforce that use-routes is the same for dhcp4 and dhcp6 in networkd backend.

### DIFF
--- a/src/networkd.c
+++ b/src/networkd.c
@@ -409,6 +409,10 @@ combine_dhcp_overrides(net_definition* def, dhcp_overrides* combined_dhcp_overri
             g_fprintf(stderr, DHCP_OVERRIDES_ERROR, def->id, "route-metric");
             exit(1);
         }
+        if (def->dhcp4_overrides.use_routes != def->dhcp6_overrides.use_routes) {
+            g_fprintf(stderr, DHCP_OVERRIDES_ERROR, def->id, "use-routes");
+            exit(1);
+        }
         /* Just use dhcp4_overrides now, since we know they are the same. */
         *combined_dhcp_overrides = def->dhcp4_overrides;
     }

--- a/tests/generator/test_dhcp_overrides.py
+++ b/tests/generator/test_dhcp_overrides.py
@@ -364,6 +364,9 @@ UseMTU=true
     def test_dhcp_overrides_default_metric(self):
         self.assert_dhcp_overrides_guint('route-metric', 'RouteMetric')
 
+    def test_dhcp_overrides_use_routes(self):
+        self.assert_dhcp_overrides_bool('use-routes', 'UseRoutes')
+
 
 class TestNetworkManager(TestBase):
 


### PR DESCRIPTION
## Description
networkd does not support separate configuration for dhcp4 and dhcp6.

For all other DHCP override options, an appropriate error is produced when the option is set differently for dhcp4 and dhcp6.  When the use-routes DHCP override option was introduced this check was omitted.

## Checklist

- [X] Runs `make check` successfully.
- [X] Retains 100% code coverage (`make check-coverage`).
- [X] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Closes an open bug in Launchpad.

