### PR TITLE
Add suport for WPA Wired driver for 802.1x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,7 @@ install: default
 	install -m 644 doc/*.5 $(DESTDIR)/$(MANDIR)/man5/
 	install -m 644 doc/*.8 $(DESTDIR)/$(MANDIR)/man8/
 	install -D -m 644 src/netplan-wpa@.service $(DESTDIR)/$(SYSTEMD_UNIT_DIR)/netplan-wpa@.service
+	install -D -m 644 src/netplan-wpa-wired@.service $(DESTDIR)/$(SYSTEMD_UNIT_DIR)/netplan-wpa-wired@.service
 	install -T -D -m 644 netplan.completions $(DESTDIR)/$(BASH_COMPLETIONS_DIR)/netplan
 
 %.html: %.md

--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -496,6 +496,9 @@ interfaces, as well as individual wifi networks, by means of the ``auth`` block.
      :    The EAP method to use. The supported EAP methods are ``tls`` (TLS),
           ``peap`` (Protected EAP), and ``ttls`` (Tunneled TLS).
 
+     ``wired`` (bool)
+     :    Indicates to use the wired WPA driver if true.
+
      ``identity`` (scalar)
      :    The identity to use for EAP.
 

--- a/examples/dhcp_wired8021x.yaml
+++ b/examples/dhcp_wired8021x.yaml
@@ -1,0 +1,12 @@
+network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    enp3s0:
+      dhcp4: true
+      auth:
+        key-management: 802.1x
+        wired: true
+        method: ttls
+        identity: fluffy@cisco.com
+        password: hash:83...11

--- a/src/netplan-wpa-wired@.service
+++ b/src/netplan-wpa-wired@.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=WPA supplicant for netplan %I
+DefaultDependencies=no
+Requires=sys-subsystem-net-devices-%i.device
+After=sys-subsystem-net-devices-%i.device
+Before=network.target
+Wants=network.target
+
+[Service]
+Type=simple
+ExecStart=/sbin/wpa_supplicant -c /run/netplan/wpa-%I.conf -i%I -Dwired

--- a/src/parse.c
+++ b/src/parse.c
@@ -625,6 +625,33 @@ handle_auth_str(yaml_document_t* doc, yaml_node_t* node, const void* data, GErro
     return TRUE;
 }
 
+/**
+ * Generic handler for setting a cur_netdef gboolean field from a scalar node
+ * @data: offset into net_definition where the gboolean field to write is located
+ */
+static gboolean
+handle_auth_bool(yaml_document_t* doc, yaml_node_t* node, const void* data, GError** error)
+{
+    guint offset = GPOINTER_TO_UINT(data);
+    gboolean v;
+
+    if (g_ascii_strcasecmp(scalar(node), "true") == 0 ||
+        g_ascii_strcasecmp(scalar(node), "on") == 0 ||
+        g_ascii_strcasecmp(scalar(node), "yes") == 0 ||
+        g_ascii_strcasecmp(scalar(node), "y") == 0)
+        v = TRUE;
+    else if (g_ascii_strcasecmp(scalar(node), "false") == 0 ||
+        g_ascii_strcasecmp(scalar(node), "off") == 0 ||
+        g_ascii_strcasecmp(scalar(node), "no") == 0 ||
+        g_ascii_strcasecmp(scalar(node), "n") == 0)
+        v = FALSE;
+    else
+        return yaml_error(node, error, "invalid boolean value '%s'", scalar(node));
+
+    *((gboolean*) ((void*) cur_auth + offset)) = v;
+    return TRUE;
+}
+
 static gboolean
 handle_auth_key_management(yaml_document_t* doc, yaml_node_t* node, const void* _, GError** error)
 {
@@ -667,6 +694,7 @@ const mapping_entry_handler auth_handlers[] = {
     {"client-certificate", YAML_SCALAR_NODE, handle_auth_str, NULL, auth_offset(client_certificate)},
     {"client-key", YAML_SCALAR_NODE, handle_auth_str, NULL, auth_offset(client_key)},
     {"client-key-password", YAML_SCALAR_NODE, handle_auth_str, NULL, auth_offset(client_key_password)},
+    {"wired", YAML_SCALAR_NODE, handle_auth_bool, NULL, auth_offset(wired)},
     {NULL}
 };
 

--- a/src/parse.h
+++ b/src/parse.h
@@ -140,6 +140,7 @@ typedef struct authentication_settings {
     char* client_certificate;
     char* client_key;
     char* client_key_password;
+    gboolean wired;
 } authentication_settings;
 
 /* Fields below are valid for dhcp4 and dhcp6 unless otherwise noted. */


### PR DESCRIPTION
## Description

To use 802.1x on a wired interface, there needs to be a way to specify to use the wired driver. This adds a new Boolean flag to support that. 


## Checklist

- [ x] Runs `make check` successfully.
- [ ] Retains 100% code coverage (`make check-coverage`).
- [ x] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Closes an open bug in Launchpad.

