### PR TITLE
Honor LDFLAGS when linking the generator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ NOSETESTS3 ?= $(shell which nosetests-3 || which nosetests3 || echo true)
 default: generate doc/netplan.html doc/netplan.5 doc/netplan-generate.8 doc/netplan-apply.8 doc/netplan-try.8
 
 generate: src/generate.[hc] src/parse.[hc] src/util.[hc] src/networkd.[hc] src/nm.[hc] src/validation.[hc] src/error.[hc]
-	$(CC) $(BUILDFLAGS) $(CFLAGS) -o $@ $(filter %.c, $^) `pkg-config --cflags --libs glib-2.0 gio-2.0 yaml-0.1 uuid`
+	$(CC) $(BUILDFLAGS) $(CFLAGS) $(LDFLAGS) -o $@ $(filter %.c, $^) `pkg-config --cflags --libs glib-2.0 gio-2.0 yaml-0.1 uuid`
 
 clean:
 	rm -f generate doc/*.html doc/*.[1-9]


### PR DESCRIPTION
## Description

The generator is compiled and linked in a single command that honors
CFLAGS but not LDFLAGS. To make it easier for packagers, any linking
should honor LDFLAGS, so add them to the command.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [n/a] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Closes an open bug in Launchpad.

