### PR TITLE
Fix generation of hashed passwords for wired 802.1x 

### DIFF
--- a/src/networkd.c
+++ b/src/networkd.c
@@ -683,7 +683,7 @@ append_wpa_auth_conf(GString* s, const authentication_settings* auth)
             g_string_append_printf(s, "  psk=\"%s\"\n", auth->password);
         } else {
           if (strncmp(auth->password, "hash:",5) == 0) {
-            g_string_append_printf(s, "  password= %s\n", auth->password);
+            g_string_append_printf(s, "  password=%s\n", auth->password);
           } else {
             g_string_append_printf(s, "  password=\"%s\"\n", auth->password);
           }

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -682,7 +682,11 @@ append_wpa_auth_conf(GString* s, const authentication_settings* auth)
         if (auth->key_management == KEY_MANAGEMENT_WPA_PSK) {
             g_string_append_printf(s, "  psk=\"%s\"\n", auth->password);
         } else {
+          if (strncmp(auth->password, "hash:",5) == 0) {
+            g_string_append_printf(s, "  password= %s\n", auth->password);
+          } else {
             g_string_append_printf(s, "  password=\"%s\"\n", auth->password);
+          }
         }
     }
     if (auth->ca_certificate) {


### PR DESCRIPTION
## Description

Fixes https://bugs.launchpad.net/netplan/+bug/1819831

## Checklist

- [ X] Runs `make check` successfully.
- [ ] Retains 100% code coverage (`make check-coverage`).
- [ X] New/changed keys in YAML format are documented.
- [ X] \(Optional\) Closes an open bug in Launchpad.

