### PR TITLE
tests/test_terminal.py: Ensure terminal state is restored at end of test

### DIFF
--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -58,8 +58,10 @@ class TestTerminal(unittest.TestCase):
         self.terminal.disable_nonblocking_io()
         self.assertNotEquals(flags, self.terminal.orig_flags)
         self.terminal.reset()
-        flags = self.terminal.orig_flags
+        flags = fcntl.fcntl(self.terminal.fd, fcntl.F_GETFL)
         self.assertEquals(flags, self.terminal.orig_flags)
+        self.terminal.disable_nonblocking_io()
+        self.terminal.save()
 
     def test_save_and_restore_with_dict(self):
         self.terminal.enable_nonblocking_io()
@@ -71,6 +73,7 @@ class TestTerminal(unittest.TestCase):
         self.terminal.reset(orig_settings)
         flags = fcntl.fcntl(self.terminal.fd, fcntl.F_GETFL)
         self.assertEquals(flags, orig_settings.get('flags'))
+        self.terminal.disable_nonblocking_io()
 
     def test_reset(self):
         self.terminal.enable_nonblocking_io()


### PR DESCRIPTION
test_save, test_save_and_restore_with_dict: Ensure that we restore the
terminal state at the end of each test, as other tests rely on a clean
state to start. Previously, the tests would work the first time but fail
if re-run.

test_save: also compare self.terminal.orig_flags to the current
terminal flags, as opposed to a copy of itself (which would always pass)

Fixes LP: #1817660

## Checklist

- [X] Runs `make check` successfully.
- [X] Retains 100% code coverage (`make check-coverage`).
- [N/A] New/changed keys in YAML format are documented.
- [X] \(Optional\) Closes an open bug in Launchpad.

