### PR TITLE
Backport DHCP override options to Bionic.

### DIFF
--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -190,6 +190,16 @@ Virtual devices
     device's MAC address as a unique identifier rather than a RFC4361-compliant
     Client ID. This has no effect when NetworkManager is used as a renderer.
 
+ ``dhcp4-overrides`` (mapping)
+
+ :  (networkd backend only) Overrides default DHCP behavior; see the
+    ``DHCP Overrides`` section below.
+
+ ``dhcp6-overrides`` (mapping)
+
+ :  (networkd backend only) Overrides default DHCP behavior; see the
+    ``DHCP Overrides`` section below.
+
 ``accept-ra`` (bool)
 
 :   Accept Router Advertisement that would have the kernel configure IPv6 by itself.
@@ -293,6 +303,74 @@ similar to ``gateway*``, and ``search:`` is a list of search domains.
 ``routing-policy`` (mapping)
 
 :   Configure policy routing for the device; see the ``Routing`` section below.
+
+## DHCP Overrides
+Several DHCP behavior overrides are available. Most currently only have any
+effect when using the ``networkd`` backend, with the exception of ``use-routes``
+and ``route-metric``.
+
+Overrides only have an effect if the corresponding ``dhcp4`` or ``dhcp6`` is
+set to ``true``.
+
+If both ``dhcp4`` and ``dhcp6`` are ``true``, the ``networkd`` backend requires
+that ``dhcp4-overrides`` and ``dhcp6-overrides`` contain the same keys and
+values. If the values do not match, an error will be shown and the network
+configuration will not be applied.
+
+When using the NetworkManager backend, different values may be specified for
+``dhcp4-overrides`` and ``dhcp6-overrides``, and will be applied to the DHCP
+client processes as specified in the netplan YAML.
+
+:    The ``dhcp4-overrides`` and ``dhcp6-overrides`` mappings override the
+     default DHCP behavior.
+
+     ``use-dns`` (bool)
+     :    Default: ``true``. When ``true``, the DNS servers received from the
+          DHCP server will be used and take precedence over any statically
+          configured ones. Currently only has an effect on the ``networkd``
+          backend.
+
+     ``use-ntp`` (bool)
+     :    Default: ``true``. When ``true``, the NTP servers received from the
+          DHCP server will be used by systemd-timesyncd and take precedence
+          over any statically configured ones. Currently only has an effect on
+          the ``networkd`` backend.
+
+     ``send-hostname`` (bool)
+     :    Default: ``true``. When ``true``, the machine's hostname will be sent
+          to the DHCP server. Currently only has an effect on the ``networkd``
+          backend.
+
+     ``use-hostname`` (bool)
+     :    Default: ``true``. When ``true``, the hostname received from the DHCP
+          server will be set as the transient hostname of the system. Currently
+          only has an effect on the ``networkd`` backend.
+
+     ``use-mtu`` (bool)
+     :    Default: ``true``. When ``true``, the MTU received from the DHCP
+          server will be set as the MTU of the network interface. When ``false``,
+          the MTU advertised by the DHCP server will be ignored. Currently only
+          has an effect on the ``networkd`` backend.
+
+     ``hostname`` (scalar)
+     :    Use this value for the hostname which is sent to the DHCP server,
+          instead of machine's hostname. Currently only has an effect on the
+          ``networkd`` backend.
+
+     ``use-routes`` (bool)
+     :    Default: ``true``. When ``true``, the routes received from the DHCP
+          server will be installed in the routing table normally. When set to
+          ``false``, routes from the DHCP server will be ignored: in this case,
+          the user is responsible for adding static routes if necessary for
+          correct network operation. This allows users to avoid installing a
+          default gateway for interfaces configured via DHCP. Available for
+          both the ``networkd`` and ``NetworkManager`` backends.
+
+     ``route-metric`` (scalar)
+     :    Use this value for default metric for automatically-added routes.
+          Use this to prioritize routes for devices by setting a higher metric
+          on a preferred interface. Available for both the ``networkd`` and
+          ``NetworkManager`` backends.
 
 
 ## Routing

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -297,6 +297,59 @@ write_ip_rule(ip_rule* r, GString* s)
         g_string_append_printf(s, "TypeOfService=%d\n", r->tos);
 }
 
