### PR TITLE
Introduce support for networkd address options

### DIFF
--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -231,7 +231,7 @@ Virtual devices
     When enabled, accept Router Advertisements. When disabled, do not respond to
     Router Advertisements.  If unset use the host kernel default setting.
 
-``addresses`` (sequence of scalars)
+``addresses`` (sequence of scalars and mappings)
 
 :   Add static addresses to the interface in addition to the ones received
     through DHCP or RA. Each sequence entry is in CIDR notation, i. e. of the
@@ -242,7 +242,29 @@ Virtual devices
     configured and DHCP is disabled, the interface may still be brought online,
     but will not be addressable from the network.
 
+    In addition to the addresses themselves one can specify configuration
+    parameters as mappings. Current supported options are:
+
+    ``lifetime`` (scalar) – since **0.100**
+    :    Default: ``forever``. This can be ``forever`` or ``0`` and corresponds
+         to the ``PreferredLifetime`` option in ``systemd-networkd``'s Address
+         section. Currently supported on the ``networkd`` backend only.
+
+    ``label`` (scalar) – since **0.100**
+    :    An IP address label, equivalent to the ``ip address label``
+         command. Currently supported on the ``networkd`` backend only.
+
     Example: ``addresses: [192.168.14.2/24, "2001:1::1/64"]``
+
+    Example:
+
+        ethernets:
+          eth0:
+            addresses:
+              - 10.0.0.15/24:
+                  lifetime: 0
+                  label: "maas"
+              - "2001:1::1/64"
 
 ``ipv6-address-generation`` (scalar) – since **0.99**
 

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -402,6 +402,19 @@ write_ip_rule(NetplanIPRule* r, GString* s)
         g_string_append_printf(s, "TypeOfService=%d\n", r->tos);
 }
 
+static void
+write_addr_option(NetplanAddressOptions* o, GString* s)
+{
+    g_string_append_printf(s, "\n[Address]\n");
+    g_assert(o->address);
+    g_string_append_printf(s, "Address=%s\n", o->address);
+
+    if (o->lifetime)
+        g_string_append_printf(s, "PreferredLifetime=%s\n", o->lifetime);
+    if (o->label)
+        g_string_append_printf(s, "Label=%s\n", o->label);
+}
+
 #define DHCP_OVERRIDES_ERROR                                            \
     "ERROR: %s: networkd requires that %s has the same value in both "  \
     "dhcp4_overrides and dhcp6_overrides\n"
@@ -601,6 +614,13 @@ write_network_file(const NetplanNetDefinition* def, const char* rootdir, const c
         for (unsigned i = 0; i < def->ip_rules->len; ++i) {
             NetplanIPRule* cur_rule = g_array_index (def->ip_rules, NetplanIPRule*, i);
             write_ip_rule(cur_rule, network);
+        }
+    }
+
+    if (def->address_options) {
+        for (unsigned i = 0; i < def->address_options->len; ++i) {
+            NetplanAddressOptions* opts = g_array_index(def->address_options, NetplanAddressOptions*, i);
+            write_addr_option(opts, network);
         }
     }
 

--- a/src/nm.c
+++ b/src/nm.c
@@ -760,6 +760,11 @@ write_nm_conf(NetplanNetDefinition* def, const char* rootdir)
         exit(1);
     }
 
