### PR TITLE
add dbus based "netplan apply" interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 generate
+netplan-dbus
 test-coverage
 doc/*.html
 doc/*.[1-9]

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 BUILDFLAGS = \
 	-std=c99 \
 	-D_XOPEN_SOURCE=500 \
+	-DSBINDIR=\"$(SBINDIR)\" \
 	-Wall \
 	-Werror \
 	$(NULL)
@@ -12,25 +13,31 @@ BASH_COMPLETIONS_DIR=$(shell pkg-config --variable=completionsdir bash-completio
 ROOTPREFIX ?= /
 PREFIX ?= /usr
 ROOTLIBEXECDIR ?= $(ROOTPREFIX)/lib
+LIBEXECDIR ?= $(PREFIX)/lib
 SBINDIR ?= $(PREFIX)/sbin
 DATADIR ?= $(PREFIX)/share
 DOCDIR ?= $(DATADIR)/doc
 MANDIR ?= $(DATADIR)/man
 
-PYCODE = netplan/ $(wildcard src/*.py) $(wildcard tests/*.py)
+# FIXME: also add $(wildcard tests/generator/*.py) here
+PYCODE = netplan/ $(wildcard src/*.py) $(wildcard tests/*.py)  $(wildcard tests/dbus/*.py)
 
 # Order: Fedora/Mageia/openSUSE || Debian/Ubuntu || null
 PYFLAKES3 ?= $(shell which pyflakes-3 || which pyflakes3 || echo true)
 PYCODESTYLE3 ?= $(shell which pycodestyle-3 || which pycodestyle || which pep8 || echo true)
 NOSETESTS3 ?= $(shell which nosetests-3 || which nosetests3 || echo true)
 
-default: generate doc/netplan.html doc/netplan.5 doc/netplan-generate.8 doc/netplan-apply.8 doc/netplan-try.8
+default: generate netplan-dbus dbus/io.netplan.Netplan.service doc/netplan.html doc/netplan.5 doc/netplan-generate.8 doc/netplan-apply.8 doc/netplan-try.8
 
 generate: src/generate.[hc] src/parse.[hc] src/util.[hc] src/networkd.[hc] src/nm.[hc] src/validation.[hc] src/error.[hc]
 	$(CC) $(BUILDFLAGS) $(CFLAGS) -o $@ $(filter %.c, $^) `pkg-config --cflags --libs glib-2.0 gio-2.0 yaml-0.1 uuid`
 
+netplan-dbus: src/dbus.c
+	$(CC) $(BUILDFLAGS) $(CFLAGS) -o $@ $^ `pkg-config --cflags --libs libsystemd glib-2.0`
+
 clean:
 	rm -f generate doc/*.html doc/*.[1-9]
+	rm -f netplan-dbus dbus/*.service
 	rm -f *.gcda *.gcno generate.info
 	rm -rf test-coverage .coverage
 
@@ -81,6 +88,15 @@ install: default
 	install -m 644 doc/*.8 $(DESTDIR)/$(MANDIR)/man8/
 	install -D -m 644 src/netplan-wpa@.service $(DESTDIR)/$(SYSTEMD_UNIT_DIR)/netplan-wpa@.service
 	install -T -D -m 644 netplan.completions $(DESTDIR)/$(BASH_COMPLETIONS_DIR)/netplan
+	# dbus
+	mkdir -p $(DESTDIR)/share/dbus-1/system.d $(DESTDIR)/share/dbus-1/system-services
+	install -m 755 netplan-dbus $(DESTDIR)/$(ROOTLIBEXECDIR)/netplan/
+	install -m 644 dbus/io.netplan.Netplan.conf $(DESTDIR)/share/dbus-1/system.d/
+	install -m 644 dbus/io.netplan.Netplan.service $(DESTDIR)/share/dbus-1/system-services/
+
+%.service: %.service.in
+	sed -e "s#@ROOTLIBEXECDIR@#$(ROOTLIBEXECDIR)/#" $< > $@
+
 
 %.html: %.md
 	pandoc -s --toc -o $@ $<

--- a/dbus/io.netplan.Netplan.conf
+++ b/dbus/io.netplan.Netplan.conf
@@ -1,0 +1,18 @@
+<!DOCTYPE busconfig PUBLIC
+ "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+
+  <policy user="root">
+    <allow own="io.netplan.Netplan"/>
+  </policy>
+
+  <policy context="default">
+    <allow send_destination="io.netplan.Netplan"
+           send_interface="io.netplan.Netplan"/>
+    <allow send_destination="io.netplan.Netplan"
+           send_interface="org.freedesktop.DBus.Introspectable"/>
+  </policy>
+
+</busconfig>
+

--- a/dbus/io.netplan.Netplan.service.in
+++ b/dbus/io.netplan.Netplan.service.in
@@ -1,0 +1,4 @@
+[D-BUS Service]
+Name=io.netplan.Netplan
+Exec=@ROOTLIBEXECDIR@/netplan/netplan-dbus
+User=root

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -1,0 +1,93 @@
+#include <errno.h>
+#include <stdbool.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+
+#include <glib.h>
+#include <systemd/sd-bus.h>
+
+static int method_apply(sd_bus_message *m, void *userdata, sd_bus_error *ret_error) {
+    g_autoptr(GError) err = NULL;
+    g_autofree gchar *stdout = NULL;
+    g_autofree gchar *stderr = NULL;
+    gint exit_status = 0;
+
+    gchar *argv[] = {SBINDIR "/" "netplan", "apply", NULL};
+
+    // for tests only: allow changing what netplan to run
+    if (getuid() != 0 && getenv("DBUS_TEST_NETPLAN_CMD") != 0) {
+       argv[0] = getenv("DBUS_TEST_NETPLAN_CMD");
+    }
+
+    g_spawn_sync("/", argv, NULL, 0, NULL, NULL, &stdout, &stderr, &exit_status, &err);
+    if (err != NULL) {
+        return sd_bus_error_setf(ret_error, SD_BUS_ERROR_FAILED, "cannot run netplan apply: %s", err->message);
+    }
+    g_spawn_check_exit_status(exit_status, &err);
+    if (err != NULL) {
+       return sd_bus_error_setf(ret_error, SD_BUS_ERROR_FAILED, "netplan apply failed: %s\nstdout: '%s'\nstderr: '%s'", err->message, stdout, stderr);
+    }
+    
+    return sd_bus_reply_method_return(m, "b", true);
+}
+
+static const sd_bus_vtable netplan_vtable[] = {
+    SD_BUS_VTABLE_START(0),
+    SD_BUS_METHOD("Apply", "", "b", method_apply, 0),
+    SD_BUS_VTABLE_END
+};
+
+int main(int argc, char *argv[]) {
+    sd_bus_slot *slot = NULL;
+    sd_bus *bus = NULL;
+    int r;
+   
+    r = sd_bus_open_system(&bus);
+    if (r < 0) {
+        fprintf(stderr, "Failed to connect to system bus: %s\n", strerror(-r));
+        goto finish;
+    }
+
+    r = sd_bus_add_object_vtable(bus,
+                                     &slot,
+                                     "/io/netplan/Netplan",  /* object path */
+                                     "io.netplan.Netplan",   /* interface name */
+                                     netplan_vtable,
+                                     NULL);
+    if (r < 0) {
+        fprintf(stderr, "Failed to issue method call: %s\n", strerror(-r));
+        goto finish;
+    }
+
+    r = sd_bus_request_name(bus, "io.netplan.Netplan", 0);
+    if (r < 0) {
+        fprintf(stderr, "Failed to acquire service name: %s\n", strerror(-r));
+        goto finish;
+    }
+
+    for (;;) {
+        r = sd_bus_process(bus, NULL);
+        if (r < 0) {
+            fprintf(stderr, "Failed to process bus: %s\n", strerror(-r));
+            goto finish;
+        }
+        if (r > 0)
+            continue;
+
+        /* Wait for the next request to process */
+        r = sd_bus_wait(bus, (uint64_t) -1);
+        if (r < 0) {
+            fprintf(stderr, "Failed to wait on bus: %s\n", strerror(-r));
+            goto finish;
+        }
+    }
+
+finish:
+    sd_bus_slot_unref(slot);
+    sd_bus_unref(bus);
+
+    return r < 0 ? EXIT_FAILURE : EXIT_SUCCESS;
+}