+#define DHCP_OVERRIDES_ERROR                                            \
+    "ERROR: %s: networkd requires that %s has the same value in both "  \
+    "dhcp4_overrides and dhcp6_overrides\n"
+
+static void
+combine_dhcp_overrides(net_definition* def, dhcp_overrides* combined_dhcp_overrides)
+{
+    /* if only one of dhcp4 or dhcp6 is enabled, those overrides are used */
+    if (def->dhcp4 && !def->dhcp6) {
+        *combined_dhcp_overrides = def->dhcp4_overrides;
+    } else if (!def->dhcp4 && def->dhcp6) {
+        *combined_dhcp_overrides = def->dhcp6_overrides;
+    } else {
+        /* networkd doesn't support separately configuring dhcp4 and dhcp6, so
+         * we enforce that they are the same.
+         */
+        if (def->dhcp4_overrides.use_dns != def->dhcp6_overrides.use_dns) {
+            g_fprintf(stderr, DHCP_OVERRIDES_ERROR, def->id, "use-dns");
+            exit(1);
+        }
+        if (def->dhcp4_overrides.use_ntp != def->dhcp6_overrides.use_ntp) {
+            g_fprintf(stderr, DHCP_OVERRIDES_ERROR, def->id, "use-ntp");
+            exit(1);
+        }
+        if (def->dhcp4_overrides.send_hostname != def->dhcp6_overrides.send_hostname) {
+            g_fprintf(stderr, DHCP_OVERRIDES_ERROR, def->id, "send-hostname");
+            exit(1);
+        }
+        if (def->dhcp4_overrides.use_hostname != def->dhcp6_overrides.use_hostname) {
+            g_fprintf(stderr, DHCP_OVERRIDES_ERROR, def->id, "use-hostname");
+            exit(1);
+        }
+        if (def->dhcp4_overrides.use_mtu != def->dhcp6_overrides.use_mtu) {
+            g_fprintf(stderr, DHCP_OVERRIDES_ERROR, def->id, "use-mtu");
+            exit(1);
+        }
+        if (g_strcmp0(def->dhcp4_overrides.hostname, def->dhcp6_overrides.hostname) != 0) {
+            g_fprintf(stderr, DHCP_OVERRIDES_ERROR, def->id, "hostname");
+            exit(1);
+        }
+        if (def->dhcp4_overrides.metric != def->dhcp6_overrides.metric) {
+            g_fprintf(stderr, DHCP_OVERRIDES_ERROR, def->id, "route-metric");
+            exit(1);
+        }
+        if (def->dhcp4_overrides.use_routes != def->dhcp6_overrides.use_routes) {
+            g_fprintf(stderr, DHCP_OVERRIDES_ERROR, def->id, "use-routes");
+            exit(1);
+        }
+        /* Just use dhcp4_overrides now, since we know they are the same. */
+        *combined_dhcp_overrides = def->dhcp4_overrides;
+    }
+}
+
 static void
 write_network_file(net_definition* def, const char* rootdir, const char* path)
 {
@@ -419,15 +472,45 @@ write_network_file(net_definition* def, const char* rootdir, const char* path)
     }
 
     if (def->dhcp4 || def->dhcp6) {
-        /* isc-dhcp dhclient compatible UseMTU, networkd default is to
-         * not accept MTU, which breaks clouds */
-        g_string_append_printf(s, "\n[DHCP]\nUseMTU=true\n");
         /* NetworkManager compatible route metrics */
-        g_string_append_printf(s, "RouteMetric=%i\n", (def->type == ND_WIFI ? 600 : 100));
+        g_string_append(s, "\n[DHCP]\n");
         if (g_strcmp0(def->dhcp_identifier, "duid") != 0)
             g_string_append_printf(s, "ClientIdentifier=%s\n", def->dhcp_identifier);
         if (def->critical)
             g_string_append_printf(s, "CriticalConnection=true\n");
+
+        dhcp_overrides combined_dhcp_overrides;
+        combine_dhcp_overrides(def, &combined_dhcp_overrides);
+
+        if (combined_dhcp_overrides.metric == METRIC_UNSPEC) {
+            g_string_append_printf(s, "RouteMetric=%i\n", (def->type == ND_WIFI ? 600 : 100));
+        } else {
+            g_string_append_printf(s, "RouteMetric=%u\n",
+                                   combined_dhcp_overrides.metric);
+        }
+
+        /* Only set MTU from DHCP if use-mtu dhcp-override is not false. */
+        if (!combined_dhcp_overrides.use_mtu) {
+            /* isc-dhcp dhclient compatible UseMTU, networkd default is to
+             * not accept MTU, which breaks clouds */
+            g_string_append_printf(s, "UseMTU=false\n");
+        } else {
+            g_string_append_printf(s, "UseMTU=true\n");
+        }
+
+        /* Only write DHCP options that differ from the networkd default. */
+        if (!combined_dhcp_overrides.use_routes)
+            g_string_append_printf(s, "UseRoutes=false\n");
+        if (!combined_dhcp_overrides.use_dns)
+            g_string_append_printf(s, "UseDNS=false\n");
+        if (!combined_dhcp_overrides.use_ntp)
+            g_string_append_printf(s, "UseNTP=false\n");
+        if (!combined_dhcp_overrides.send_hostname)
+            g_string_append_printf(s, "SendHostname=false\n");
+        if (!combined_dhcp_overrides.use_hostname)
+            g_string_append_printf(s, "UseHostname=false\n");
+        if (combined_dhcp_overrides.hostname)
+            g_string_append_printf(s, "Hostname=%s\n", combined_dhcp_overrides.hostname);
     }
 
     /* these do not contain secrets and need to be readable by

--- a/src/nm.c
+++ b/src/nm.c
@@ -437,6 +437,14 @@ write_nm_conf_access_point(net_definition* def, const char* rootdir, const wifi_
         write_routes(def, s, AF_INET);
     }
 
+    if (!def->dhcp4_overrides.use_routes) {
+        g_string_append(s, "ignore-auto-routes=true\n");
+        g_string_append(s, "never-default=true\n");
+    }
+
+    if (def->dhcp4 && def->dhcp4_overrides.metric != METRIC_UNSPEC)
+        g_string_append_printf(s, "route-metric=%u\n", def->dhcp4_overrides.metric);
+
     if (def->dhcp6 || def->ip6_addresses || def->gateway6 || def->ip6_nameservers) {
         g_string_append(s, "\n[ipv6]\n");
         g_string_append(s, def->dhcp6 ? "method=auto\n" : "method=manual\n");
@@ -457,6 +465,14 @@ write_nm_conf_access_point(net_definition* def, const char* rootdir, const wifi_
 
         /* We can only write valid routes if there is a DHCPv6 or static IPv6 address */
         write_routes(def, s, AF_INET6);
