### PR TITLE
nm: support route attributes "from", "onlink", and "table" and "match.interface-name"

### DIFF
--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -89,8 +89,8 @@ Virtual devices
      :   Current interface name. Globs are supported, and the primary use case
          for matching on names, as selecting one fixed name can be more easily
          achieved with having no ``match:`` at all and just using the ID (see
-         above). Note that currently only networkd supports globbing,
-         NetworkManager does not.
+         above).
+         (``NetworkManager``: as of v1.14.0)
 
      ``macaddress`` (scalar)
      :   Device's MAC address in the form "XX:XX:XX:XX:XX:XX". Globs are not
@@ -440,6 +440,7 @@ These options are available for all types of interfaces.
 
      ``from`` (scalar)
      :    Set a source IP address for traffic going through the route.
+          (``NetworkManager``: as of v1.8.0)
 
      ``to`` (scalar)
      :    Destination address for the route.
@@ -450,6 +451,7 @@ These options are available for all types of interfaces.
      ``on-link`` (bool)
      :    When set to "true", specifies that the route is directly connected
           to the interface.
+          (``NetworkManager``: as of v1.12.0 for IPv4 and v1.18.0 for IPv6)
 
      ``metric`` (scalar)
      :    The relative priority of the route. Must be a positive integer value.
@@ -460,7 +462,8 @@ These options are available for all types of interfaces.
 
      ``scope`` (scalar)
      :    The route scope, how wide-ranging it is to the network. Possible
-          values are "global", "link", or "host".
+          values are "global", "link", or "host". ``NetworkManager`` does
+          not support setting a scope.
 
      ``table`` (scalar)
      :    The table number to use for the route. In some scenarios, it may be
@@ -469,6 +472,7 @@ These options are available for all types of interfaces.
           parameter. Allowed values are positive integers starting from 1.
           Some values are already in use to refer to specific routing tables:
           see ``/etc/iproute2/rt_tables``.
+          (``NetworkManager``: as of v1.10.0)
 
 ``routing-policy`` (mapping)
 
@@ -1142,7 +1146,6 @@ This is a complex example which shows most available features:
         switchports:
           # all cards on second PCI bus unconfigured by
           # themselves, will be added to br0 below
-          # note: globbing is not supported by NetworkManager
           match:
             name: enp2*
           mtu: 1280

--- a/src/nm.c
+++ b/src/nm.c
@@ -205,8 +205,7 @@ write_routes(const NetplanNetDefinition* def, GString *s, int family)
                 /* For IPv6 addresses, kernel and NetworkManager don't support a scope.
                  * For IPv4 addresses, NetworkManager determines the scope of addresses on its own
                  * ("link" for addresses without gateway, "global" for addresses with next-hop). */
-                g_fprintf(stderr, "ERROR: %s: NetworkManager does not support setting a scope for routes\n", def->id);
-                exit(1);
+                g_fprintf(stderr, "WARNING: %s: NetworkManager does not support setting a scope for routes\n", def->id);
             }
 
             g_string_append_printf(s, "route%d=%s,%s",

--- a/src/nm.c
+++ b/src/nm.c
@@ -224,12 +224,12 @@ write_routes(const NetplanNetDefinition* def, GString *s, int family)
                 g_string_append_printf(s, "route%d_options=", j);
                 if (cur_route->onlink) {
                     /* onlink for IPv6 addresses is only supported since nm-1.18.0. */
-                    g_string_append_printf(s, "onlink=true ");
+                    g_string_append_printf(s, "onlink=true,");
                 }
                 if (cur_route->table != NETPLAN_ROUTE_TABLE_UNSPEC)
-                    g_string_append_printf(s, "table=%u ", cur_route->table);
+                    g_string_append_printf(s, "table=%u,", cur_route->table);
                 if (cur_route->from)
-                    g_string_append_printf(s, "from=%s ", cur_route->from);
+                    g_string_append_printf(s, "src=%s,", cur_route->from);
                 s->str[s->len - 1] = '\n';
             }
             j++;

--- a/src/nm.c
+++ b/src/nm.c
@@ -201,11 +201,15 @@ write_routes(const NetplanNetDefinition* def, GString *s, int family)
                 exit(1);
             }
 
