### PR TITLE
Rework renderer parsing / netdef validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ NOSETESTS3 ?= $(shell which nosetests-3 || which nosetests3 || echo true)
 
 default: generate doc/netplan.html doc/netplan.5 doc/netplan-generate.8 doc/netplan-apply.8 doc/netplan-try.8
 
-generate: src/generate.[hc] src/parse.[hc] src/util.[hc] src/networkd.[hc] src/nm.[hc]
+generate: src/generate.[hc] src/parse.[hc] src/util.[hc] src/networkd.[hc] src/nm.[hc] src/validation.[hc] src/error.[hc]
 	$(CC) $(BUILDFLAGS) $(CFLAGS) -o $@ $(filter %.c, $^) `pkg-config --cflags --libs glib-2.0 gio-2.0 yaml-0.1 uuid`
 
 clean:

--- a/src/error.c
+++ b/src/error.c
@@ -1,0 +1,174 @@
+/*
+ * Copyright (C) 2019 Canonical, Ltd.
+ * Author: Mathieu Trudel-Lapierre <mathieu.trudel-lapierre@canonical.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <glib.h>
+#include <glib/gstdio.h>
+#include <gio/gio.h>
+
+#include <yaml.h>
+
+#include "parse.h"
+
+
+/****************************************************
+ * Loading and error handling
+ ****************************************************/
+
+static void
+write_error_marker(GString *message, int column)
+{
+    int i;
+
+    for (i = 0; (column > 0 && i < column); i++)
+        g_string_append_printf(message, " ");
+
+    g_string_append_printf(message, "^");
+}
+
+static char *
+get_syntax_error_context(const int line_num, const int column, GError **error)
+{
+    GString *message = NULL;
+    GFile *cur_file = g_file_new_for_path(current_file);
+    GFileInputStream *file_stream;
+    GDataInputStream *stream;
+    gsize len;
+    gchar* line = NULL;
+
+    message = g_string_sized_new(200);
+    file_stream = g_file_read(cur_file, NULL, error);
+    stream = g_data_input_stream_new (G_INPUT_STREAM(file_stream));
+    g_object_unref(file_stream);
+
+    for (int i = 0; i < line_num + 1; i++) {
+        g_free(line);
+        line = g_data_input_stream_read_line(stream, &len, NULL, error);
+    }
+    g_string_append_printf(message, "%s\n", line);
+
+    write_error_marker(message, column);
+
+    g_object_unref(stream);
+    g_object_unref(cur_file);
+
+    return g_string_free(message, FALSE);
+}
+
+static char *
+get_parser_error_context(const yaml_parser_t *parser, GError **error)
+{
+    GString *message = NULL;
+    unsigned char* line = parser->buffer.pointer;
+    unsigned char* current = line;
+
+    message = g_string_sized_new(200);
+
+    while (current > parser->buffer.start) {
+        current--;
+        if (*current == '\n') {
+            line = current + 1;
+            break;
+        }
+    }
+    if (current <= parser->buffer.start)
+        line = parser->buffer.start;
+    current = line + 1;
+    while (current <= parser->buffer.last) {
+        if (*current == '\n') {
+            *current = '\0';
+            break;
+        }
+        current++;
+    }
+
+    g_string_append_printf(message, "%s\n", line);
+
+    write_error_marker(message, parser->problem_mark.column);
+
+    return g_string_free(message, FALSE);
+}
+
+gboolean
+parser_error(const yaml_parser_t* parser, const char* yaml, GError** error)
+{
+    char *error_context = get_parser_error_context(parser, error);
+    if ((char)*parser->buffer.pointer == '\t')
+        g_set_error(error, G_MARKUP_ERROR, G_MARKUP_ERROR_PARSE,
+                    "%s:%zu:%zu: Invalid YAML: tabs are not allowed for indent:\n%s",
+                    yaml,
+                    parser->problem_mark.line + 1,
+                    parser->problem_mark.column + 1,
+                    error_context);
+    else if (((char)*parser->buffer.pointer == ' ' || (char)*parser->buffer.pointer == '\0')
+             && !parser->token_available)
+        g_set_error(error, G_MARKUP_ERROR, G_MARKUP_ERROR_PARSE,
+                    "%s:%zu:%zu: Invalid YAML: aliases are not supported:\n%s",
+                    yaml,
+                    parser->problem_mark.line + 1,
+                    parser->problem_mark.column + 1,
+                    error_context);
+    else if (parser->state == YAML_PARSE_BLOCK_MAPPING_KEY_STATE)
+        g_set_error(error, G_MARKUP_ERROR, G_MARKUP_ERROR_PARSE,
+                    "%s:%zu:%zu: Invalid YAML: inconsistent indentation:\n%s",
+                    yaml,
+                    parser->problem_mark.line + 1,
+                    parser->problem_mark.column + 1,
+                    error_context);
+    else {
+        g_set_error(error, G_MARKUP_ERROR, G_MARKUP_ERROR_PARSE,
+                    "%s:%zu:%zu: Invalid YAML: %s:\n%s",
+                    yaml,
+                    parser->problem_mark.line + 1,
+                    parser->problem_mark.column + 1,
+                    parser->problem,
+                    error_context);
+    }
+    g_free(error_context);
+
+    return FALSE;
+}
+
+/**
+ * Put a YAML specific error message for @node into @error.
+ */
+gboolean
+yaml_error(const yaml_node_t* node, GError** error, const char* msg, ...)
+{
+    va_list argp;
+    char* s;
+    char* error_context = NULL;
+
+    va_start(argp, msg);
+    g_vasprintf(&s, msg, argp);
+    if (node != NULL) {
+        error_context = get_syntax_error_context(node->start_mark.line, node->start_mark.column, error);
+        g_set_error(error, G_MARKUP_ERROR, G_MARKUP_ERROR_PARSE,
+                    "%s:%zu:%zu: Error in network definition: %s\n%s",
+                    current_file,
+                    node->start_mark.line + 1,
+                    node->start_mark.column + 1,
+                    s,
+                    error_context);
+    } else {
+        g_set_error(error, G_MARKUP_ERROR, G_MARKUP_ERROR_PARSE,
+                    "Error in network definition: %s", s);
+    }
+    g_free(s);
+    va_end(argp);
+    return FALSE;
+}
+