+
+        if (!def->dhcp6_overrides.use_routes) {
+            g_string_append(s, "ignore-auto-routes=true\n");
+            g_string_append(s, "never-default=true\n");
+        }
+
+        if (def->dhcp6_overrides.metric != METRIC_UNSPEC)
+            g_string_append_printf(s, "route-metric=%u\n", def->dhcp6_overrides.metric);
     }
     else {
         g_string_append(s, "\n[ipv6]\nmethod=ignore\n");

--- a/src/parse.h
+++ b/src/parse.h
@@ -75,6 +75,18 @@ typedef struct missing_node {
     const yaml_node_t* node;
 } missing_node;
 
+/* Fields below are valid for dhcp4 and dhcp6 unless otherwise noted. */
+typedef struct dhcp_overrides {
+    gboolean use_dns;
+    gboolean use_ntp;
+    gboolean send_hostname;
+    gboolean use_hostname;
+    gboolean use_mtu;
+    gboolean use_routes;
+    char* hostname;
+    guint metric;
+} dhcp_overrides;
+
 /**
  * Represent a configuration stanza
  */
@@ -94,6 +106,8 @@ typedef struct net_definition {
     gboolean dhcp4;
     gboolean dhcp6;
     char* dhcp_identifier;
+    dhcp_overrides dhcp4_overrides;
+    dhcp_overrides dhcp6_overrides;
     ra_mode accept_ra;
     GArray* ip4_addresses;
     GArray* ip6_addresses;

--- a/tests/generate.py
+++ b/tests/generate.py
@@ -36,10 +36,13 @@ exe_generate = os.path.join(os.path.dirname(os.path.dirname(
 os.environ['G_DEBUG'] = 'fatal-criticals'
 
 # common patterns for expected output
-ND_DHCP4 = '[Match]\nName=%s\n\n[Network]\nDHCP=ipv4\nLinkLocalAddressing=ipv6\n\n[DHCP]\nUseMTU=true\nRouteMetric=100\n'
-ND_WIFI_DHCP4 = '[Match]\nName=%s\n\n[Network]\nDHCP=ipv4\nLinkLocalAddressing=ipv6\n\n[DHCP]\nUseMTU=true\nRouteMetric=600\n'
-ND_DHCP6 = '[Match]\nName=%s\n\n[Network]\nDHCP=ipv6\nLinkLocalAddressing=ipv6\n\n[DHCP]\nUseMTU=true\nRouteMetric=100\n'
-ND_DHCPYES = '[Match]\nName=%s\n\n[Network]\nDHCP=yes\nLinkLocalAddressing=ipv6\n\n[DHCP]\nUseMTU=true\nRouteMetric=100\n'
+ND_DHCP4 = '[Match]\nName=%s\n\n[Network]\nDHCP=ipv4\nLinkLocalAddressing=ipv6\n\n[DHCP]\nRouteMetric=100\nUseMTU=true\n'
+ND_DHCP4_NOMTU = '[Match]\nName=%s\n\n[Network]\nDHCP=ipv4\nLinkLocalAddressing=ipv6\n\n[DHCP]\nRouteMetric=100\nUseMTU=false\n'
+ND_WIFI_DHCP4 = '[Match]\nName=%s\n\n[Network]\nDHCP=ipv4\nLinkLocalAddressing=ipv6\n\n[DHCP]\nRouteMetric=600\nUseMTU=true\n'
+ND_DHCP6 = '[Match]\nName=%s\n\n[Network]\nDHCP=ipv6\nLinkLocalAddressing=ipv6\n\n[DHCP]\nRouteMetric=100\nUseMTU=true\n'
+ND_DHCP6_NOMTU = '[Match]\nName=%s\n\n[Network]\nDHCP=ipv6\nLinkLocalAddressing=ipv6\n\n[DHCP]\nRouteMetric=100\nUseMTU=false\n'
+ND_DHCPYES = '[Match]\nName=%s\n\n[Network]\nDHCP=yes\nLinkLocalAddressing=ipv6\n\n[DHCP]\nRouteMetric=100\nUseMTU=true\n'
+ND_DHCPYES_NOMTU = '[Match]\nName=%s\n\n[Network]\nDHCP=yes\nLinkLocalAddressing=ipv6\n\n[DHCP]\nRouteMetric=100\nUseMTU=false\n'
 UDEV_MAC_RULE = 'SUBSYSTEM=="net", ACTION=="add", DRIVERS=="%s", ATTR{address}=="%s", NAME="%s"\n'
 UDEV_NO_MAC_RULE = 'SUBSYSTEM=="net", ACTION=="add", DRIVERS=="%s", NAME="%s"\n'
 
@@ -326,8 +329,8 @@ DHCP=ipv6
 LinkLocalAddressing=ipv6
 
 [DHCP]
-UseMTU=true
 RouteMetric=100
+UseMTU=true
 '''})
         self.assert_networkd_udev(None)
 
@@ -490,8 +493,8 @@ DHCP=ipv4
 LinkLocalAddressing=ipv6
 
 [DHCP]
-UseMTU=true
 RouteMetric=100
+UseMTU=true
 '''})
         self.assert_networkd_udev(None)
         self.assert_nm_udev('ACTION=="add|change", SUBSYSTEM=="net", ENV{ID_NET_DRIVER}=="ixgbe", ENV{NM_UNMANAGED}="1"\n')
@@ -572,7 +575,7 @@ unmanaged-devices+=interface-name:*,''')
       dhcp4: true''')
 
         self.assert_networkd({'def1.network': '[Match]\n\n[Network]\nDHCP=ipv4\nLinkLocalAddressing=ipv6\n\n'
-                                              '[DHCP]\nUseMTU=true\nRouteMetric=100\n'})
+                                              '[DHCP]\nRouteMetric=100\nUseMTU=true\n'})
         self.assert_networkd_udev(None)
         self.assert_nm(None, '''[keyfile]
 # devices managed by networkd
@@ -597,8 +600,8 @@ DHCP=ipv4
 LinkLocalAddressing=ipv6
 
 [DHCP]
-UseMTU=true
 RouteMetric=100
+UseMTU=true
 '''})
         self.assert_nm(None, '''[keyfile]
 # devices managed by networkd
@@ -654,8 +657,8 @@ LinkLocalAddressing=ipv6
 ConfigureWithoutCarrier=yes
 
 [DHCP]
-UseMTU=true
 RouteMetric=100
+UseMTU=true
 ''',
                               'br0.netdev': '[NetDev]\nName=br0\nMACAddress=00:01:02:03:04:05\nKind=bridge\n'})
 
