### PR TITLE
Deal with NM 1.15.2's addition of the .nmconnection extension

### DIFF
--- a/src/nm.c
+++ b/src/nm.c
@@ -576,18 +576,16 @@ write_nm_conf_access_point(net_definition* def, const char* rootdir, const wifi_
         g_string_append(s, "\n[ipv6]\nmethod=ignore\n");
     }
 
-    conf_path = g_strjoin(NULL, "run/NetworkManager/system-connections/netplan-", def->id, NULL);
-
     if (ap) {
         g_autofree char* escaped_ssid = g_uri_escape_string(ap->ssid, NULL, TRUE);
-        conf_path = g_strjoin(NULL, "run/NetworkManager/system-connections/netplan-", def->id, "-", escaped_ssid, NULL);
+        conf_path = g_strjoin(NULL, "run/NetworkManager/system-connections/netplan-", def->id, "-", escaped_ssid, ".nmconnection", NULL);
 
         g_string_append_printf(s, "\n[wifi]\nssid=%s\nmode=%s\n", ap->ssid, wifi_mode_str(ap->mode));
         if (ap->has_auth) {
             write_wifi_auth_parameters(&ap->auth, s);
         }
     } else {
-        conf_path = g_strjoin(NULL, "run/NetworkManager/system-connections/netplan-", def->id, NULL);
+        conf_path = g_strjoin(NULL, "run/NetworkManager/system-connections/netplan-", def->id, ".nmconnection", NULL);
         if (def->has_auth) {
             write_dot1x_auth_parameters(&def->auth, s);
         }

--- a/tests/generator/base.py
+++ b/tests/generator/base.py
@@ -150,9 +150,12 @@ class TestBase(unittest.TestCase):
         con_dir = os.path.join(self.workdir.name, 'run', 'NetworkManager', 'system-connections')
         if connections_map:
             self.assertEqual(set(os.listdir(con_dir)),
-                             set(['netplan-' + n for n in connections_map]))
+                             set(['netplan-' + n.split('.nmconnection')[0] + '.nmconnection' for n in connections_map]))
             for fname, contents in connections_map.items():
-                with open(os.path.join(con_dir, 'netplan-' + fname)) as f:
+                extension = ''
+                if '.nmconnection' not in fname:
+                    extension = '.nmconnection'
+                with open(os.path.join(con_dir, 'netplan-' + fname + extension)) as f:
                     self.assertEqual(f.read(), contents)
                     # NM connection files might contain secrets
                     self.assertEqual(stat.S_IMODE(os.fstat(f.fileno()).st_mode), 0o600)

--- a/tests/generator/test_bridges.py
+++ b/tests/generator/test_bridges.py
@@ -201,7 +201,7 @@ UseMTU=true
                                                      '[Network]\nLinkLocalAddressing=no\nBridge=br0\n'})
 
     @unittest.skipIf("CODECOV_TOKEN" in os.environ, "Skip on codecov.io: GLib changed hashtable sorting")
-    def test_eth_bridge_nm_blacklist(self):
+    def test_eth_bridge_nm_blacklist(self):  # pragma: nocover
         self.generate('''network:
   renderer: networkd
   ethernets:

--- a/tests/generator/test_common.py
+++ b/tests/generator/test_common.py
@@ -1101,7 +1101,7 @@ unmanaged-devices+=interface-name:engreen,''')
         # Skip on codecov.io; GLib changed hashtable elements ordering between
         # releases, so we can't depend on the exact order.
         # TODO: (cyphermox) turn this into an "assert_in_nm()" function.
-        if "CODECOV_TOKEN" not in os.environ:
+        if "CODECOV_TOKEN" not in os.environ:  # pragma: nocover
             self.assert_nm(None, '''[keyfile]
 # devices managed by networkd
 unmanaged-devices+=interface-name:engreen,interface-name:enblue,''')

--- a/tests/generator/test_vlans.py
+++ b/tests/generator/test_vlans.py
@@ -27,7 +27,7 @@ from .base import TestBase
 class TestNetworkd(TestBase):
 
     @unittest.skipIf("CODECOV_TOKEN" in os.environ, "Skipping on codecov.io: GLib changed hashtable elements order")
-    def test_vlan(self):
+    def test_vlan(self):  # pragma: nocover
         self.generate('''network:
   version: 2
   ethernets:

--- a/tests/generator/test_vlans.py
+++ b/tests/generator/test_vlans.py
@@ -183,7 +183,7 @@ method=auto
         self.assert_networkd({})
 
         # get assigned UUID  from en-v connection
-        with open(os.path.join(self.workdir.name, 'run/NetworkManager/system-connections/netplan-en-v')) as f:
+        with open(os.path.join(self.workdir.name, 'run/NetworkManager/system-connections/netplan-en-v.nmconnection')) as f:
             m = re.search('uuid=([0-9a-fA-F-]{36})\n', f.read())
             self.assertTrue(m)
             uuid = m.group(1)


### PR DESCRIPTION
## Description

Deal with changes in NM. Fix the tests so .nmconnection isn't mandatory when writing the tests.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [n/a] New/changed keys in YAML format are documented.
- [x] \(Optional\) Closes an open bug in Launchpad.

