### PR TITLE
Honor LDFLAGS when building netplan-dbus

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ generate: src/generate.[hc] src/parse.[hc] src/util.[hc] src/networkd.[hc] src/n
 	$(CC) $(BUILDFLAGS) $(CFLAGS) $(LDFLAGS) -o $@ $(filter %.c, $^) `pkg-config --cflags --libs glib-2.0 gio-2.0 yaml-0.1 uuid`
 
 netplan-dbus: src/dbus.c src/_features.h
-	$(CC) $(BUILDFLAGS) $(CFLAGS) -o $@ $^ `pkg-config --cflags --libs libsystemd glib-2.0`
+	$(CC) $(BUILDFLAGS) $(CFLAGS) $(LDFLAGS) -o $@ $^ `pkg-config --cflags --libs libsystemd glib-2.0`
 
 src/_features.h: src/[^_]*.[hc]
 	echo "#include <stddef.h>\nstatic const char *feature_flags[] __attribute__((__unused__)) = {" > $@


### PR DESCRIPTION
This is a follow-up to #91, not sure how I missed this, sorry about
that.

## Description
netplan-dbus is compiled and linked in a single command that honors
CFLAGS but not LDFLAGS. To make it easier for packagers, any linking
should honor LDFLAGS, so add them to the command.

## Checklist

- [x ] Runs `make check` successfully.
- [ x] Retains 100% code coverage (`make check-coverage`).
- [ x] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Closes an open bug in Launchpad.