@@ -699,8 +702,8 @@ LinkLocalAddressing=ipv6
 IPv6AcceptRA=no
 
 [DHCP]
-UseMTU=true
 RouteMetric=100
+UseMTU=true
 '''})
 
     def test_bridge_dhcp6_no_accept_ra(self):
@@ -726,8 +729,8 @@ IPv6AcceptRA=no
 ConfigureWithoutCarrier=yes
 
 [DHCP]
-UseMTU=true
 RouteMetric=100
+UseMTU=true
 ''',
                               'br0.netdev': '''[NetDev]
 Name=br0
@@ -764,8 +767,8 @@ IPv6AcceptRA=yes
 ConfigureWithoutCarrier=yes
 
 [DHCP]
-UseMTU=true
 RouteMetric=100
+UseMTU=true
 ''',
                               'bond0.netdev': '''[NetDev]
 Name=bond0
@@ -796,8 +799,8 @@ LinkLocalAddressing=ipv6
 IPv6AcceptRA=yes
 
 [DHCP]
-UseMTU=true
 RouteMetric=100
+UseMTU=true
 '''})
 
     def test_eth_dhcp6_accept_ra_unset(self):
@@ -814,8 +817,8 @@ DHCP=ipv6
 LinkLocalAddressing=ipv6
 
 [DHCP]
-UseMTU=true
 RouteMetric=100
+UseMTU=true
 '''})
 
     def test_eth_dhcp4_and_6(self):
@@ -863,8 +866,8 @@ Address=192.168.14.2/24
 Address=2001:FFfe::1/64
 
 [DHCP]
-UseMTU=true
 RouteMetric=100
+UseMTU=true
 '''})
 
     def test_dhcp_critical_true(self):
@@ -884,9 +887,9 @@ DHCP=ipv4
 LinkLocalAddressing=ipv6
 
 [DHCP]
-UseMTU=true
-RouteMetric=100
 CriticalConnection=true
+RouteMetric=100
+UseMTU=true
 '''})
 
     def test_dhcp_identifier_mac(self):
@@ -906,9 +909,9 @@ DHCP=ipv4
 LinkLocalAddressing=ipv6
 
 [DHCP]
-UseMTU=true
-RouteMetric=100
 ClientIdentifier=mac
+RouteMetric=100
+UseMTU=true
 '''})
 
     def test_dhcp_identifier_duid(self):
@@ -929,9 +932,350 @@ DHCP=ipv4
 LinkLocalAddressing=ipv6
 
 [DHCP]
-UseMTU=true
 RouteMetric=100
