### PR TITLE
doc: clarify that bonding parameters up/down-delay only apply to miim…

### DIFF
--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -725,14 +725,16 @@ wpasupplicant installed if you let the ``networkd`` renderer handle wifi.
      ``up-delay`` (scalar)
      :    Specify the delay before enabling a link once the link is physically
           up. The default value is ``0``. This maps to the UpDelaySec= property
-          for the networkd renderer. If no time suffix is specified, the value
-          will be interpreted as milliseconds.
+          for the networkd renderer. This option is only valid for the miimon
+          link monitor. If no time suffix is specified, the value will be
+          interpreted as milliseconds.
 
      ``down-delay`` (scalar)
      :    Specify the delay before disabling a link once the link has been
           lost. The default value is ``0``. This maps to the DownDelaySec=
-          property for the networkd renderer. If no time suffix is specified,
-          the value will be interpreted as milliseconds.
+          property for the networkd renderer. This option is only valid for the
+          miimon link monitor. If no time suffix is specified, the value will
+          be interpreted as milliseconds.
 
      ``fail-over-mac-policy`` (scalar)
      :    Set whether to set all slaves to the same MAC address when adding


### PR DESCRIPTION
## Description
Small change to add clarification that the bonding parameters `up-delay` and `down-delay` apply only to the miimon link monitoring mode. This is explicitly mentioned in the [linux kernel][1] and [systemd][2] documentation, just adding it here as well for consistency.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [x] New/changed keys in YAML format 
- [ ] \(Optional\) Closes an open bug in Launchpad.

[1]: https://www.kernel.org/doc/Documentation/networking/bonding.txt
[2]: https://www.freedesktop.org/software/systemd/man/systemd.netdev.html