### PR TITLE
Bonding mode validation

### DIFF
--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -725,14 +725,16 @@ wpasupplicant installed if you let the ``networkd`` renderer handle wifi.
      ``up-delay`` (scalar)
      :    Specify the delay before enabling a link once the link is physically
           up. The default value is ``0``. This maps to the UpDelaySec= property
-          for the networkd renderer. If no time suffix is specified, the value
-          will be interpreted as milliseconds.
+          for the networkd renderer. This option is only valid for the miimon
+          link monitor. If no time suffix is specified, the value will be
+          interpreted as milliseconds.
 
      ``down-delay`` (scalar)
      :    Specify the delay before disabling a link once the link has been
           lost. The default value is ``0``. This maps to the DownDelaySec=
-          property for the networkd renderer. If no time suffix is specified,
-          the value will be interpreted as milliseconds.
+          property for the networkd renderer. This option is only valid for the
+          miimon link monitor. If no time suffix is specified, the value will
+          be interpreted as milliseconds.
 
      ``fail-over-mac-policy`` (scalar)
      :    Set whether to set all slaves to the same MAC address when adding

--- a/src/parse.c
+++ b/src/parse.c
@@ -776,12 +776,7 @@ handle_bond_mode(yaml_document_t* doc, yaml_node_t* node, const void* data, GErr
         strcmp(scalar(node), "balance-alb") == 0))
         return yaml_error(node, error, "unknown bond mode '%s'", scalar(node));
 
-    guint offset = GPOINTER_TO_UINT(data);
-    char** dest = (char**) ((void*) cur_netdef + offset);
-    g_free(*dest);
-    *dest = g_strdup(scalar(node));
-
-    return TRUE;
+    return handle_netdef_str(doc, node, data, error);
 }
 
 /**

--- a/src/parse.c
+++ b/src/parse.c
@@ -760,6 +760,31 @@ handle_bridge_interfaces(yaml_document_t* doc, yaml_node_t* node, const void* da
 }
 
 /**
+ * Handler for bond "mode" types.
+ * @data: offset into net_definition where the const char* field to write is
+ *        located
+ */
+static gboolean
+handle_bond_mode(yaml_document_t* doc, yaml_node_t* node, const void* data, GError** error)
+{
+    if (!(strcmp(scalar(node), "balance-rr") == 0 ||
+        strcmp(scalar(node), "active-backup") == 0 ||
+        strcmp(scalar(node), "balance-xor") == 0 ||
+        strcmp(scalar(node), "broadcast") == 0 ||
+        strcmp(scalar(node), "802.3ad") == 0 ||
+        strcmp(scalar(node), "balance-tlb") == 0 ||
+        strcmp(scalar(node), "balance-alb") == 0))
+        return yaml_error(node, error, "unknown bond mode '%s'", scalar(node));
+
+    guint offset = GPOINTER_TO_UINT(data);
+    char** dest = (char**) ((void*) cur_netdef + offset);
+    g_free(*dest);
+    *dest = g_strdup(scalar(node));
+
+    return TRUE;
+}
+
+/**
  * Handler for bond "interfaces:" list.
  * @data: ignored
  */
@@ -1345,7 +1370,7 @@ handle_bond_primary_slave(yaml_document_t* doc, yaml_node_t* node, const void* d
 }
 
 const mapping_entry_handler bond_params_handlers[] = {
-    {"mode", YAML_SCALAR_NODE, handle_netdef_str, NULL, netdef_offset(bond_params.mode)},
+    {"mode", YAML_SCALAR_NODE, handle_bond_mode, NULL, netdef_offset(bond_params.mode)},
     {"lacp-rate", YAML_SCALAR_NODE, handle_netdef_str, NULL, netdef_offset(bond_params.lacp_rate)},
     {"mii-monitor-interval", YAML_SCALAR_NODE, handle_netdef_str, NULL, netdef_offset(bond_params.monitor_interval)},
     {"min-links", YAML_SCALAR_NODE, handle_netdef_guint, NULL, netdef_offset(bond_params.min_links)},

--- a/tests/generator/test_bonds.py
+++ b/tests/generator/test_bonds.py
@@ -656,7 +656,7 @@ method=ignore
 class TestConfigErrors(TestBase):
 
     def test_bond_invalid_mode(self):
-        self.generate('''network:
+        err = self.generate('''network:
   version: 2
   ethernets:
     eno1:

--- a/tests/generator/test_bonds.py
+++ b/tests/generator/test_bonds.py
@@ -655,6 +655,23 @@ method=ignore
 
 class TestConfigErrors(TestBase):
 
+    def test_bond_invalid_mode(self):
+        self.generate('''network:
+  version: 2
+  ethernets:
+    eno1:
+      match:
+        name: eth0
+  bonds:
+    bond0:
+      interfaces: [eno1]
+      parameters:
+        mode: lacp
+        arp-ip-targets:
+          - 2001:dead:beef::1
+      dhcp4: true''', expect_fail=True)
+        self.assertIn("unknown bond mode 'lacp'", err)
+
     def test_bond_invalid_arp_target(self):
         self.generate('''network:
   version: 2

--- a/tests/generator/test_bonds.py
+++ b/tests/generator/test_bonds.py
@@ -158,7 +158,7 @@ UseMTU=true
   bonds:
     bn0:
       parameters:
-        mode: 802.1ad
+        mode: 802.3ad
         lacp-rate: 10
         mii-monitor-interval: 10
         min-links: 10
@@ -184,7 +184,7 @@ UseMTU=true
 
         self.assert_networkd({'bn0.netdev': '[NetDev]\nName=bn0\nKind=bond\n\n'
                                             '[Bond]\n'
-                                            'Mode=802.1ad\n'
+                                            'Mode=802.3ad\n'
                                             'LACPTransmitRate=10\n'
                                             'MIIMonitorSec=10ms\n'
                                             'MinLinks=10\n'
@@ -231,7 +231,7 @@ UseMTU=true
   bonds:
     bn0:
       parameters:
-        mode: 802.1ad
+        mode: 802.3ad
         mii-monitor-interval: 10ms
         up-delay: 20ms
         down-delay: 30s
@@ -241,7 +241,7 @@ UseMTU=true
 
         self.assert_networkd({'bn0.netdev': '[NetDev]\nName=bn0\nKind=bond\n\n'
                                             '[Bond]\n'
-                                            'Mode=802.1ad\n'
+                                            'Mode=802.3ad\n'
                                             'MIIMonitorSec=10ms\n'
                                             'ARPIntervalSec=15m\n'
                                             'UpDelaySec=20ms\n'
@@ -494,7 +494,7 @@ method=ignore
     bn0:
       interfaces: [eno1, switchport]
       parameters:
-        mode: 802.1ad
+        mode: 802.3ad
         lacp-rate: 10
         mii-monitor-interval: 10
         min-links: 10
@@ -555,7 +555,7 @@ type=bond
 interface-name=bn0
 
 [bond]
-mode=802.1ad
+mode=802.3ad
 lacp_rate=10
 miimon=10
 min_links=10


### PR DESCRIPTION
## Description
This changes adds checks for bond modes to prevent the acceptance of invalid modes or aliases.  For example, supplying `mode: 4` instead of `mode: 802.3ad`

Any existing code coverage that originally handled bonding covers this.

## Checklist

- [* ] Runs `make check` successfully.
- [?] Retains 100% code coverage (`make check-coverage`).
- [N/A] New/changed keys in YAML format are documented.
- [N/A] \(Optional\) Closes an open bug in Launchpad.