+UseMTU=true
 '''})
+
+    # Common tests for dhcp override booleans
+    def run_dhcp_overrides_bool_tests(self, override_name, networkd_name):
+        # dhcp4 yes
+        self.generate('''network:
+  version: 2
+  ethernets:
+    engreen:
+      dhcp4: yes
+      dhcp4-overrides:
+        %s: yes
+''' % override_name)
+        # silently ignored since yes is the default
+        self.assert_networkd({'engreen.network': ND_DHCP4 % 'engreen'})
+
+        # dhcp6 yes
+        self.generate('''network:
+  version: 2
+  ethernets:
+    engreen:
+      dhcp6: yes
+      dhcp6-overrides:
+        %s: yes
+''' % override_name)
+        # silently ignored since yes is the default
+        self.assert_networkd({'engreen.network': ND_DHCP6 % 'engreen'})
+
+        # dhcp4 and dhcp6 both yes
+        self.generate('''network:
+  version: 2
+  ethernets:
+    engreen:
+      dhcp4: yes
+      dhcp4-overrides:
+        %s: yes
+      dhcp6: yes
+      dhcp6-overrides:
+        %s: yes
+''' % (override_name, override_name))
+        # silently ignored since yes is the default
+        self.assert_networkd({'engreen.network': ND_DHCPYES % 'engreen'})
+
+        # dhcp4 no
+        self.generate('''network:
+  version: 2
+  ethernets:
+    engreen:
+      dhcp4: yes
+      dhcp4-overrides:
+        %s: no
+''' % override_name)
+        self.assert_networkd({'engreen.network': ND_DHCP4 % 'engreen' + '%s=false\n' % networkd_name})
+
+        # dhcp6 no
+        self.generate('''network:
+  version: 2
+  ethernets:
+    engreen:
+      dhcp6: yes
+      dhcp6-overrides:
+        %s: no
+''' % override_name)
+        self.assert_networkd({'engreen.network': ND_DHCP6 % 'engreen' + '%s=false\n' % networkd_name})
+
+        # dhcp4 and dhcp6 both no
+        self.generate('''network:
+  version: 2
+  ethernets:
+    engreen:
+      dhcp4: yes
+      dhcp4-overrides:
+        %s: no
+      dhcp6: yes
+      dhcp6-overrides:
+        %s: no
+''' % (override_name, override_name))
+        self.assert_networkd({'engreen.network': ND_DHCPYES % 'engreen' + '%s=false\n' % networkd_name})
+
+        # mismatched values
+        err = self.generate('''network:
+  version: 2
+  ethernets:
+    engreen:
+      dhcp4: yes
+      dhcp4-overrides:
+        %s: yes
+      dhcp6: yes
+      dhcp6-overrides:
+        %s: no
+''' % (override_name, override_name), expect_fail=True)
+        self.assertEqual(err, 'ERROR: engreen: networkd requires that '
+                              '%s has the same value in both dhcp4_overrides and dhcp6_overrides\n' % override_name)
+
+    # Common tests for dhcp override strings
+    def run_dhcp_overrides_string_tests(self, override_name, networkd_name):
+        # dhcp4 only
+        self.generate('''network:
+  version: 2
+  ethernets:
+    engreen:
+      dhcp4: yes
+      dhcp4-overrides:
+        %s: foo
+''' % override_name)
+        self.assert_networkd({'engreen.network': ND_DHCP4 % 'engreen' + '%s=foo\n' % networkd_name})
+
+        # dhcp6 only
+        self.generate('''network:
+  version: 2
+  ethernets:
+    engreen:
+      dhcp6: yes
+      dhcp6-overrides:
+        %s: foo
+''' % override_name)
+        self.assert_networkd({'engreen.network': ND_DHCP6 % 'engreen' + '%s=foo\n' % networkd_name})
+
+        # dhcp4 and dhcp6
+        self.generate('''network:
+  version: 2
+  ethernets:
+    engreen:
+      dhcp4: yes
+      dhcp4-overrides:
+        %s: foo
+      dhcp6: yes
+      dhcp6-overrides:
+        %s: foo
+''' % (override_name, override_name))
+        self.assert_networkd({'engreen.network': ND_DHCPYES % 'engreen' + '%s=foo\n' % networkd_name})
+
+        # mismatched values
+        err = self.generate('''network:
+  version: 2
+  ethernets:
+    engreen:
+      dhcp4: yes
+      dhcp4-overrides:
+        %s: foo
+      dhcp6: yes
+      dhcp6-overrides:
+        %s: bar
+''' % (override_name, override_name), expect_fail=True)
+        self.assertEqual(err, 'ERROR: engreen: networkd requires that %s has the same value in both dhcp4_overrides and dhcp6_overrides\n' % override_name)
+
+    # Common tests for dhcp override booleans
+    def run_dhcp_mtu_overrides_bool_tests(self, override_name, networkd_name):
+        # dhcp4 yes
+        self.generate('''network:
+  version: 2
+  ethernets:
+    engreen:
+      dhcp4: yes
+      dhcp4-overrides:
+        %s: yes
+''' % override_name)
+        self.assert_networkd({'engreen.network': ND_DHCP4 % 'engreen'})
+
+        # dhcp6 yes
+        self.generate('''network:
+  version: 2
+  ethernets:
+    engreen:
+      dhcp6: yes
+      dhcp6-overrides:
+        %s: yes
+''' % override_name)
+        # silently ignored since yes is the default
+        self.assert_networkd({'engreen.network': ND_DHCP6 % 'engreen'})
+
+        # dhcp4 and dhcp6 both yes
+        self.generate('''network:
+  version: 2
+  ethernets:
+    engreen:
+      dhcp4: yes
+      dhcp4-overrides:
+        %s: yes
+      dhcp6: yes
+      dhcp6-overrides:
+        %s: yes
+''' % (override_name, override_name))
+        # silently ignored since yes is the default
+        self.assert_networkd({'engreen.network': ND_DHCPYES % 'engreen'})
+
+        # dhcp4 no
+        self.generate('''network:
+  version: 2
+  ethernets:
+    engreen:
+      dhcp4: yes
+      dhcp4-overrides:
+        %s: no
+''' % override_name)
+        self.assert_networkd({'engreen.network': ND_DHCP4_NOMTU % 'engreen'})
+
+        # dhcp6 no
+        self.generate('''network:
+  version: 2
+  ethernets:
+    engreen:
+      dhcp6: yes
+      dhcp6-overrides:
+        %s: no
+''' % override_name)
+        self.assert_networkd({'engreen.network': ND_DHCP6_NOMTU % 'engreen'})
+
+        # dhcp4 and dhcp6 both no
+        self.generate('''network:
+  version: 2
+  ethernets:
+    engreen:
+      dhcp4: yes
+      dhcp4-overrides:
+        %s: no
+      dhcp6: yes
+      dhcp6-overrides:
+        %s: no
+''' % (override_name, override_name))
+        self.assert_networkd({'engreen.network': ND_DHCPYES_NOMTU % 'engreen'})
+
+        # mismatched values
+        err = self.generate('''network:
+  version: 2
+  ethernets:
+    engreen:
+      dhcp4: yes
+      dhcp4-overrides:
+        %s: yes
+      dhcp6: yes
+      dhcp6-overrides:
+        %s: no
+''' % (override_name, override_name), expect_fail=True)
+        self.assertEqual(err, 'ERROR: engreen: networkd requires that '
+                              '%s has the same value in both dhcp4_overrides and dhcp6_overrides\n' % override_name)
+
+    def run_dhcp_overrides_guint_tests(self, override_name, networkd_name):
+        # dhcp4 only
+        self.generate('''network:
+  version: 2
+  ethernets:
+    engreen:
+      dhcp4: yes
+      dhcp4-overrides:
+        %s: 6000
+''' % override_name)
+        self.assert_networkd({'engreen.network': '''[Match]
+Name=engreen
+
+[Network]
+DHCP=ipv4
+LinkLocalAddressing=ipv6
+
+[DHCP]
+RouteMetric=6000
+UseMTU=true
+'''})
+
+        # dhcp6 only
+        self.generate('''network:
+  version: 2
+  ethernets:
+    engreen:
+      dhcp6: yes
+      dhcp6-overrides:
+        %s: 6000
+''' % override_name)
+        self.assert_networkd({'engreen.network': '''[Match]
+Name=engreen
+
+[Network]
+DHCP=ipv6
+LinkLocalAddressing=ipv6
+
+[DHCP]
+RouteMetric=6000
+UseMTU=true
+'''})
+
+        # dhcp4 and dhcp6
+        self.generate('''network:
+  version: 2
+  ethernets:
+    engreen:
+      dhcp4: yes
+      dhcp4-overrides:
+        %s: 6000
+      dhcp6: yes
+      dhcp6-overrides:
+        %s: 6000
+''' % (override_name, override_name))
+        self.assert_networkd({'engreen.network': '''[Match]
+Name=engreen
+
+[Network]
+DHCP=yes
+LinkLocalAddressing=ipv6
+
+[DHCP]
+RouteMetric=6000
+UseMTU=true
+'''})
+
+        # mismatched values
+        err = self.generate('''network:
+  version: 2
+  ethernets:
+    engreen:
+      dhcp4: yes
+      dhcp4-overrides:
+        %s: 3333
+      dhcp6: yes
+      dhcp6-overrides:
+        %s: 5555
+''' % (override_name, override_name), expect_fail=True)
+        self.assertEqual(err, 'ERROR: engreen: networkd requires that '
+                              '%s has the same value in both dhcp4_overrides and dhcp6_overrides\n' % override_name)
+
+    def test_dhcp_overrides_use_dns(self):
+        self.run_dhcp_overrides_bool_tests('use-dns', 'UseDNS')
+
+    def test_dhcp_overrides_use_ntp(self):
+        self.run_dhcp_overrides_bool_tests('use-ntp', 'UseNTP')
+
+    def test_dhcp_overrides_send_hostname(self):
+        self.run_dhcp_overrides_bool_tests('send-hostname', 'SendHostname')
+
+    def test_dhcp_overrides_use_hostname(self):
+        self.run_dhcp_overrides_bool_tests('use-hostname', 'UseHostname')
+
+    def test_dhcp_overrides_use_routes(self):
+        self.run_dhcp_overrides_bool_tests('use-routes', 'UseRoutes')
+
+    def test_dhcp_overrides_hostname(self):
+        self.run_dhcp_overrides_string_tests('hostname', 'Hostname')
+
+    def test_dhcp_overrides_use_mtu(self):
+        self.run_dhcp_mtu_overrides_bool_tests('use-mtu', 'UseMTU')
+
+    def test_dhcp_overrides_default_metric(self):
+        self.run_dhcp_overrides_guint_tests('route-metric', 'RouteMetric')
 
     def test_route_v4_single(self):
         self.generate('''network:
@@ -1378,8 +1722,8 @@ Destination=10.10.10.0/24
 Gateway=8.8.8.8
 
 [DHCP]
-UseMTU=true
 RouteMetric=600
+UseMTU=true
 '''})
 
         self.assert_nm(None, '''[keyfile]
@@ -1429,8 +1773,8 @@ LinkLocalAddressing=ipv6
 ConfigureWithoutCarrier=yes
 
 [DHCP]
-UseMTU=true
 RouteMetric=100
+UseMTU=true
 '''})
         self.assert_nm(None, '''[keyfile]
 # devices managed by networkd
@@ -1456,8 +1800,8 @@ LinkLocalAddressing=ipv6
 ConfigureWithoutCarrier=yes
 
 [DHCP]
-UseMTU=true
 RouteMetric=100
+UseMTU=true
 '''})
         self.assert_nm(None, '''[keyfile]
 # devices managed by networkd
@@ -1486,8 +1830,8 @@ Address=1.2.3.4/12
 ConfigureWithoutCarrier=yes
 
 [DHCP]
-UseMTU=true
 RouteMetric=100
+UseMTU=true
 '''})
         self.assert_nm(None, '''[keyfile]
 # devices managed by networkd
@@ -1518,8 +1862,8 @@ LinkLocalAddressing=ipv6
 ConfigureWithoutCarrier=yes
 
 [DHCP]
-UseMTU=true
 RouteMetric=100