+    if (def->address_options) {
+        g_fprintf(stderr, "ERROR: %s: NetworkManager does not support address options\n", def->id);
+        exit(1);
+    }
+
     /* for wifi we need to create a separate connection file for every SSID */
     if (def->type == NETPLAN_DEF_TYPE_WIFI) {
         GHashTableIter iter;

--- a/src/parse.c
+++ b/src/parse.c
@@ -836,6 +836,13 @@ handle_addresses(yaml_document_t* doc, yaml_node_t* node, const void* _, GError*
             if (!cur_netdef->address_options)
                 cur_netdef->address_options = g_array_new(FALSE, FALSE, sizeof(NetplanAddressOptions*));
 
+            for (unsigned i = 0; i < cur_netdef->address_options->len; ++i) {
+                NetplanAddressOptions* opts = g_array_index(cur_netdef->address_options, NetplanAddressOptions*, i);
+                /* check for multi-pass parsing, return early if options for this address already exist */
+                if (!g_strcmp0(scalar(key), opts->address))
+                    return TRUE;
+            }
+
             cur_addr_option = g_new0(NetplanAddressOptions, 1);
             cur_addr_option->address = g_strdup(scalar(key));
 

--- a/src/parse.h
+++ b/src/parse.h
@@ -225,6 +225,7 @@ struct net_definition {
     NetplanRAMode accept_ra;
     GArray* ip4_addresses;
     GArray* ip6_addresses;
+    GArray* address_options;
     gboolean ip6_privacy;
     guint ip6_addr_gen_mode;
     char* gateway4;
@@ -364,6 +365,12 @@ typedef enum {
     NETPLAN_WIFI_BAND_5,
     NETPLAN_WIFI_BAND_24
 } NetplanWifiBand;
+
+typedef struct {
+    char* address;
+    char* lifetime;
+    char* label;
+} NetplanAddressOptions;
 
 typedef struct {
     NetplanWifiMode mode;

--- a/tests/generator/base.py
+++ b/tests/generator/base.py
@@ -36,6 +36,7 @@ os.environ.update({'LD_LIBRARY_PATH': '.:{}'.format(os.environ.get('LD_LIBRARY_P
 os.environ['G_DEBUG'] = 'fatal-criticals'
 
 # common patterns for expected output
+ND_EMPTY = '[Match]\nName=%s\n\n[Network]\nLinkLocalAddressing=%s\nConfigureWithoutCarrier=yes\n'
 ND_DHCP4 = '[Match]\nName=%s\n\n[Network]\nDHCP=ipv4\nLinkLocalAddressing=ipv6\n\n[DHCP]\nRouteMetric=100\nUseMTU=true\n'
 ND_DHCP4_NOMTU = '[Match]\nName=%s\n\n[Network]\nDHCP=ipv4\nLinkLocalAddressing=ipv6\n\n[DHCP]\nRouteMetric=100\nUseMTU=false\n'
 ND_WIFI_DHCP4 = '[Match]\nName=%s\n\n[Network]\nDHCP=ipv4\nLinkLocalAddressing=ipv6\n\n[DHCP]\nRouteMetric=600\nUseMTU=true\n'

--- a/tests/generator/test_common.py
+++ b/tests/generator/test_common.py
@@ -291,6 +291,72 @@ RouteMetric=100
 UseMTU=true
 '''})
 
+    def test_eth_address_option_lifetime_zero(self):
+        self.generate('''network:
+  version: 2
+  ethernets:
+    engreen:
+      addresses:
+        - 192.168.14.2/24:
+            lifetime: 0
+        - 2001:FFfe::1/64''')
+
+        self.assert_networkd({'engreen.network': '''[Match]
+Name=engreen
+
+[Network]
+LinkLocalAddressing=ipv6
+Address=2001:FFfe::1/64
+
+[Address]
+Address=192.168.14.2/24
+PreferredLifetime=0
+'''})
+
+    def test_eth_address_option_lifetime_forever(self):
+        self.generate('''network:
+  version: 2
+  ethernets:
+    engreen:
+      addresses:
+        - 192.168.14.2/24:
+            lifetime: forever
+        - 2001:FFfe::1/64''')
+
+        self.assert_networkd({'engreen.network': '''[Match]
+Name=engreen
+
+[Network]
+LinkLocalAddressing=ipv6
+Address=2001:FFfe::1/64
+
+[Address]
+Address=192.168.14.2/24
+PreferredLifetime=forever
+'''})
+
+    def test_eth_address_option_label(self):
+        self.generate('''network:
+  version: 2
+  ethernets:
+    engreen:
+      addresses:
+        - 192.168.14.2/24:
+            label: test-label
+        - 2001:FFfe::1/64''')
+
+        self.assert_networkd({'engreen.network': '''[Match]
+Name=engreen
+
+[Network]
+LinkLocalAddressing=ipv6
+Address=2001:FFfe::1/64
+
+[Address]
+Address=192.168.14.2/24
+Label=test-label
+'''})
+
     def test_dhcp_critical_true(self):
         self.generate('''network:
   version: 2

--- a/tests/generator/test_common.py
+++ b/tests/generator/test_common.py
@@ -19,7 +19,7 @@
 import os
 import textwrap
 
-from .base import TestBase, ND_DHCP4, ND_DHCP6, ND_DHCPYES
+from .base import TestBase, ND_DHCP4, ND_DHCP6, ND_DHCPYES, ND_EMPTY
 
 
 class TestNetworkd(TestBase):
@@ -356,6 +356,39 @@ Address=2001:FFfe::1/64
 Address=192.168.14.2/24
 Label=test-label
 '''})
+
+    def test_eth_address_option_multi_pass(self):
+        self.generate('''network:
+  version: 2
+  bridges:
+    br0:
+      interfaces: [engreen]
+  ethernets:
+    engreen:
+      addresses:
+        - 192.168.14.2/24:
+            label: test-label
+        - 2001:FFfe::1/64:
+            label: ip6''')
+
+        self.assert_networkd({
+            'engreen.network': '''[Match]
+Name=engreen
+
+[Network]
+LinkLocalAddressing=no
+Bridge=br0
+
+[Address]
+Address=192.168.14.2/24
+Label=test-label
+
+[Address]
+Address=2001:FFfe::1/64
+Label=ip6
+''',
+            'br0.network': ND_EMPTY % ('br0', 'ipv6'),
+            'br0.netdev': '[NetDev]\nName=br0\nKind=bridge\n'})
 
     def test_dhcp_critical_true(self):
         self.generate('''network:

--- a/tests/generator/test_errors.py
+++ b/tests/generator/test_errors.py
@@ -348,6 +348,45 @@ class TestConfigErrors(TestBase):
       ipv6-address-generation: eui64''', expect_fail=True)
         self.assertIn("ERROR: engreen: ipv6-address-generation is not supported by networkd", err)
 
+    def test_invalid_address_node_type(self):
+        err = self.generate('''network:
+  version: 2
+  ethernets:
+    engreen:
+      addresses: [[192.168.1.15]]''', expect_fail=True)
+        self.assertIn("expected either scalar or mapping (check indentation)", err)
+
+    def test_invalid_address_option_value(self):
+        err = self.generate('''network:
+  version: 2
+  ethernets:
+    engreen:
+      addresses:
+      - 0.0.0.0.0/24:
+          lifetime: 0''', expect_fail=True)
+        self.assertIn("malformed address '0.0.0.0.0/24', must be X.X.X.X/NN or X:X:X:X:X:X:X:X/NN", err)
+
+    def test_invalid_address_option_lifetime(self):
+        err = self.generate('''network:
+  version: 2
+  ethernets:
+    engreen:
+      addresses:
+      - 192.168.1.15/24:
+          lifetime: 1''', expect_fail=True)
+        self.assertIn("invalid lifetime value '1'", err)
+
+    def test_invalid_nm_options(self):
+        err = self.generate('''network:
+  version: 2
+  renderer: NetworkManager
+  ethernets:
+    engreen:
+      addresses:
+      - 192.168.1.15/24:
+          lifetime: 0''', expect_fail=True)
+        self.assertIn('NetworkManager does not support address options', err)
+
     def test_invalid_gateway4(self):
         for a in ['300.400.1.1', '1.2.3', '192.168.14.1/24']:
             err = self.generate('''network:


### PR DESCRIPTION
## Description
This patch introduces a way to set options for the [Address] section in the networkd backend. It changes the addresses YAML key to a sequence of scalars and mappings, keeping backward compatibility with the previous address notation.

We can extend the current address notation either flattened or expanded, e.g. below:
```
addresses: [192.168.14.2/24, "2001:1::1/64": {lifetime: 0}]
```
```
addresses:
  - 192.168.14.2/24:
      lifetime: 0
      label: test-label
  - 2001:FFfe::1/64''')
```
Due to the nature of the networkd backend, addresses which have these options set need to be placed in their separate [Address] section in the resulting `.network` file.

Two keys are supported for now: `lifetime` and `label`, which correspond to their networkd counterparts `PreferredLifetime` and `Label`. I've tried to write this in a way that makes it easy to add other keys in the future, but I'm open to other different approaches in changing the code.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [x] New/changed keys in YAML format are documented.
- [x] \(Optional\) Closes an open bug in Launchpad. [LP: #1803203](https://bugs.launchpad.net/bugs/1803203)

