### PR TITLE
Wireguard

### DIFF
--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -797,7 +797,8 @@ more general information about tunnels.
 
 :   Defines the tunnel mode. Valid options are ``sit``, ``gre``, ``ip6gre``,
     ``ipip``, ``ipip6``, ``ip6ip6``, ``vti``, and ``vti6``. Additionally,
-    the ``networkd`` backend also supports ``gretap`` and ``ip6gretap`` modes.
+    the ``networkd`` backend also supports ``gretap``, ``ip6gretap``, ``wireguard``
+    and ``l2tp`` modes.
     In addition, the ``NetworkManager`` backend supports ``isatap`` tunnels.
 
 ``local`` (scalar)
@@ -847,6 +848,86 @@ Examples:
 ``keys`` (scalar or mapping)
 
 :   Alternate name for the ``key`` field. See above.
+
+Wireguard-specific keys:
+
+    ``private_key`` (scalar)
+    :   Base64-encoded private key. Either this or ``private_key_file`` is required.
+
+    ``private_key_file`` (scalar)
+    :   Path to a file with the private key. If the file is readable, the ``private_key`` is ignored.
+
+    ``fwmark`` (scalar)
+    :   Firewall mark for outgoing WireGuard packets from this interface, optional.
+
+    ``listen_port``
+    :   UDP port to listen at or 'auto'. Optional, defaults to 'auto'.
+
+    ``public_key`` (scalar)
+    :   Peer's base64-encoded public key, required.
+
+    ``preshared_key`` (scalar)
+    :   Optional preshared key for the interface.
+
+    ``endpoint`` (scalar)
+    :   Endpoint IP address, followed by a colon, and then a port number.
+
+    ``allowed_ips`` (sequence of scalars)
+    :    A list of IP (v4 or v6) addresses with CIDR masks from which
+         this peer is allowed to send incoming traffic and to which outgoing traffic for this
+         peer is directed. The catch-all 0.0.0.0/0 may be specified for matching all IPv4
+         addresses, and ::/0 may be specified for matching all IPv6 addresses.
+
+    ``keepalive`` (scalar)
+    :    An interval in seconds, between 1 and 65535 inclusive, of how often to send an
+         authenticated empty packet to the peer for the purpose of keeping a stateful firewall
+         or NAT mapping valid persistently. Optional.
+
+
+L2TP-specific keys:
+    ``local_ip`` (scalar)
+    :    The IP address of the local interface. Takes an IP address, or the special
+         values "auto", "static", or "dynamic". When an address is set, then the local
+         interface must have the address. If "auto", then one of the addresses on the local
+         interface is used. Similarly, if "static" or "dynamic" is set, then one of the static
+         or dynamic addresses on the local interface is used. Defaults to "auto".
+
+    ``peer_tunnel_id`` (scalar)
+    :    Peer tunnel id, required.
+
+    ``local_tunnel_id`` (scalar)
+    :    Local tunnel id, required.
+
+    ``encapsulation_type`` (scalar)
+    :    The encapsulation type of the tunnel. "udp" or "ip".
+
+    ``udp_source_port`` (scalar)
+    :    The UDP source port. Required for udp encapsulation type.
+
+    ``udp_destination_port`` (scalar)
+    :    The UDP destination port. Required for udp encapsulation type.
+
+    ``udp_checksum`` (scalar)
+    :     When true, specifies if UDP checksum is calculated for transmitted packets over IPv4.
+
+    ``udp6_checksum_tx`` (scalar)
+    :     When false, skip UDP checksum calculation for transmitted packets over IPv6.
+
+    ``udp6_checksum_rx`` (scalar)
+    :     When false, skip UDP checksum calculation for received packets over IPv6.
+
+    ``session_name`` (scalar)
+    :     Session name, required.
+
+    ``session_id`` (scalar)
+    :     Local session id, required.
+
+    ``peer_session_id`` (scalar)
+    :     Peer session id, required.
+
+    ``l2_specific_header`` (scalar)
+    :      layer2specific header type of the session. One of "none" or "default".
+           Defaults to "default".
 
 
 ## Properties for device type ``vlans:``

--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -941,6 +941,11 @@ L2TP-specific keys:
 :    netplan ID of the underlying device definition on which this VLAN gets
      created.
 