--- a/tests/dbus/test_dbus.py
+++ b/tests/dbus/test_dbus.py
@@ -1,0 +1,129 @@
+#
+# Copyright (C) 2019 Canonical, Ltd.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+
+class MockCmd:
+    """MockCmd will mock a given command name and capture all calls to it"""
+    def __init__(self, name):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.name = name
+        self.path = os.path.join(self._tmp.name, name)
+        self.call_log = os.path.join(self._tmp.name, "call.log")
+        with open(self.path, "w") as fp:
+            fp.write("""#!/bin/bash
+printf "%%s" "$(basename "$0")" >> %(log)s
+printf '\\0' >> %(log)s
+
+for arg in "$@"; do
+     printf "%%s" "$arg" >> %(log)s
+     printf '\\0'  >> %(log)s
+done
+
+printf '\\0' >> %(log)s
+""" % {'log': self.call_log})
+        os.chmod(self.path, 0o755)
+
+    def calls(self):
+        """
+        calls() returns the calls to the given mock command in the form of
+        [ ["cmd", "call1-arg1"], ["cmd", "call2-arg1"], ... ]
+        """
+        with open(self.call_log) as fp:
+            b = fp.read()
+        calls = []
+        for raw_call in b.rstrip("\0\0").split("\0\0"):
+            call = raw_call.rstrip("\0")
+            calls.append(call.split("\0"))
+        return calls
+
+
+class TestNetplanDBus(unittest.TestCase):
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmp)
+        self.mock_netplan_cmd = MockCmd("netplan")
+        self._create_mock_system_bus()
+        self._run_netplan_dbus_on_mock_bus()
+
+    def _create_mock_system_bus(self):
+        env = {}
+        output = subprocess.check_output(["dbus-launch"], env={})
+        for s in output.decode("utf-8").split("\n"):
+            if s == "":
+                continue
+            k, v = s.split("=", 1)
+            env[k] = v
+        # override system bus with the fake one
+        os.environ["DBUS_SYSTEM_BUS_ADDRESS"] = env["DBUS_SESSION_BUS_ADDRESS"]
+        self.addCleanup(os.kill, int(env["DBUS_SESSION_BUS_PID"]), 15)
+
+    def _run_netplan_dbus_on_mock_bus(self):
+        # run netplan-dbus in a fake system bus
+        os.environ["DBUS_TEST_NETPLAN_CMD"] = self.mock_netplan_cmd.path
+        p = subprocess.Popen(
+            os.path.join(os.path.dirname(__file__), "..", "..", "netplan-dbus"),
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        self.addCleanup(self._cleanup_netplan_dbus, p)
+
+    def _cleanup_netplan_dbus(self, p):
+        p.terminate()
+        p.wait()
+        # netplan-dbus does not produce output
+        self.assertEqual(p.stdout.read(), b"")
+        self.assertEqual(p.stderr.read(), b"")
+
+    def test_netplan_dbus_happy(self):
+        BUSCTL_NETPLAN_APPLY = [
+            "busctl", "call",
+            "io.netplan.Netplan",
+            "/io/netplan/Netplan",
+            "io.netplan.Netplan",
+            "Apply",
+        ]
+        output = subprocess.check_output(
+            BUSCTL_NETPLAN_APPLY, encoding="utf-8")
+        self.assertEqual(output, "b true\n")
+        # one call to netplan apply in total
+        self.assertEquals(self.mock_netplan_cmd.calls(), [
+                ["netplan", "apply"],
+            ])
+
+        # and again!
+        output = subprocess.check_output(
+            BUSCTL_NETPLAN_APPLY, encoding="utf-8")
+        # and another call to netplan apply
+        self.assertEquals(self.mock_netplan_cmd.calls(), [
+                ["netplan", "apply"],
+                ["netplan", "apply"],
+            ])
+
+    def test_netplan_dbus_no_such_command(self):
+        cp = subprocess.run(
+            ["busctl", "call",
+             "io.netplan.Netplan",
+             "/io/netplan/Netplan",
+             "io.netplan.Netplan",
+             "NoSuchCommand"],
+            capture_output=True, encoding="utf-8")
+        self.assertEqual(cp.returncode, 1)
+        self.assertEqual(cp.stdout, "")
+        self.assertEqual(cp.stderr, "Unknown method 'NoSuchCommand' or interface 'io.netplan.Netplan'.\n")

--- a/tests/dbus/test_dbus.py
+++ b/tests/dbus/test_dbus.py
@@ -99,31 +99,31 @@ class TestNetplanDBus(unittest.TestCase):
             "io.netplan.Netplan",
             "Apply",
         ]