+UseMTU=true
 ''',
                               'eno1.network': '[Match]\nName=eno1\n\n'
                                               '[Network]\nLinkLocalAddressing=no\nBridge=br0\n',
@@ -1565,8 +1909,8 @@ LinkLocalAddressing=ipv6
 ConfigureWithoutCarrier=yes
 
 [DHCP]
-UseMTU=true
 RouteMetric=100
+UseMTU=true
 ''',
                               'eno1.network': '[Match]\nName=eno1\n\n'
                                               '[Network]\nLinkLocalAddressing=no\nBridge=br0\n',
@@ -1613,8 +1957,8 @@ LinkLocalAddressing=ipv6
 ConfigureWithoutCarrier=yes
 
 [DHCP]
-UseMTU=true
 RouteMetric=100
+UseMTU=true
 ''',
                               'eno1.network': '[Match]\nName=eno1\n\n'
                                               '[Network]\nLinkLocalAddressing=no\nBridge=br0\n\n'
@@ -1639,8 +1983,8 @@ LinkLocalAddressing=ipv6
 ConfigureWithoutCarrier=yes
 
 [DHCP]
-UseMTU=true
 RouteMetric=100
+UseMTU=true
 '''})
         self.assert_nm(None, '''[keyfile]
 # devices managed by networkd
@@ -1670,8 +2014,8 @@ LinkLocalAddressing=ipv6
 ConfigureWithoutCarrier=yes
 
 [DHCP]
-UseMTU=true
 RouteMetric=100
+UseMTU=true
 ''',
                               'eno1.network': '[Match]\nName=eno1\n\n'
                                               '[Network]\nLinkLocalAddressing=no\nBond=bn0\n',
@@ -1702,8 +2046,8 @@ LinkLocalAddressing=ipv6
 ConfigureWithoutCarrier=yes
 
 [DHCP]
-UseMTU=true
 RouteMetric=100
+UseMTU=true
 ''',
                               'eno1.network': '[Match]\nName=eno1\n\n'
                                               '[Network]\nLinkLocalAddressing=no\nBond=bn0\n',
@@ -1775,8 +2119,8 @@ LinkLocalAddressing=ipv6
 ConfigureWithoutCarrier=yes
 
 [DHCP]
-UseMTU=true
 RouteMetric=100
+UseMTU=true
 ''',
                               'eno1.network': '[Match]\nName=eno1\n\n'
                                               '[Network]\nLinkLocalAddressing=no\nBond=bn0\n',
@@ -1818,8 +2162,8 @@ LinkLocalAddressing=ipv6
 ConfigureWithoutCarrier=yes
 
 [DHCP]
-UseMTU=true
 RouteMetric=100
+UseMTU=true
 ''',
                               'eno1.network': '[Match]\nName=eno1\n\n'
                                               '[Network]\nLinkLocalAddressing=no\nBond=bn0\n',
@@ -1854,8 +2198,8 @@ LinkLocalAddressing=ipv6
 ConfigureWithoutCarrier=yes
 
 [DHCP]
-UseMTU=true
 RouteMetric=100
+UseMTU=true
 ''',
                               'eno1.network': '[Match]\nName=eno1\n\n'
                                               '[Network]\nLinkLocalAddressing=no\nBond=bn0\nPrimarySlave=true\n',
@@ -1892,8 +2236,8 @@ LinkLocalAddressing=ipv6
 ConfigureWithoutCarrier=yes
 
 [DHCP]
-UseMTU=true
 RouteMetric=100
+UseMTU=true
 ''',
                               'eno1.network': '[Match]\nName=eno1\n\n'
                                               '[Network]\nLinkLocalAddressing=no\nBond=bn0\n',
@@ -2024,8 +2368,8 @@ LinkLocalAddressing=ipv6
 ConfigureWithoutCarrier=yes
 
 [DHCP]
-UseMTU=true
 RouteMetric=100
+UseMTU=true
 '''})
         self.assert_nm(None, '''[keyfile]
 # devices managed by networkd
@@ -2142,8 +2486,8 @@ DHCP=yes
 LinkLocalAddressing=yes
 
 [DHCP]
-UseMTU=true
 RouteMetric=100
+UseMTU=true
 '''})
 
     def test_link_local_ipv4(self):
@@ -2164,8 +2508,8 @@ DHCP=yes
 LinkLocalAddressing=ipv4
 
 [DHCP]
-UseMTU=true
 RouteMetric=100
+UseMTU=true
 '''})
 
     def test_link_local_ipv6(self):
@@ -2186,8 +2530,8 @@ DHCP=yes
 LinkLocalAddressing=ipv6
 
 [DHCP]
-UseMTU=true
 RouteMetric=100
+UseMTU=true
 '''})
 
     def test_link_local_disabled(self):
@@ -2208,8 +2552,8 @@ DHCP=yes
 LinkLocalAddressing=no
 
 [DHCP]
-UseMTU=true
 RouteMetric=100
+UseMTU=true
 '''})
 
 
@@ -4053,6 +4397,174 @@ method=ignore
 ''' % uuid})
         self.assert_nm_udev(None)
 
