### PR TITLE
make output more deterministic and fix tests

### DIFF
--- a/src/networkd.c
+++ b/src/networkd.c
@@ -516,12 +516,13 @@ write_network_file(net_definition* def, const char* rootdir, const char* path)
 
     if (def->has_vlans) {
         /* iterate over all netdefs to find VLANs attached to us */
-        GHashTableIter i;
+        GList *l = netdefs_ordered;
         net_definition* nd;
-        g_hash_table_iter_init(&i, netdefs);
-        while (g_hash_table_iter_next (&i, NULL, (gpointer*) &nd))
+        for (; l != NULL; l = l->next) {
+            nd = l->data;
             if (nd->vlan_link == def)
                 g_string_append_printf(network, "VLAN=%s\n", nd->id);
+        }
     }
 
     if (def->routes != NULL) {

--- a/src/nm.c
+++ b/src/nm.c
@@ -632,9 +632,9 @@ write_nm_conf(net_definition* def, const char* rootdir)
 }
 
 static void
-nd_append_non_nm_ids(gpointer key, gpointer value, gpointer str)
+nd_append_non_nm_ids(gpointer data, gpointer str)
 {
-    net_definition* nd = value;
+    net_definition* nd = data;
 
     if (nd->backend != BACKEND_NM) {
         if (nd->match.driver) {
@@ -662,7 +662,7 @@ write_nm_conf_finish(const char* rootdir)
      * auto-connect and interferes */
     s = g_string_new("[keyfile]\n# devices managed by networkd\nunmanaged-devices+=");
     len = s->len;
-    g_hash_table_foreach(netdefs, nd_append_non_nm_ids, s);
+    g_list_foreach(netdefs_ordered, nd_append_non_nm_ids, s);
     if (s->len > len)
         g_string_free_to_file(s, rootdir, "run/NetworkManager/conf.d/netplan.conf", NULL);
     else

--- a/tests/generator/test_bridges.py
+++ b/tests/generator/test_bridges.py
@@ -214,7 +214,7 @@ UseMTU=true
       dhcp4: yes''')
         self.assert_nm(None, '''[keyfile]
 # devices managed by networkd
-unmanaged-devices+=interface-name:mybr,interface-name:eth42,interface-name:eth43,''')
+unmanaged-devices+=interface-name:eth42,interface-name:eth43,interface-name:mybr,''')
 
     def test_bridge_components(self):
         self.generate('''network:

--- a/tests/generator/test_vlans.py
+++ b/tests/generator/test_vlans.py
@@ -47,8 +47,8 @@ Name=en1
 
 [Network]
 LinkLocalAddressing=ipv6
-VLAN=enred
 VLAN=enblue
+VLAN=enred
 VLAN=engreen
 ''',
                               'enblue.netdev': '''[NetDev]
@@ -102,7 +102,7 @@ UseMTU=true
 '''})
         self.assert_nm(None, '''[keyfile]
 # devices managed by networkd
-unmanaged-devices+=interface-name:en1,interface-name:enred,interface-name:enblue,interface-name:engreen,''')
+unmanaged-devices+=interface-name:en1,interface-name:enblue,interface-name:enred,interface-name:engreen,''')
         self.assert_nm_udev(None)
 
 


### PR DESCRIPTION
Some tests were failing on my system because of a couple of places the
output depended on hashmap order. Fix those to iterate over the more
deterministic netdef_ordered list instead, and fix a couple of tests
that hardcoded a different order.


## Description


## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Closes an open bug in Launchpad.

