### PR TITLE
Makefile: add tests/generator/*.py to PYCODE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ DATADIR ?= $(PREFIX)/share
 DOCDIR ?= $(DATADIR)/doc
 MANDIR ?= $(DATADIR)/man
 
-PYCODE = netplan/ $(wildcard src/*.py) $(wildcard tests/*.py)
+PYCODE = netplan/ $(wildcard src/*.py) $(wildcard tests/*.py) $(wildcard tests/generator/*.py)
 
 # Order: Fedora/Mageia/openSUSE || Debian/Ubuntu || null
 PYFLAKES3 ?= $(shell which pyflakes-3 || which pyflakes3 || echo true)

--- a/tests/generator/base.py
+++ b/tests/generator/base.py
@@ -20,8 +20,6 @@
 
 import os
 import random
-import re
-import sys
 import stat
 import string
 import tempfile

--- a/tests/generator/test_args.py
+++ b/tests/generator/test_args.py
@@ -17,7 +17,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
-import sys
 import subprocess
 
 from .base import TestBase, exe_generate

--- a/tests/generator/test_auth.py
+++ b/tests/generator/test_auth.py
@@ -18,7 +18,6 @@
 
 import os
 import stat
-import sys
 
 from .base import TestBase, ND_DHCP4, ND_WIFI_DHCP4
 
@@ -401,7 +400,6 @@ ssid=peer2peer
 mode=adhoc
 '''})
         self.assert_nm_udev(None)
-
 
     def test_auth_wired(self):
         self.generate('''network:

--- a/tests/generator/test_bonds.py
+++ b/tests/generator/test_bonds.py
@@ -16,9 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
-import sys
-
 from .base import TestBase
 
 

--- a/tests/generator/test_bridges.py
+++ b/tests/generator/test_bridges.py
@@ -17,7 +17,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
-import sys
 import unittest
 
 from .base import TestBase
@@ -713,4 +712,3 @@ class TestConfigErrors(TestBase):
         port-priority:
           eno1: 257
       dhcp4: true''', expect_fail=True)
-

--- a/tests/generator/test_common.py
+++ b/tests/generator/test_common.py
@@ -18,7 +18,6 @@
 
 import os
 import textwrap
-import sys
 
 from .base import TestBase, ND_DHCP4, ND_DHCP6, ND_DHCPYES
 
@@ -1252,4 +1251,3 @@ LinkLocalAddressing=ipv6
 ''',
                               'enyellow.network': ND_DHCP4 % 'enyellow',
                               'enblue.network': ND_DHCP4 % 'enblue'})
-

--- a/tests/generator/test_dhcp_overrides.py
+++ b/tests/generator/test_dhcp_overrides.py
@@ -16,11 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
-import sys
-
-from .base import (TestBase, ND_DHCP4, ND_DHCP4_NOMTU, ND_DHCP6, ND_DHCP6_NOMTU,
-        ND_DHCPYES, ND_DHCPYES_NOMTU)
+from .base import (TestBase, ND_DHCP4, ND_DHCP4_NOMTU, ND_DHCP6,
+                   ND_DHCP6_NOMTU, ND_DHCPYES, ND_DHCPYES_NOMTU)
 
 
 class TestNetworkd(TestBase):

--- a/tests/generator/test_errors.py
+++ b/tests/generator/test_errors.py
@@ -16,9 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
-import sys
-
 from .base import TestBase
 
 
@@ -671,4 +668,3 @@ class TestConfigErrors(TestBase):
     engreen:
       dhcp4: *yes''', expect_fail=True)
         self.assertIn("aliases are not supported", err)
-

--- a/tests/generator/test_ethernets.py
+++ b/tests/generator/test_ethernets.py
@@ -17,9 +17,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
-import sys
 
-from .base import TestBase, ND_DHCP4, ND_DHCP6, ND_DHCPYES, UDEV_MAC_RULE, UDEV_NO_MAC_RULE
+from .base import TestBase, ND_DHCP4, UDEV_MAC_RULE, UDEV_NO_MAC_RULE
 
 
 class TestNetworkd(TestBase):
@@ -588,4 +587,3 @@ method=ignore
 '''})
         self.assert_networkd({})
         self.assert_nm_udev(None)
-

--- a/tests/generator/test_routing.py
+++ b/tests/generator/test_routing.py
@@ -16,9 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
-import sys
-
 from .base import TestBase
 
 

--- a/tests/generator/test_tunnels.py
+++ b/tests/generator/test_tunnels.py
@@ -16,10 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
-import sys
-
 from .base import TestBase
+
 
 def prepare_config_for_mode(renderer, mode, key=None):
     config = """network:

--- a/tests/generator/test_vlans.py
+++ b/tests/generator/test_vlans.py
@@ -17,7 +17,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
-import sys
 import re
 import unittest
 
@@ -222,4 +221,3 @@ method=auto
 method=ignore
 ''' % uuid})
         self.assert_nm_udev(None)
-

--- a/tests/generator/test_wifis.py
+++ b/tests/generator/test_wifis.py
@@ -18,7 +18,6 @@
 
 import os
 import stat
-import sys
 
 from .base import TestBase, ND_WIFI_DHCP4
 
@@ -319,4 +318,3 @@ method=ignore
 ssid=homenet
 mode=adhoc
 '''})
-


### PR DESCRIPTION
While working on new tests I noticed that the tests in
tests/generator are not checked by pyflakes. This PR fixes this
and also fixes the pyflakes errors.


