### PR TITLE
io.netplan.Netplan.service.in: add assumed apparmor label

### DIFF
--- a/dbus/io.netplan.Netplan.service.in
+++ b/dbus/io.netplan.Netplan.service.in
@@ -2,3 +2,4 @@
 Name=io.netplan.Netplan
 Exec=@ROOTLIBEXECDIR@/netplan/netplan-dbus
 User=root
+AssumedAppArmorLabel=unconfined


### PR DESCRIPTION
## Description

This is needed for initial activation via D-Bus from a confined program such as
a snap. See https://github.com/snapcore/snapd/pull/7214#discussion_r314333683 as
well as https://bugs.launchpad.net/ubuntu/+source/systemd/+bug/1749000

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).