+## Properties for device type ``dummies:``
+
+    None.
+
+
 Example:
 
     ethernets:

--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -870,7 +870,7 @@ Wireguard-specific keys:
     :   Optional preshared key for the interface.
 
     ``endpoint`` (scalar)
-    :   Endpoint IP address, followed by a colon, and then a port number.
+    :   Endpoint IPv4/IPv6 address or a hostname, followed by a colon, and then a port number.
 
     ``allowed_ips`` (sequence of scalars)
     :    A list of IP (v4 or v6) addresses with CIDR masks from which

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -360,6 +360,10 @@ write_netdev_file(net_definition* def, const char* rootdir, const char* path)
             g_string_append_printf(s, "Kind=vlan\n\n[VLAN]\nId=%u\n", def->vlan_id);
             break;
 
+        case ND_DUMMY:
+            g_string_append_printf(s, "Kind=dummy\n");
+            break;
+
         case ND_TUNNEL:
             switch(def->tunnel.mode) {
                 case TUNNEL_MODE_GRE:

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -153,8 +153,8 @@ write_wireguard_params(GString* s, net_definition* def)
 
     if (def->wireguard.keepalive)
         g_string_append_printf(peer, "PersistentKeepalive=%d\n", def->wireguard.keepalive);
-    if (def->wireguard.endpoint)
-        g_string_append_printf(peer, "Endpoint=%s\n", def->wireguard.endpoint);
+    if (def->tunnel.remote_ip)
+        g_string_append_printf(peer, "Endpoint=%s\n", def->tunnel.remote_ip);
     if (def->wireguard.preshared_key)
         g_string_append_printf(peer, "PresharedKey=%s\n", def->wireguard.preshared_key);
 
@@ -172,7 +172,8 @@ write_l2tp_params(GString* s, net_definition* def)
 
     g_string_append_printf(params, "TunnelId=%u\n", def->l2tp.local_tunnel_id);
     g_string_append_printf(params, "PeerTunnelId=%u\n", def->l2tp.peer_tunnel_id);
-    g_string_append_printf(params, "Local=%s\n", def->l2tp.local_ip);
+    if (def->tunnel.local_ip)
+        g_string_append_printf(params, "Local=%s\n", def->tunnel.local_ip);
     g_string_append_printf(params, "Remote=%s\n", def->tunnel.remote_ip);
     if (def->l2tp.encapsulation_type) {
         g_string_append_printf(params, "EncapsulationType=%s\n", def->l2tp.encapsulation_type);

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -132,7 +132,7 @@ write_wireguard_params(GString* s, net_definition* def)
     if (def->wireguard.private_key_file)
         g_string_append_printf(params, "PrivateKeyFile=%s\n", def->wireguard.private_key_file);
     if (def->wireguard.listen_port)
-        g_string_append_printf(params, "Listen=%u\n", def->wireguard.listen_port);
+        g_string_append_printf(params, "ListenPort=%u\n", def->wireguard.listen_port);
     if (def->wireguard.fwmark)
         g_string_append_printf(params, "FWMark=%u\n", def->wireguard.fwmark);
 

--- a/src/nm.c
+++ b/src/nm.c
@@ -86,6 +86,8 @@ type_str(netdef_type type)
             return "bond";
         case ND_VLAN:
             return "vlan";
+        case ND_DUMMY:
+            return "dummy";
         case ND_TUNNEL:
             return "ip-tunnel";
         // LCOV_EXCL_START

--- a/src/parse.c
+++ b/src/parse.c
@@ -569,7 +569,7 @@ validate_address(const gchar *address, int permitted, int required, const gchar*
     if (restype)
         *restype = 0; /* means a parse error */
 
-    int por = permitted | required;
+    permitted = permitted | required;
 
     /* it it can be NULL, let it be, otherwise don't. */
     if (address == NULL) {
@@ -579,7 +579,7 @@ validate_address(const gchar *address, int permitted, int required, const gchar*
     }
 
     /* keep some sanity */
-    g_assert(!((por & ADDR_HAS_PREFIX) && (por & ADDR_HAS_PORT)));
+    g_assert(!((permitted & ADDR_HAS_PREFIX) && (permitted & ADDR_HAS_PORT)));
 
     /* check if it's a keyword before everything else */
     int i = 0;
@@ -890,7 +890,7 @@ handle_addresses(yaml_document_t* doc, yaml_node_t* node, const void* _, GError*
         assert_type(entry, YAML_SCALAR_NODE);
         int addr_type;
 
-        if (validate_address(scalar(entry), ADDR_IS_IPV4 | ADDR_IS_IPV6 | ADDR_HAS_PREFIX, ADDR_HAS_PREFIX, NULL, &addr_type)) {
+        if (validate_address(scalar(entry), ADDR_IS_IPV4 | ADDR_IS_IPV6, ADDR_HAS_PREFIX, NULL, &addr_type)) {
             if (addr_type & ADDR_IS_IPV4) {
                 if (!cur_netdef->ip4_addresses)
                     cur_netdef->ip4_addresses = g_array_new(FALSE, FALSE, sizeof(char*));
@@ -1724,7 +1724,7 @@ handle_wireguard_allowed_ips(yaml_document_t* doc, yaml_node_t* node, const void
         yaml_node_t *entry = yaml_document_get_node(doc, *i);
         assert_type(entry, YAML_SCALAR_NODE);
 
-        if (validate_address(scalar(entry), ADDR_IS_IPV4 | ADDR_IS_IPV6 | ADDR_HAS_PREFIX, ADDR_HAS_PREFIX, NULL, NULL)) {
+        if (validate_address(scalar(entry), ADDR_IS_IPV4 | ADDR_IS_IPV6, ADDR_HAS_PREFIX, NULL, NULL)) {
             if (!cur_netdef->wireguard.allowed_ips)
                 cur_netdef->wireguard.allowed_ips = g_array_new(FALSE, FALSE, sizeof(char*));
             char* s = g_strdup(scalar(entry));
@@ -2025,7 +2025,7 @@ validate_tunnel(net_definition* nd, yaml_node_t* node, GError** error)
                 return yaml_error(node, error, "%s: 'remote' must be a valid IPv6 address without prefix for this tunnel type", nd->id);
             break;
         case TUNNEL_MODE_WIREGUARD:
-            if (!validate_address(nd->tunnel.remote_ip, ADDR_IS_IPV4 | ADDR_IS_IPV6 | ADDR_IS_HOSTNAME | ADDR_HAS_PORT,
+            if (!validate_address(nd->tunnel.remote_ip, ADDR_IS_IPV4 | ADDR_IS_IPV6 | ADDR_IS_HOSTNAME,
                                     ADDR_IS_OPTIONAL | ADDR_HAS_PORT, NULL, NULL))
                 return yaml_error(node, error, "%s: 'remote' must be a valid IPv6 or IPv6 address without prefix"
                                     " or a hostname with port for this tunnel type", nd->id);

--- a/src/parse.c
+++ b/src/parse.c
@@ -1883,12 +1883,10 @@ validate_address(const gchar *address, int permitted, int required, const gchar*
             has_port = TRUE;
         }
     }
-printf("per=%x req=%x addr=%s \n has_port=%d has_prefix=%d expect_ip6=%d\n", permitted, required, addr, has_port, has_prefix, expect_ip6);
     is_ip4 = is_ip4_address(addr);
     is_ip6 = is_ip6_address(addr);
     is_host_name = is_ip4 ? FALSE : is_hostname(addr);
 
-printf("ip4=%d ip6=%d\n", is_ip4, is_ip6);
     if (expect_ip6 && !is_ip6)
         return FALSE;
 

--- a/src/parse.c
+++ b/src/parse.c
@@ -575,7 +575,7 @@ validate_address(const gchar *address, int permitted, int required, const gchar*
     if (address == NULL) {
         if (restype)
             *restype = ADDR_IS_OPTIONAL;
-        return required & ADDR_IS_OPTIONAL;
+        return permitted & ADDR_IS_OPTIONAL;
     }
 
     /* keep some sanity */
@@ -2032,7 +2032,7 @@ validate_tunnel(net_definition* nd, yaml_node_t* node, GError** error)
             /* local_ip is not used in wireguard */
             break;
         case TUNNEL_MODE_L2TP:
-            if (!validate_address(nd->tunnel.local_ip, ADDR_IS_IPV4 | ADDR_IS_IPV6, ADDR_IS_OPTIONAL, L2TP_LOCAL_KEYWORDS, NULL))
+            if (!validate_address(nd->tunnel.local_ip, ADDR_IS_IPV4 | ADDR_IS_IPV6 | ADDR_IS_OPTIONAL, 0, L2TP_LOCAL_KEYWORDS, NULL))
                 return yaml_error(node, error, "%s: 'local' must be a valid IPv4 or IPv6 address without prefix, or "
                                                " one of 'auto', 'static' or 'dynamic' for this tunnel type", nd->id);
             if (!validate_address(nd->tunnel.remote_ip, ADDR_IS_IPV4 | ADDR_IS_IPV6, 0, NULL, NULL))

--- a/src/parse.c
+++ b/src/parse.c
@@ -603,6 +603,9 @@ validate_address(const gchar *address, int permitted, int required, const gchar*
         has_port = FALSE;
         *prefix_len = '\0';
         prefix_len++; /* skip former '/' into first char of prefix */
+        if (strlen(prefix_len) == 0)
+            return FALSE;
+
         prefix_len_num = g_ascii_strtoull(prefix_len, NULL, 10);
     } else {
         last_bracket = strchr(addr, ']');
@@ -651,8 +654,6 @@ validate_address(const gchar *address, int permitted, int required, const gchar*
 
     /* validate prefix */
     if (has_prefix) {
-        if (prefix_len_num == 0)
-            return FALSE;
         if (is_ip4 && prefix_len_num > 32)
             return FALSE;
         if (is_ip6 && prefix_len_num > 128)
@@ -1244,7 +1245,6 @@ handle_ip_rule_ip(yaml_document_t* doc, yaml_node_t* node, const void* data, GEr
         *dest = g_strdup(scalar(node));
         return TRUE;
     }
-
     return yaml_error(node, error, "invalid IP address in route to %s", scalar(node));
 }
 

--- a/src/parse.c
+++ b/src/parse.c
@@ -1912,8 +1912,12 @@ validate_tunnel(net_definition* nd, yaml_node_t* node, GError** error)
                                     g_ascii_strup(tunnel_mode_to_string(nd->tunnel.mode), -1));
                     break;
                 case TUNNEL_MODE_WIREGUARD:
-                    if (!nd->wireguard.private_key && !nd->wireguard.private_key_file)
-                        return yaml_error(node, error, "%s: private_key or private_key_file is required.", nd->id);
+                    if (!nd->wireguard.private_key) {
+                        if (0 && !nd->wireguard.private_key_file) /* private_key_file since systemd 76df7779 */
+                            return yaml_error(node, error, "%s: private_key or private_key_file is required.", nd->id);
+                        else
+                            return yaml_error(node, error, "%s: private_key is required.", nd->id);
+                    }
                     if (!nd->wireguard.public_key)
                         return yaml_error(node, error, "%s: public_key is required.", nd->id);
                     if (!nd->wireguard.allowed_ips)

--- a/src/parse.c
+++ b/src/parse.c
@@ -1206,7 +1206,7 @@ handle_routes_ip(yaml_document_t* doc, yaml_node_t* node, const void* data, GErr
     char** dest = (char**) ((void*) cur_route + offset);
     g_free(*dest);
 
-    if (validate_address(scalar(node), ADDR_IS_IPV4 | ADDR_IS_IPV6, 0, NULL, &addr_type)) {
+    if (validate_address(scalar(node), ADDR_IS_IPV4 | ADDR_IS_IPV6 | ADDR_HAS_PREFIX, 0, NULL, &addr_type)) {
         if (addr_type & ADDR_IS_IPV4)
             family = AF_INET;
 
@@ -1231,7 +1231,7 @@ handle_ip_rule_ip(yaml_document_t* doc, yaml_node_t* node, const void* data, GEr
     char** dest = (char**) ((void*) cur_ip_rule + offset);
     g_free(*dest);
 
-    if (validate_address(scalar(node), ADDR_IS_IPV4 | ADDR_IS_IPV6, 0, NULL, &addr_type)) {
+    if (validate_address(scalar(node), ADDR_IS_IPV4 | ADDR_IS_IPV6 | ADDR_HAS_PREFIX, 0, NULL, &addr_type)) {
         if (addr_type & ADDR_IS_IPV4)
             family = AF_INET;
 

--- a/src/parse.c
+++ b/src/parse.c
@@ -651,6 +651,8 @@ validate_address(const gchar *address, int permitted, int required, const gchar*
 
     /* validate prefix */
     if (has_prefix) {
+        if (prefix_len_num == 0)
+            return FALSE;
         if (is_ip4 && prefix_len_num > 32)
             return FALSE;
         if (is_ip6 && prefix_len_num > 128)
@@ -884,45 +886,26 @@ static gboolean
 handle_addresses(yaml_document_t* doc, yaml_node_t* node, const void* _, GError** error)
 {
     for (yaml_node_item_t *i = node->data.sequence.items.start; i < node->data.sequence.items.top; i++) {
-        g_autofree char* addr = NULL;
-        char* prefix_len;
-        guint64 prefix_len_num;
         yaml_node_t *entry = yaml_document_get_node(doc, *i);
         assert_type(entry, YAML_SCALAR_NODE);
+        int addr_type;
 
-        /* split off /prefix_len */
-        addr = g_strdup(scalar(entry));
-        prefix_len = strrchr(addr, '/');
-        if (!prefix_len)
-            return yaml_error(node, error, "address '%s' is missing /prefixlength", scalar(entry));
-        *prefix_len = '\0';
-        prefix_len++; /* skip former '/' into first char of prefix */
-        prefix_len_num = g_ascii_strtoull(prefix_len, NULL, 10);
-
-        /* is it an IPv4 address? */
-        if (is_ip4_address(addr)) {
-            if (prefix_len_num == 0 || prefix_len_num > 32)
-                return yaml_error(node, error, "invalid prefix length in address '%s'", scalar(entry));
-
-            if (!cur_netdef->ip4_addresses)
-                cur_netdef->ip4_addresses = g_array_new(FALSE, FALSE, sizeof(char*));
-            char* s = g_strdup(scalar(entry));
-            g_array_append_val(cur_netdef->ip4_addresses, s);
-            continue;
+        if (validate_address(scalar(entry), ADDR_IS_IPV4 | ADDR_IS_IPV6 | ADDR_HAS_PREFIX, ADDR_HAS_PREFIX, NULL, &addr_type)) {
+            if (addr_type & ADDR_IS_IPV4) {
+                if (!cur_netdef->ip4_addresses)
+                    cur_netdef->ip4_addresses = g_array_new(FALSE, FALSE, sizeof(char*));
+                char* s = g_strdup(scalar(entry));
+                g_array_append_val(cur_netdef->ip4_addresses, s);
+            }
+            if (addr_type & ADDR_IS_IPV6) {
+                if (!cur_netdef->ip6_addresses)
+                    cur_netdef->ip6_addresses = g_array_new(FALSE, FALSE, sizeof(char*));
+                char* s = g_strdup(scalar(entry));
+                g_array_append_val(cur_netdef->ip6_addresses, s);
+            }
+        } else {
+            return yaml_error(node, error, "malformed address '%s', must be X.X.X.X/NN or X:X:X:X:X:X:X:X/NN", scalar(entry));
         }
-
-        /* is it an IPv6 address? */
-        if (is_ip6_address(addr)) {
-            if (prefix_len_num == 0 || prefix_len_num > 128)
-                return yaml_error(node, error, "invalid prefix length in address '%s'", scalar(entry));
-            if (!cur_netdef->ip6_addresses)
-                cur_netdef->ip6_addresses = g_array_new(FALSE, FALSE, sizeof(char*));
-            char* s = g_strdup(scalar(entry));
-            g_array_append_val(cur_netdef->ip6_addresses, s);
-            continue;
-        }
-
-        return yaml_error(node, error, "malformed address '%s', must be X.X.X.X/NN or X:X:X:X:X:X:X:X/NN", scalar(entry));
     }
 
     return TRUE;

--- a/src/parse.c
+++ b/src/parse.c
@@ -1917,12 +1917,8 @@ validate_tunnel(net_definition* nd, yaml_node_t* node, GError** error)
                                     g_ascii_strup(tunnel_mode_to_string(nd->tunnel.mode), -1));
                     break;
                 case TUNNEL_MODE_WIREGUARD:
-                    if (!nd->wireguard.private_key) {
-                        if (0 && !nd->wireguard.private_key_file) /* private_key_file since systemd 76df7779 */
-                            return yaml_error(node, error, "%s: private_key or private_key_file is required.", nd->id);
-                        else
-                            return yaml_error(node, error, "%s: private_key is required.", nd->id);
-                    }
+                    if (!nd->wireguard.private_key && !nd->wireguard.private_key_file) /* private_key_file since systemd 76df7779 */
+                        return yaml_error(node, error, "%s: private_key or private_key_file is required.", nd->id);
                     if (!nd->wireguard.public_key)
                         return yaml_error(node, error, "%s: public_key is required.", nd->id);
                     if (!nd->wireguard.allowed_ips)

--- a/src/parse.c
+++ b/src/parse.c
@@ -1826,6 +1826,11 @@ const mapping_entry_handler vlan_def_handlers[] = {
     {NULL}
 };
 
+const mapping_entry_handler dummy_def_handlers[] = {
+    COMMON_LINK_HANDLERS,
+    {NULL}
+};
+
 const mapping_entry_handler tunnel_def_handlers[] = {
     COMMON_LINK_HANDLERS,
     {"mode", YAML_SCALAR_NODE, handle_tunnel_mode},
@@ -2176,6 +2181,7 @@ handle_network_type(yaml_document_t* doc, yaml_node_t* node, const void* data, G
             case ND_TUNNEL: handlers = tunnel_def_handlers; break;
             case ND_VLAN: handlers = vlan_def_handlers; break;
             case ND_WIFI: handlers = wifi_def_handlers; break;
+            case ND_DUMMY: handlers = dummy_def_handlers; break;
             default: g_assert_not_reached(); // LCOV_EXCL_LINE
         }
         if (!process_mapping(doc, value, handlers, error))
@@ -2203,6 +2209,7 @@ const mapping_entry_handler network_handlers[] = {
     {"version", YAML_SCALAR_NODE, handle_network_version},
     {"vlans", YAML_MAPPING_NODE, handle_network_type, NULL, GUINT_TO_POINTER(ND_VLAN)},
     {"wifis", YAML_MAPPING_NODE, handle_network_type, NULL, GUINT_TO_POINTER(ND_WIFI)},
+    {"dummies", YAML_MAPPING_NODE, handle_network_type, NULL, GUINT_TO_POINTER(ND_DUMMY)},
     {NULL}
 };
 

--- a/src/parse.c
+++ b/src/parse.c
@@ -1049,23 +1049,24 @@ handle_nameservers_addresses(yaml_document_t* doc, yaml_node_t* node, const void
     for (yaml_node_item_t *i = node->data.sequence.items.start; i < node->data.sequence.items.top; i++) {
         yaml_node_t *entry = yaml_document_get_node(doc, *i);
         assert_type(entry, YAML_SCALAR_NODE);
+        int addr_type;
 
-        /* is it an IPv4 address? */
-        if (is_ip4_address(scalar(entry))) {
-            if (!cur_netdef->ip4_nameservers)
-                cur_netdef->ip4_nameservers = g_array_new(FALSE, FALSE, sizeof(char*));
-            char* s = g_strdup(scalar(entry));
-            g_array_append_val(cur_netdef->ip4_nameservers, s);
-            continue;
-        }
+        if (validate_address(scalar(entry), ADDR_IS_IPV4 | ADDR_IS_IPV6, 0, NULL, &addr_type)) {
+            if (addr_type & ADDR_IS_IPV4) {
+                if (!cur_netdef->ip4_nameservers)
+                    cur_netdef->ip4_nameservers = g_array_new(FALSE, FALSE, sizeof(char*));
+                char* s = g_strdup(scalar(entry));
+                g_array_append_val(cur_netdef->ip4_nameservers, s);
+                continue;
+            }
 
-        /* is it an IPv6 address? */
-        if (is_ip6_address(scalar(entry))) {
-            if (!cur_netdef->ip6_nameservers)
-                cur_netdef->ip6_nameservers = g_array_new(FALSE, FALSE, sizeof(char*));
-            char* s = g_strdup(scalar(entry));
-            g_array_append_val(cur_netdef->ip6_nameservers, s);
-            continue;
+            if (addr_type & ADDR_IS_IPV6) {
+                if (!cur_netdef->ip6_nameservers)
+                    cur_netdef->ip6_nameservers = g_array_new(FALSE, FALSE, sizeof(char*));
+                char* s = g_strdup(scalar(entry));
+                g_array_append_val(cur_netdef->ip6_nameservers, s);
+                continue;
+            }
         }
 
         return yaml_error(node, error, "malformed address '%s', must be X.X.X.X or X:X:X:X:X:X:X:X", scalar(entry));

--- a/src/parse.h
+++ b/src/parse.h
@@ -84,6 +84,8 @@ typedef enum {
     TUNNEL_MODE_GRETAP      = 101,
     TUNNEL_MODE_IP6GRETAP   = 102,
 
+    TUNNEL_MODE_WIREGUARD   = 103,
+    TUNNEL_MODE_L2TP        = 104,
     _TUNNEL_MODE_MAX,
 } tunnel_mode;
 
@@ -102,6 +104,8 @@ tunnel_mode_table[_TUNNEL_MODE_MAX] = {
 
     [TUNNEL_MODE_GRETAP] = "gretap",
     [TUNNEL_MODE_IP6GRETAP] = "ip6gretap",
+    [TUNNEL_MODE_WIREGUARD] = "wireguard",
+    [TUNNEL_MODE_L2TP] = "l2tp",
 };
 
 struct optional_address_option {
@@ -262,6 +266,40 @@ typedef struct net_definition {
         char *input_key;
         char *output_key;
     } tunnel;
+
+    struct {
+        /* wireguard */
+        char *private_key;
+        char *private_key_file;
+        guint fwmark;
+        guint listen_port;
+
+        /* wireguard peer */
+        char *public_key;
+        char *preshared_key;
+        char *endpoint;
+        GArray *allowed_ips;
+        guint keepalive;
+    } wireguard;
+
+    struct {
+        /* l2tp */
+        char *local_ip;
+        guint peer_tunnel_id;
+        guint local_tunnel_id;
+        char *encapsulation_type;
+        guint udp_source_port;
+        guint udp_destination_port;
+        gboolean udp_checksum;
+        gboolean udp6_checksum_tx;
+        gboolean udp6_checksum_rx;
+
+        /* l2tp session */
+        char *session_name;
+        guint session_id;
+        guint peer_session_id;
+        char *l2_specific_header;
+    } l2tp;
 
     authentication_settings auth;
     gboolean has_auth;

--- a/src/parse.h
+++ b/src/parse.h
@@ -277,14 +277,12 @@ typedef struct net_definition {
         /* wireguard peer */
         char *public_key;
         char *preshared_key;
-        char *endpoint;
         GArray *allowed_ips;
         guint keepalive;
     } wireguard;
 
     struct {
         /* l2tp */
-        char *local_ip;
         guint peer_tunnel_id;
         guint local_tunnel_id;
         char *encapsulation_type;

--- a/src/parse.h
+++ b/src/parse.h
@@ -34,6 +34,7 @@ typedef enum {
     ND_BRIDGE = ND_VIRTUAL,
     ND_BOND,
     ND_VLAN,
+    ND_DUMMY,
     ND_TUNNEL,
 } netdef_type;
 


### PR DESCRIPTION
## Description
preliminary.
add wireguard and l2tp support.

questions: 
  - is it a good idea to put them into tunnels section at all
  - l2tp has interesting format for local_ip, so what should  be done:
     - new keyword, not use existing local (as is done now)
     - reuse local, change its parser
  - wireguard has (optional) endpoint, should the remote key be reused for that?
  - coverage does not exclude glib, the results are useless (bionic). any tips?

## Checklist

- [ x] Runs `make check` successfully.
- [ ] Retains 100% code coverage (`make check-coverage`).
- [ x] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Closes an open bug in Launchpad.

