### PR TITLE
netplan/apply: use dbus when inside a snap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__
 *.pyc
 .coverage
 .vscode
+dbus/io.netplan.Netplan.service


### PR DESCRIPTION
## Description

Continuation of #93 to have the `netplan apply` command use the D-Bus activated service to actually run the privileged version of `netplan apply` outside of snap confinement. After this is merged, we will update the `network-setup-control` interface in snapd to allow calling this D-Bus service so that running `netplan apply` inside a strictly confined snap will result in `netplan apply` really being called outside of confinement. 

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).