--- a/src/error.h
+++ b/src/error.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2019 Canonical, Ltd.
+ * Author: Mathieu Trudel-Lapierre <mathieu.trudel-lapierre@canonical.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <glib.h>
+#include <glib/gstdio.h>
+#include <gio/gio.h>
+
+#include <yaml.h>
+
+
+gboolean
+parser_error(const yaml_parser_t* parser, const char* yaml, GError** error);
+
+gboolean
+yaml_error(const yaml_node_t* node, GError** error, const char* msg, ...);

--- a/src/generate.c
+++ b/src/generate.c
@@ -237,7 +237,10 @@ int main(int argc, char** argv)
             process_input_file(g_hash_table_lookup(configs, i->data));
     }
 
-    g_assert(finish_parse(&error));
+    if (!finish_parse(&error)) {
+        g_fprintf(stderr, "%s\n", error->message);
+        exit(1);
+    }
 
     /* Clean up generated config from previous runs */
     cleanup_networkd_conf(rootdir);

--- a/src/parse.c
+++ b/src/parse.c
@@ -1985,7 +1985,7 @@ handle_network_type(yaml_document_t* doc, yaml_node_t* node, const void* data, G
             /* create new network definition */
             cur_netdef = g_new0(net_definition, 1);
             cur_netdef->type = GPOINTER_TO_UINT(data);
-            cur_netdef->backend = backend_cur_type ?: get_default_backend_for_type(cur_netdef->type);
+            cur_netdef->backend = backend_cur_type ?: BACKEND_NONE;
             cur_netdef->id = g_strdup(scalar(key));
 
             /* Set some default values */

--- a/src/parse.h
+++ b/src/parse.h
@@ -20,6 +20,17 @@
 #include <uuid.h>
 #include <yaml.h>
 
+
+/* file that is currently being processed, for useful error messages */
+const char* current_file;
+
+/* List of "seen" ids not found in netdefs yet by the parser.
+ * These are removed when it exists in this list and we reach the point of
+ * creating a netdef for that id; so by the time we're done parsing the yaml
+ * document it should be empty. */
+GHashTable *missing_id;
+int missing_ids_found;
+
 /****************************************************
  * Parsed definitions
  ****************************************************/

--- a/src/validation.c
+++ b/src/validation.c
@@ -1,0 +1,223 @@
+/*
+ * Copyright (C) 2019 Canonical, Ltd.
+ * Author: Mathieu Trudel-Lapierre <mathieu.trudel-lapierre@canonical.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <glib.h>
+#include <glib/gstdio.h>
+#include <gio/gio.h>
+#include <arpa/inet.h>
+
+#include <yaml.h>
+
+#include "parse.h"
+#include "error.h"
+
+
+/* Check sanity for address types */
+
+gboolean
+is_ip4_address(const char* address)
+{
+    struct in_addr a4;
+    int ret;
+
+    ret = inet_pton(AF_INET, address, &a4);
+    g_assert(ret >= 0);
+    if (ret > 0)
+        return TRUE;
+
+    return FALSE;
+}
+
+gboolean
+is_ip6_address(const char* address)
+{
+    struct in6_addr a6;
+    int ret;
+
+    ret = inet_pton(AF_INET6, address, &a6);
+    g_assert(ret >= 0);
+    if (ret > 0)
+        return TRUE;
+
+    return FALSE;
+}
+
+/************************************************
+ * Validation for grammar and backend rules.
+ ************************************************/
+static gboolean
+validate_tunnel_grammar(net_definition* nd, yaml_node_t* node, GError** error)
+{
+    if (nd->tunnel.mode == TUNNEL_MODE_UNKNOWN)
+        return yaml_error(node, error, "%s: missing 'mode' property for tunnel", nd->id);
+
+    /* Validate local/remote IPs */
+    if (!nd->tunnel.local_ip)
+        return yaml_error(node, error, "%s: missing 'local' property for tunnel", nd->id);
+    if (!nd->tunnel.remote_ip)
+        return yaml_error(node, error, "%s: missing 'remote' property for tunnel", nd->id);
+
+    switch(nd->tunnel.mode) {
+        case TUNNEL_MODE_IPIP6:
+        case TUNNEL_MODE_IP6IP6:
+        case TUNNEL_MODE_IP6GRE:
+        case TUNNEL_MODE_IP6GRETAP:
+        case TUNNEL_MODE_VTI6:
+            if (!is_ip6_address(nd->tunnel.local_ip))
+                return yaml_error(node, error, "%s: 'local' must be a valid IPv6 address for this tunnel type", nd->id);
+            if (!is_ip6_address(nd->tunnel.remote_ip))
+                return yaml_error(node, error, "%s: 'remote' must be a valid IPv6 address for this tunnel type", nd->id);
+            break;
+
+        default:
+            if (!is_ip4_address(nd->tunnel.local_ip))
+                return yaml_error(node, error, "%s: 'local' must be a valid IPv4 address for this tunnel type", nd->id);
+            if (!is_ip4_address(nd->tunnel.remote_ip))
+                return yaml_error(node, error, "%s: 'remote' must be a valid IPv4 address for this tunnel type", nd->id);
+            break;
+    }
+
+    return TRUE;
+}
+
+static gboolean
+validate_tunnel_backend_rules(net_definition* nd, yaml_node_t* node, GError** error)
+{
+    /* Backend-specific validation rules for tunnels */
+    switch (nd->backend) {
+        case BACKEND_NETWORKD:
+            switch (nd->tunnel.mode) {
+                case TUNNEL_MODE_VTI:
+                case TUNNEL_MODE_VTI6:
+                    break;
+
+                /* TODO: Remove this exception and fix ISATAP handling with the
+                 *       networkd backend.
+                 *       systemd-networkd has grown ISATAP support in 918049a.
+                 */
+                case TUNNEL_MODE_ISATAP:
+                    return yaml_error(node, error,
+                                    "%s: %s tunnel mode is not supported by networkd",
+                                    nd->id,
+                                    g_ascii_strup(tunnel_mode_to_string(nd->tunnel.mode), -1));
+                    break;
+
+                default:
+                    if (nd->tunnel.input_key)
+                        return yaml_error(node, error, "%s: 'input-key' is not required for this tunnel type", nd->id);
+                    if (nd->tunnel.output_key)
+                        return yaml_error(node, error, "%s: 'output-key' is not required for this tunnel type", nd->id);
+                    break;
+            }
+            break;
+
+        case BACKEND_NM:
+            switch (nd->tunnel.mode) {
+                case TUNNEL_MODE_GRE:
+                case TUNNEL_MODE_IP6GRE:
+                    break;
+
+                case TUNNEL_MODE_GRETAP:
+                case TUNNEL_MODE_IP6GRETAP:
+                    return yaml_error(node, error,
+                                    "%s: %s tunnel mode is not supported by NetworkManager",
+                                    nd->id,
+                                    g_ascii_strup(tunnel_mode_to_string(nd->tunnel.mode), -1));
+                    break;
+
+                default:
+                    if (nd->tunnel.input_key)
+                        return yaml_error(node, error, "%s: 'input-key' is not required for this tunnel type", nd->id);
+                    if (nd->tunnel.output_key)
+                        return yaml_error(node, error, "%s: 'output-key' is not required for this tunnel type", nd->id);
+                    break;
+            }
+            break;
+
+        // LCOV_EXCL_START
+        default:
+            break;
+        // LCOV_EXCL_STOP
+    }
+
+    return TRUE;
+}
+
+gboolean
+validate_netdef_grammar(net_definition* nd, yaml_node_t* node, GError** error)
+{
+    int missing_id_count = g_hash_table_size(missing_id);
+    gboolean valid = FALSE;
+
+    g_assert(nd->type != ND_NONE);
+
+    /* Skip all validation if we're missing some definition IDs (devices).
+     * The ones we have yet to see may be necessary for validation to succeed,
+     * we can complete it on the next parser pass. */
+    if (missing_id_count > 0)
+        return TRUE;
+
+    /* set-name: requires match: */
+    if (nd->set_name && !nd->has_match)
+        return yaml_error(node, error, "%s: 'set-name:' requires 'match:' properties", nd->id);
+
+    if (nd->type == ND_WIFI && nd->access_points == NULL)
+        return yaml_error(node, error, "%s: No access points defined", nd->id);
+
+    if (nd->type == ND_VLAN) {
+        if (!nd->vlan_link)
+            return yaml_error(node, error, "%s: missing 'link' property", nd->id);
+        nd->vlan_link->has_vlans = TRUE;
+        if (nd->vlan_id == G_MAXUINT)
+            return yaml_error(node, error, "%s: missing 'id' property", nd->id);
+        if (nd->vlan_id > 4094)
+            return yaml_error(node, error, "%s: invalid id '%u' (allowed values are 0 to 4094)", nd->id, nd->vlan_id);
+    }
+
+    if (nd->type == ND_TUNNEL) {
+        valid = validate_tunnel_grammar(nd, node, error);
+        if (!valid)
+            goto netdef_grammar_error;
+    }
+
+    valid = TRUE;
+
+netdef_grammar_error:
+    return valid;
+}
+
+gboolean
+validate_backend_rules(net_definition* nd, GError** error)
+{
+    gboolean valid = FALSE;
+    /* Set a dummy, NULL yaml_node_t for error reporting */
+    yaml_node_t* node = NULL;
+
+    g_assert(nd->type != ND_NONE);
+
+    if (nd->type == ND_TUNNEL) {
+        valid = validate_tunnel_backend_rules(nd, node, error);
+        if (!valid)
+            goto backend_rules_error;
+    }
+
+    valid = TRUE;
+
+backend_rules_error:
+    return valid;
+}
+

--- a/src/validation.h
+++ b/src/validation.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2019 Canonical, Ltd.
+ * Author: Mathieu Trudel-Lapierre <mathieu.trudel-lapierre@canonical.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "parse.h"
+
+
+gboolean is_ip4_address(const char* address);
+gboolean is_ip6_address(const char* address);
+
+gboolean
+validate_netdef_grammar(net_definition* nd, yaml_node_t* node, GError** error);
+
+gboolean
+validate_backend_rules(net_definition* nd, GError** error);

--- a/tests/generator/test_common.py
+++ b/tests/generator/test_common.py
@@ -1073,10 +1073,11 @@ class TestMerging(TestBase):
     def test_global_backend(self):
         self.generate('''network:
   version: 2
+  renderer: NetworkManager
   ethernets:
     engreen:
       dhcp4: y''',
-                      confs={'backend': 'network:\n  renderer: NetworkManager'})
+                      confs={'backend': 'network:\n  renderer: networkd'})
 
         self.assert_networkd({'engreen.network': ND_DHCP4 % 'engreen'})
         self.assert_nm(None, '''[keyfile]


### PR DESCRIPTION
## Description

Rework renderer parsing and netdef validation to revert commit fe1fac85 and work around the resulting failures in validating tunnels (which have renderer-specific rules). Seems more logical to go about validating in a single pass anyway, once we're sure we do have all the required information.

This would fix https://bugs.launchpad.net/ubuntu/+source/netplan.io/+bug/1825206


## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [n/a] New/changed keys in YAML format are documented.
- [x] \(Optional\) Closes an open bug in Launchpad.