-            if (cur_route->scope) {
+            if (!g_strcmp0(cur_route->scope, "global")) {
                 /* For IPv6 addresses, kernel and NetworkManager don't support a scope.
                  * For IPv4 addresses, NetworkManager determines the scope of addresses on its own
                  * ("link" for addresses without gateway, "global" for addresses with next-hop). */
-                g_fprintf(stderr, "WARNING: %s: NetworkManager does not support setting a scope for routes\n", def->id);
+                g_debug("%s: NetworkManager does not support setting a scope for routes, it will auto-detect them.", def->id);
+            } else if (cur_route->scope) {
+                /* Error out if scope is not set to its default value of 'global' */
+                g_fprintf(stderr, "ERROR: %s: NetworkManager does not support setting a scope for routes\n", def->id);
+                exit(1);
             }
 
             g_string_append_printf(s, "route%d=%s,%s",

--- a/src/nm.c
+++ b/src/nm.c
@@ -201,23 +201,11 @@ write_routes(const NetplanNetDefinition* def, GString *s, int family)
                 exit(1);
             }
 
-            if (cur_route->scope && g_ascii_strcasecmp(cur_route->scope, "global") != 0) {
-                g_fprintf(stderr, "ERROR: %s: NetworkManager only supports global scoped routes\n", def->id);
-                exit(1);
-            }
-
-            if (cur_route->table != NETPLAN_ROUTE_TABLE_UNSPEC) {
-                g_fprintf(stderr, "ERROR: %s: NetworkManager does not support non-default routing tables\n", def->id);
-                exit(1);
-            }
-
-            if (cur_route->from) {
-                g_fprintf(stderr, "ERROR: %s: NetworkManager does not support routes with 'from'\n", def->id);
-                exit(1);
-            }
-
-            if (cur_route->onlink) {
-                g_fprintf(stderr, "ERROR: %s: NetworkManager does not support on-link routes\n", def->id);
+            if (cur_route->scope) {
+                /* For IPv6 addresses, kernel and NetworkManager don't support a scope.
+                 * For IPv4 addresses, NetworkManager determines the scope of addresses on its own
+                 * ("link" for addresses without gateway, "global" for addresses with next-hop). */
+                g_fprintf(stderr, "ERROR: %s: NetworkManager does not support setting a scope for routes\n", def->id);
                 exit(1);
             }
 
@@ -226,6 +214,21 @@ write_routes(const NetplanNetDefinition* def, GString *s, int family)
             if (cur_route->metric != NETPLAN_METRIC_UNSPEC)
                 g_string_append_printf(s, ",%d", cur_route->metric);
             g_string_append(s, "\n");
+
+            if (   cur_route->onlink
+                || cur_route->table != NETPLAN_ROUTE_TABLE_UNSPEC
+                || cur_route->from) {
+                g_string_append_printf(s, "route%d_options=", j);
+                if (cur_route->onlink) {
+                    /* onlink for IPv6 addresses is only supported since nm-1.18.0. */
+                    g_string_append_printf(s, "onlink=true ");
+                }
+                if (cur_route->table != NETPLAN_ROUTE_TABLE_UNSPEC)
+                    g_string_append_printf(s, "table=%u ", cur_route->table);
+                if (cur_route->from)
+                    g_string_append_printf(s, "from=%s ", cur_route->from);
+                s->str[s->len - 1] = '\n';
+            }
             j++;
         }
     }