+    def test_override_default_metric_v4(self):
+        self.generate('''network:
+  version: 2
+  renderer: NetworkManager
+  ethernets:
+    engreen:
+      dhcp4: yes
+      dhcp4-overrides:
+        route-metric: 3333
+''')
+        # silently ignored since yes is the default
+        self.assert_nm({'engreen': '''[connection]
+id=netplan-engreen
+type=ethernet
+interface-name=engreen
+
+[ethernet]
+wake-on-lan=0
+
+[ipv4]
+method=auto
+route-metric=3333
+
+[ipv6]
+method=ignore
+'''})
+
+    def test_override_default_metric_v6(self):
+        self.generate('''network:
+  version: 2
+  renderer: NetworkManager
+  ethernets:
+    engreen:
+      dhcp4: yes
+      dhcp6: yes
+      dhcp6-overrides:
+        route-metric: 6666
+''')
+        # silently ignored since yes is the default
+        self.assert_nm({'engreen': '''[connection]
+id=netplan-engreen
+type=ethernet
+interface-name=engreen
+
+[ethernet]
+wake-on-lan=0
+
+[ipv4]
+method=auto
+
+[ipv6]
+method=auto
+route-metric=6666
+'''})
+
+    def test_use_routes_v4(self):
+        """[NetworkManager] Validate config when use-routes DHCP4 override is used"""
+        self.generate('''network:
+  version: 2
+  renderer: NetworkManager
+  ethernets:
+    engreen:
+      dhcp4: true
+      dhcp4-overrides:
+        use-routes: false
+          ''')
+        self.assert_nm({'engreen': '''[connection]
+id=netplan-engreen
+type=ethernet
+interface-name=engreen
+
+[ethernet]
+wake-on-lan=0
+
+[ipv4]
+method=auto
+ignore-auto-routes=true
+never-default=true
+
+[ipv6]
+method=ignore
+'''})
+
+    def test_use_routes_v6(self):
+        """[NetworkManager] Validate config when use-routes DHCP6 override is used"""
+        self.generate('''network:
+  version: 2
+  renderer: NetworkManager
+  ethernets:
+    engreen:
+      dhcp4: true
+      dhcp6: true
+      dhcp6-overrides:
+        use-routes: false
+          ''')
+        self.assert_nm({'engreen': '''[connection]
+id=netplan-engreen
+type=ethernet
+interface-name=engreen
+
+[ethernet]
+wake-on-lan=0
+
+[ipv4]
+method=auto
+
+[ipv6]
+method=auto
+ignore-auto-routes=true
+never-default=true
+'''})
+
+    def test_default_metric_v4(self):
+        """[NetworkManager] Validate config when setting a default metric for DHCPv4"""
+        self.generate('''network:
+  version: 2
+  renderer: NetworkManager
+  ethernets:
+    engreen:
+      dhcp4: true
+      dhcp6: true
+      dhcp4-overrides:
+        route-metric: 4000
+          ''')
+        self.assert_nm({'engreen': '''[connection]
+id=netplan-engreen
+type=ethernet
+interface-name=engreen
+
+[ethernet]
+wake-on-lan=0
+
+[ipv4]
+method=auto
+route-metric=4000
+
+[ipv6]
+method=auto
+'''})
+
+    def test_default_metric_v6(self):
+        """[NetworkManager] Validate config when setting a default metric for DHCPv6"""
+        self.generate('''network:
+  version: 2
+  renderer: NetworkManager
+  ethernets:
+    engreen:
+      dhcp4: true
+      dhcp6: true
+      dhcp6-overrides:
+        route-metric: 5050
+          ''')
+        self.assert_nm({'engreen': '''[connection]
+id=netplan-engreen
+type=ethernet
+interface-name=engreen
+
+[ethernet]
+wake-on-lan=0
+
+[ipv4]
+method=auto
+
+[ipv6]
+method=auto
+route-metric=5050
+'''})
+
 
 class TestConfigErrors(TestBase):
     def test_malformed_yaml(self):
@@ -4922,8 +5434,8 @@ LinkLocalAddressing=ipv6
 ConfigureWithoutCarrier=yes
 
 [DHCP]
-UseMTU=true
 RouteMetric=100
+UseMTU=true
 ''',
                               'bond0.netdev': '[NetDev]\nName=bond0\nKind=bond\n',
                               'bond0.network': '''[Match]
@@ -4990,8 +5502,8 @@ LinkLocalAddressing=ipv6
 ConfigureWithoutCarrier=yes
 
 [DHCP]
-UseMTU=true
 RouteMetric=100
+UseMTU=true
 ''',
                               'br0.netdev': '[NetDev]\nName=br0\nKind=bridge\n\n'
                                             '[Bridge]\nSTP=true\n',
@@ -5139,8 +5651,8 @@ LinkLocalAddressing=ipv6
 ConfigureWithoutCarrier=yes
 
 [DHCP]
-UseMTU=true
 RouteMetric=100
+UseMTU=true
 ''',
                               'eno1.network': '[Match]\nName=eno1\n\n'
                                               '[Network]\nLinkLocalAddressing=no\nBridge=br0\n',


### PR DESCRIPTION
## Description

This is a backport of the DHCP override options to Bionic.

This is frequently requested in the comments for Launchpad bug [#1759014](https://bugs.launchpad.net/netplan/+bug/1759014).

The specific options backported are:
- use-dns
- use-ntp
- send-hostname
- use-hostname
- hostname
- use-mtu
- use-routes
- metric

This is all of the override options existing at the time of this backport.


## Checklist

- [X] Runs `make check` successfully.
- [X] Retains 100% code coverage (`make check-coverage`).
- [X] New/changed keys in YAML format are documented.
- [X] \(Optional\) Closes an open bug in Launchpad. (launchpad bug [#1759014](https://bugs.launchpad.net/netplan/+bug/1759014))

