### PR TITLE
netplan/apply: use dbus when inside a snap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__
 *.pyc
 .coverage
 .vscode
+dbus/io.netplan.Netplan.service

--- a/netplan/cli/commands/apply.py
+++ b/netplan/cli/commands/apply.py
@@ -22,6 +22,7 @@ import os
 import sys
 import glob
 import subprocess
+import shutil
 
 import netplan.cli.utils as utils
 from netplan.configmanager import ConfigManager, ConfigurationError
@@ -44,6 +45,32 @@ class NetplanApply(utils.NetplanCommand):
 
     @staticmethod
     def command_apply(run_generate=True, sync=False, exit_on_error=True):  # pragma: nocover (covered in autopkgtest)
+        # if we are inside a snap, then call dbus to run netplan apply instead
+        if "SNAP" in os.environ:
+            # TODO: maybe check if we are inside a classic snap and don't do
+            # this if we are in a classic snap?
+            busctl = shutil.which("busctl")
+            if busctl is None:
+                raise RuntimeError("missing busctl utility")
+            res = subprocess.call([busctl, "call", "--quiet", "--system",
+                                   "io.netplan.Netplan",  # the service
+                                   "/io/netplan/Netplan",  # the object
+                                   "io.netplan.Netplan",  # the interface
+                                   "Apply",  # the method
+                                   ])
+
+            if res != 0:
+                if exit_on_error:
+                    sys.exit(res)
+                elif res == 130:
+                    raise PermissionError(
+                        "failed to communicate with dbus service")
+                elif res == 1:
+                    raise RuntimeError(
+                        "failed to communicate with dbus service")
+            else:
+                return
+
         old_files_networkd = bool(glob.glob('/run/systemd/network/*netplan-*'))
         old_files_nm = bool(glob.glob('/run/NetworkManager/system-connections/netplan-*'))
 


### PR DESCRIPTION
## Description

Continuation of #93 to have the `netplan apply` command use the D-Bus activated service to actually run the privileged version of `netplan apply` outside of snap confinement. After this is merged, we will update the `network-setup-control` interface in snapd to allow calling this D-Bus service so that running `netplan apply` inside a strictly confined snap will result in `netplan apply` really being called outside of confinement. 

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).

I had to reopen this because GitHub wouldn't let me re-open a PR which had the source branch force-pushed (originally was #96).