--- a/src/parse.c
+++ b/src/parse.c
@@ -1371,7 +1371,6 @@ handle_routes(yaml_document_t* doc, yaml_node_t* node, const void* _, GError** e
 
         cur_route = g_new0(NetplanIPRoute, 1);
         cur_route->type = g_strdup("unicast");
-        /* FIXME: do not pre-fill scope, NM does not support scopes and will throw a warning. */
         cur_route->scope = g_strdup("global");
         cur_route->family = G_MAXUINT; /* 0 is a valid family ID */
         cur_route->metric = NETPLAN_METRIC_UNSPEC; /* 0 is a valid metric */

--- a/src/parse.c
+++ b/src/parse.c
@@ -1371,6 +1371,7 @@ handle_routes(yaml_document_t* doc, yaml_node_t* node, const void* _, GError** e
 
         cur_route = g_new0(NetplanIPRoute, 1);
         cur_route->type = g_strdup("unicast");
+        /* FIXME: do not pre-fill scope, NM does not support scopes and will throw a warning. */
         cur_route->scope = g_strdup("global");
         cur_route->family = G_MAXUINT; /* 0 is a valid family ID */
         cur_route->metric = NETPLAN_METRIC_UNSPEC; /* 0 is a valid metric */

--- a/tests/generator/test_ethernets.py
+++ b/tests/generator/test_ethernets.py
@@ -646,16 +646,30 @@ method=ignore
         self.assert_nm_udev(None)
 
     def test_eth_match_name_glob(self):
-        err = self.generate('''network:
+        self.generate('''network:
   version: 2
   renderer: NetworkManager
   ethernets:
     def1:
       match: {name: "en*"}
-      dhcp4: true''', expect_fail=True)
-        self.assertIn('def1: NetworkManager definitions do not support name globbing', err)
+      dhcp4: true''')
 
-        self.assert_nm({})
+        self.assert_nm({'def1': '''[connection]
+id=netplan-def1
+type=ethernet
+
+[ethernet]
+wake-on-lan=0
+
+[match]
+interface-name=en*;
+
+[ipv4]
+method=auto
+
+[ipv6]
+method=ignore
+'''})
         self.assert_networkd({})
 
     def test_eth_match_all(self):

--- a/tests/generator/test_routing.py
+++ b/tests/generator/test_routing.py
@@ -731,7 +731,7 @@ route2=2001:f00f:f00f::fe/64,2001:beef:feed::1
 '''})
 
     def test_route_reject_from(self):
-        err = self.generate('''network:
+        self.generate('''network:
   version: 2
   ethernets:
     engreen:
@@ -741,14 +741,29 @@ route2=2001:f00f:f00f::fe/64,2001:beef:feed::1
         - to: 10.10.10.0/24
           via: 192.168.14.20
           from: 192.168.14.2
-          ''', expect_fail=True)
-        self.assertIn("NetworkManager does not support routes with 'from'", err)
+          ''')
 
-        self.assert_nm({})
+        self.assert_nm({'engreen': '''[connection]
+id=netplan-engreen
+type=ethernet
+interface-name=engreen
+
+[ethernet]
+wake-on-lan=0
+
+[ipv4]
+method=manual
+address1=192.168.14.2/24
+route1=10.10.10.0/24,192.168.14.20
+route1_options=from=192.168.14.2
+
+[ipv6]
+method=ignore
+'''})
         self.assert_networkd({})
 
     def test_route_reject_onlink(self):
-        err = self.generate('''network:
+        self.generate('''network:
   version: 2
   ethernets:
     engreen:
@@ -758,14 +773,29 @@ route2=2001:f00f:f00f::fe/64,2001:beef:feed::1
         - to: 10.10.10.0/24
           via: 192.168.1.20
           on-link: true
-          ''', expect_fail=True)
-        self.assertIn('NetworkManager does not support on-link routes', err)
+          ''')
 
-        self.assert_nm({})
+        self.assert_nm({'engreen': '''[connection]
+id=netplan-engreen
+type=ethernet
+interface-name=engreen
+
+[ethernet]
+wake-on-lan=0
+
+[ipv4]
+method=manual
+address1=192.168.14.2/24
+route1=10.10.10.0/24,192.168.1.20
+route1_options=onlink=true
+
+[ipv6]
+method=ignore
+'''})
         self.assert_networkd({})
 
     def test_route_reject_table(self):
-        err = self.generate('''network:
+        self.generate('''network:
   version: 2
   ethernets:
     engreen:
@@ -775,14 +805,29 @@ route2=2001:f00f:f00f::fe/64,2001:beef:feed::1
         - to: 10.10.10.0/24
           via: 192.168.1.20
           table: 31337
-          ''', expect_fail=True)
-        self.assertIn('NetworkManager does not support non-default routing tables', err)
+          ''')
 
-        self.assert_nm({})
+        self.assert_nm({'engreen': '''[connection]
+id=netplan-engreen
+type=ethernet
+interface-name=engreen
+
+[ethernet]
+wake-on-lan=0
+
+[ipv4]
+method=manual
+address1=192.168.14.2/24
+route1=10.10.10.0/24,192.168.1.20
+route1_options=table=31337
+
+[ipv6]
+method=ignore
+'''})
         self.assert_networkd({})
 
     def test_route_reject_scope(self):
-        err = self.generate('''network:
+        out = self.generate('''network:
   version: 2
   ethernets:
     engreen:
@@ -792,10 +837,25 @@ route2=2001:f00f:f00f::fe/64,2001:beef:feed::1
         - to: 10.10.10.0/24
           via: 192.168.1.20
           scope: host
-          ''', expect_fail=True)
-        self.assertIn('NetworkManager only supports global scoped routes', err)
+          ''')
+        self.assertIn('WARNING: engreen: NetworkManager does not support setting a scope for routes', out)
 
-        self.assert_nm({})
+        self.assert_nm({'engreen': '''[connection]
+id=netplan-engreen
+type=ethernet
+interface-name=engreen
+
+[ethernet]
+wake-on-lan=0
+
+[ipv4]
+method=manual
+address1=192.168.14.2/24
+route1=10.10.10.0/24,192.168.1.20
+
+[ipv6]
+method=ignore
+'''})
         self.assert_networkd({})
 
     def test_route_reject_type(self):

--- a/tests/generator/test_routing.py
+++ b/tests/generator/test_routing.py
@@ -731,7 +731,7 @@ route2=2001:f00f:f00f::fe/64,2001:beef:feed::1
 '''})
 
     def test_route_reject_from(self):
