### PR TITLE
add support for IPv6MTUBytes

### DIFF
--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -163,6 +163,10 @@ Virtual devices
     Note that **``rdnssd``**(8) is required to use RDNSS with networkd. No extra
     software is required for NetworkManager.
 
+``ipv6-mtu`` (scalar)
+:   Set the IPv6 MTU (only supported with `networkd` backend). Note
+    that needing to set this is an unusual requirement.
+
 ``ipv6-privacy`` (bool)
 
 :   Enable IPv6 Privacy Extensions (RFC 4941) for the specified interface, and

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -494,6 +494,10 @@ write_network_file(net_definition* def, const char* rootdir, const char* path)
         g_string_append(network, "\n");
     }
 
+    if (def->ipv6_mtubytes) {
+        g_string_append_printf(network, "IPv6MTUBytes=%d\n", def->ipv6_mtubytes);
+    }
+
     if (def->type >= ND_VIRTUAL)
         g_string_append(network, "ConfigureWithoutCarrier=yes\n");
 

--- a/src/nm.c
+++ b/src/nm.c
@@ -431,6 +431,11 @@ write_nm_conf_access_point(net_definition* def, const char* rootdir, const wifi_
     if (def->bond)
         g_string_append_printf(s, "slave-type=bond\nmaster=%s\n", def->bond);
 
+    if (def->ipv6_mtubytes) {
+        g_fprintf(stderr, "ERROR: %s: NetworkManager definitions do not support ipv6-mtu\n", def->id);
+        exit(1);
+    }
+
     if (def->type < ND_VIRTUAL) {
         GString *link_str = NULL;
 

--- a/src/parse.c
+++ b/src/parse.c
@@ -1537,6 +1537,7 @@ const mapping_entry_handler dhcp6_overrides_handlers[] = {
     {"dhcp6-overrides", YAML_MAPPING_NODE, NULL, dhcp6_overrides_handlers},                   \
     {"gateway4", YAML_SCALAR_NODE, handle_gateway4},                                          \
     {"gateway6", YAML_SCALAR_NODE, handle_gateway6},                                          \
+    {"ipv6-mtu", YAML_SCALAR_NODE, handle_netdef_guint, NULL, netdef_offset(ipv6_mtubytes)},  \
     {"ipv6-privacy", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(ip6_privacy)}, \
     {"link-local", YAML_SEQUENCE_NODE, handle_link_local},                                    \
     {"macaddress", YAML_SCALAR_NODE, handle_netdef_mac, NULL, netdef_offset(set_mac)},        \

--- a/src/parse.h
+++ b/src/parse.h
@@ -216,6 +216,8 @@ typedef struct net_definition {
 
     /* interface mtu */
     guint mtubytes;
+    /* ipv6 mtu */
+    guint ipv6_mtubytes;
 
     /* these properties are only valid for physical interfaces (type < ND_VIRTUAL) */
     char* set_name;

--- a/tests/generator/test_common.py
+++ b/tests/generator/test_common.py
@@ -79,8 +79,9 @@ UseMTU=true
               version: 2
               ethernets:
                 eth1:
-                  mtu: 1280
+                  mtu: 9000
                   dhcp4: n
+                  ipv6-mtu: 2000
               bonds:
                 bond0:
                   interfaces:
@@ -108,8 +109,8 @@ LinkLocalAddressing=ipv6
 ConfigureWithoutCarrier=yes
 VLAN=bond0.108
 ''',
-            'eth1.link': '[Match]\nOriginalName=eth1\n\n[Link]\nWakeOnLan=off\nMTUBytes=1280\n',
-            'eth1.network': '[Match]\nName=eth1\n\n[Network]\nLinkLocalAddressing=no\nBond=bond0\n'
+            'eth1.link': '[Match]\nOriginalName=eth1\n\n[Link]\nWakeOnLan=off\nMTUBytes=9000\n',
+            'eth1.network': '[Match]\nName=eth1\n\n[Network]\nLinkLocalAddressing=no\nIPv6MTUBytes=2000\nBond=bond0\n'
         })
         self.assert_networkd_udev(None)
 
@@ -575,6 +576,16 @@ method=link-local
 method=ignore
 ''',
         })
+
+    def test_ipv6_mtu(self):
+        self.generate(textwrap.dedent("""
+            network:
+              version: 2
+              renderer: NetworkManager
+              ethernets:
+                eth1:
+                  mtu: 9000
+                  ipv6-mtu: 2000"""), expect_fail=True)
 
     def test_eth_global_renderer(self):
         self.generate('''network:


### PR DESCRIPTION
## Description

Allow configuration of networkd's IPv6MTUBytes. network manager does not appear to allow this to be set except via router advisement.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [x] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Closes an open bug in Launchpad.