-        output = subprocess.check_output(
-            BUSCTL_NETPLAN_APPLY, encoding="utf-8")
-        self.assertEqual(output, "b true\n")
+        output = subprocess.check_output(BUSCTL_NETPLAN_APPLY)
+        self.assertEqual(output.decode("utf-8"), "b true\n")
         # one call to netplan apply in total
         self.assertEquals(self.mock_netplan_cmd.calls(), [
                 ["netplan", "apply"],
-            ])
+        ])
 
         # and again!
-        output = subprocess.check_output(
-            BUSCTL_NETPLAN_APPLY, encoding="utf-8")
+        output = subprocess.check_output(BUSCTL_NETPLAN_APPLY)
+        self.assertEqual(output.decode("utf-8"), "b true\n")
         # and another call to netplan apply
         self.assertEquals(self.mock_netplan_cmd.calls(), [
                 ["netplan", "apply"],
                 ["netplan", "apply"],
-            ])
+        ])
 
     def test_netplan_dbus_no_such_command(self):
-        cp = subprocess.run(
+        p = subprocess.Popen(
             ["busctl", "call",
              "io.netplan.Netplan",
              "/io/netplan/Netplan",
              "io.netplan.Netplan",
              "NoSuchCommand"],
-            capture_output=True, encoding="utf-8")
-        self.assertEqual(cp.returncode, 1)
-        self.assertEqual(cp.stdout, "")
-        self.assertEqual(cp.stderr, "Unknown method 'NoSuchCommand' or interface 'io.netplan.Netplan'.\n")
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        p.wait()
+        self.assertEqual(p.returncode, 1)
+        self.assertEqual(p.stdout.read().decode("utf-8"), "")
+        self.assertEqual(p.stderr.read().decode("utf-8"), "Unknown method 'NoSuchCommand' or interface 'io.netplan.Netplan'.\n")


### PR DESCRIPTION
## Description

This PR adds a new io.netplan.Netplan dbus activatable service
that can be used to Apply a netplan configuration.

The main use-case for this is Ubuntu Core where we want to allow
snaps to control the netplan network configuration via an interface.

However we do not want to give access to systemctl to restart
systemd-networkd or network-manager. The dbus service will run
outside of the confinement will archive this goal.

The interface is probably useful beyond Ubuntu Core.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).



