### PR TITLE
allow *.yaml files as well as *.yml

### DIFF
--- a/doc/netplan-generate.md
+++ b/doc/netplan-generate.md
@@ -48,9 +48,9 @@ For details of the configuration file format, see **netplan**(5).
 
 There are 3 locations that netplan generate considers:
 
- * /lib/netplan/*.yaml
- * /etc/netplan/*.yaml
- * /run/netplan/*.yaml
+ * /lib/netplan/*.yaml and /lib/netplan/*.yml
+ * /etc/netplan/*.yaml and /etc/netplan/*.yml
+ * /run/netplan/*.yaml and /run/netplan/*.yml
 
 If there are multiple files with exactly the same name, then only one
 will be read. A file in /run/netplan will shadow - completely replace

--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -3,8 +3,8 @@ Distribution installers, cloud instantiation, image builds for particular
 devices, or any other way to deploy an operating system put its desired
 network configuration into YAML configuration file(s). During
 early boot, the netplan "network renderer" runs which reads
-``/{lib,etc,run}/netplan/*.yaml`` and writes configuration to ``/run`` to hand
-off control of devices to the specified networking daemon.
+``/{lib,etc,run}/netplan/*.{yaml,yml}`` and writes configuration to ``/run``
+to hand off control of devices to the specified networking daemon.
 
  - Configured devices get handled by systemd-networkd by default,
    unless explicitly marked as managed by a specific renderer (NetworkManager)
@@ -20,8 +20,8 @@ off control of devices to the specified networking daemon.
 ## General structure
 netplan's configuration files use the
 [YAML](<http://yaml.org/spec/1.1/current.html>) format. All
-``/{lib,etc,run}/netplan/*.yaml`` are considered. Lexicographically later files
-(regardless of in which directory they are) amend (new mapping keys) or
+``/{lib,etc,run}/netplan/*.{yaml,yml}`` are considered. Lexicographically later
+files (regardless of in which directory they are) amend (new mapping keys) or
 override (same mapping keys) previous ones. A file in ``/run/netplan``
 completely shadows a file with same name in ``/etc/netplan``, and a file in
 either of those directories shadows a file with the same name in

--- a/netplan/cli/commands/generate.py
+++ b/netplan/cli/commands/generate.py
@@ -29,7 +29,7 @@ class NetplanGenerate(utils.NetplanCommand):
     def __init__(self):
         super().__init__(command_id='generate',
                          description='Generate backend specific configuration files'
-                                     ' from /etc/netplan/*.yaml',
+                                     ' from /etc/netplan/*.yaml and /etc/netplan/*.yml',
                          leaf=True)
 
     def run(self):

--- a/netplan/configmanager.py
+++ b/netplan/configmanager.py
@@ -95,8 +95,9 @@ class ConfigManager(object):
         # /run/netplan shadows /etc/netplan/, which shadows /lib/netplan
         names_to_paths = {}
         for yaml_dir in ['lib', 'etc', 'run']:
-            for yaml_file in glob.glob(os.path.join(self.prefix, yaml_dir, 'netplan', '*.yaml')):
-                names_to_paths[os.path.basename(yaml_file)] = yaml_file
+            for extension in ('*.yaml', '*.yml'):
+                for yaml_file in glob.glob(os.path.join(self.prefix, yaml_dir, 'netplan', extension)):
+                    names_to_paths[os.path.basename(yaml_file)] = yaml_file
 
         files = [names_to_paths[name] for name in sorted(names_to_paths.keys())]
 

--- a/rpm/netplan.spec
+++ b/rpm/netplan.spec
@@ -65,10 +65,10 @@ Provides:       %{ubuntu_name} = %{version}-%{release}
 Provides:       %{ubuntu_name}%{?_isa} = %{version}-%{release}
 
 %description
-netplan reads network configuration from /etc/netplan/*.yaml which are written by administrators,
-installers, cloud image instantiations, or other OS deployments. During early boot, it generates
-backend specific configuration files in /run to hand off control of devices to a particular
-networking daemon.
+netplan reads network configuration from /etc/netplan/*.yaml and /etc/netplan/*.yml which are
+written by administrators, installers, cloud image instantiations, or other OS deployments.
+During early boot, it generates backend specific configuration files in /run to hand off
+control of devices to a particular networking daemon.
 
 Currently supported backends are systemd-networkd and NetworkManager.
 

--- a/tests/generator/test_common.py
+++ b/tests/generator/test_common.py
@@ -1224,8 +1224,8 @@ UseMTU=true
   version: 2
   ethernets: {enyellow: {dhcp4: true}}''')
 
-        # this should be considered
-        with open(os.path.join(libdir, 'd.yaml'), 'w') as f:
+        # YML files (not yAml) this should be considered as well
+        with open(os.path.join(libdir, 'd.yml'), 'w') as f:
             f.write('''network:
   version: 2
   ethernets: {enblue: {dhcp4: true}}''')
@@ -1241,4 +1241,3 @@ UseMTU=true
                               'enred.link': '[Match]\nOriginalName=enred\n\n[Link]\nWakeOnLan=magic\n',
                               'enyellow.network': ND_DHCP4 % 'enyellow',
                               'enblue.network': ND_DHCP4 % 'enblue'})
-


### PR DESCRIPTION
## Description
netplan currently only accepts *.yaml files.
However, it is quite common for YAML files to have a .yml file extension: https://en.wikipedia.org/wiki/YAML

A user with YAML knowledge, but no previous netplan experience, might simply create a `/etc/netplan/01-foobar.yml` config file, and then spend hours debugging why `netplan apply` doesn't pick up the changes described in this file.

This PR allows `*.yaml` and `*.yml` for all netplan config files in all three locations.
Since the filename (including extension) is different, the order & precedent behaviour does not change.

## Checklist

- [X] Runs `make check` successfully.
~~Retains 100% code coverage (`make check-coverage`).~~ (no, but I think thats because my test setup is not working properly...)~~
~~New/changed keys in YAML format are documented.~~ (no changes in this PR)
- [X] This PR will close https://bugs.launchpad.net/netplan/+bug/1815734

