### PR TITLE
Allow parsing .yaml and .yml files

### DIFF
--- a/netplan/configmanager.py
+++ b/netplan/configmanager.py
@@ -95,7 +95,10 @@ class ConfigManager(object):
         # /run/netplan shadows /etc/netplan/, which shadows /lib/netplan
         names_to_paths = {}
         for yaml_dir in ['lib', 'etc', 'run']:
+            # Allow .yaml and .yml extension
             for yaml_file in glob.glob(os.path.join(self.prefix, yaml_dir, 'netplan', '*.yaml')):
+                names_to_paths[os.path.basename(yaml_file)] = yaml_file
+            for yaml_file in glob.glob(os.path.join(self.prefix, yaml_dir, 'netplan', '*.yml')):
                 names_to_paths[os.path.basename(yaml_file)] = yaml_file
 
         files = [names_to_paths[name] for name in sorted(names_to_paths.keys())]


### PR DESCRIPTION
## Description

Currently only .yaml files can be used, .yml is not allow. This is confusing for the user and causes a lot of unnecessary debugging time.

## Checklist

- [ ] Runs `make check` successfully.
- [ ] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Closes an open bug in Launchpad.