-        self.generate('''network:
+        out = self.generate('''network:
   version: 2
   ethernets:
     engreen:
@@ -742,6 +742,7 @@ route2=2001:f00f:f00f::fe/64,2001:beef:feed::1
           via: 192.168.14.20
           from: 192.168.14.2
           ''')
+        self.assertEqual('', out)
 
         self.assert_nm({'engreen': '''[connection]
 id=netplan-engreen
@@ -763,7 +764,7 @@ method=ignore
         self.assert_networkd({})
 
     def test_route_reject_onlink(self):
-        self.generate('''network:
+        out = self.generate('''network:
   version: 2
   ethernets:
     engreen:
@@ -774,6 +775,7 @@ method=ignore
           via: 192.168.1.20
           on-link: true
           ''')
+        self.assertEqual('', out)
 
         self.assert_nm({'engreen': '''[connection]
 id=netplan-engreen
@@ -795,7 +797,7 @@ method=ignore
         self.assert_networkd({})
 
     def test_route_reject_table(self):
-        self.generate('''network:
+        out = self.generate('''network:
   version: 2
   ethernets:
     engreen:
@@ -806,6 +808,7 @@ method=ignore
           via: 192.168.1.20
           table: 31337
           ''')
+        self.assertEqual('', out)
 
         self.assert_nm({'engreen': '''[connection]
 id=netplan-engreen
@@ -837,25 +840,10 @@ method=ignore
         - to: 10.10.10.0/24
           via: 192.168.1.20
           scope: host
-          ''')
-        self.assertIn('WARNING: engreen: NetworkManager does not support setting a scope for routes', out)
+          ''', expect_fail=True)
+        self.assertIn('ERROR: engreen: NetworkManager does not support setting a scope for routes', out)
 
-        self.assert_nm({'engreen': '''[connection]
-id=netplan-engreen
-type=ethernet
-interface-name=engreen
-
-[ethernet]
-wake-on-lan=0
-
-[ipv4]
-method=manual
-address1=192.168.14.2/24
-route1=10.10.10.0/24,192.168.1.20
-
-[ipv6]
-method=ignore
-'''})
+        self.assert_nm({})
         self.assert_networkd({})
 
     def test_route_reject_type(self):

--- a/tests/generator/test_routing.py
+++ b/tests/generator/test_routing.py
@@ -756,7 +756,7 @@ wake-on-lan=0
 method=manual
 address1=192.168.14.2/24
 route1=10.10.10.0/24,192.168.14.20
-route1_options=from=192.168.14.2
+route1_options=src=192.168.14.2
 
 [ipv6]
 method=ignore


### PR DESCRIPTION
For NetworkManager, implement some routing attributes and matching interfaces by glob pattern.

On problem is, that certain of these features require a recent enough NetworkManager. Otherwise, NetworkManager will ignore the setting or fail to load it. I don't think that general problem is solved (nor do I see it solved for networkd).