### PR TITLE
Allow `critical` to be used without `dhcp4`/`dhcp6` enabled

### DIFF
--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -198,7 +198,7 @@ Virtual devices
 
 :   (networkd backend only) Designate the connection as "critical to the
     system", meaning that special care will be taken by systemd-networkd to
-    not release the IP from DHCP when the daemon is restarted.
+    not release the assigned IP when the daemon is restarted.
 
 ``dhcp-identifier`` (scalar)
 

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -550,14 +550,17 @@ write_network_file(net_definition* def, const char* rootdir, const char* path)
         }
     }
 
-    if (def->dhcp4 || def->dhcp6) {
+    if (def->dhcp4 || def->dhcp6 || def->critical) {
         /* NetworkManager compatible route metrics */
         g_string_append(network, "\n[DHCP]\n");
+    }
 
+    if (def->critical)
+        g_string_append_printf(network, "CriticalConnection=true\n");
+
+    if (def->dhcp4 || def->dhcp6) {
         if (g_strcmp0(def->dhcp_identifier, "duid") != 0)
             g_string_append_printf(network, "ClientIdentifier=%s\n", def->dhcp_identifier);
-        if (def->critical)
-            g_string_append_printf(network, "CriticalConnection=true\n");
 
         dhcp_overrides combined_dhcp_overrides;
         combine_dhcp_overrides(def, &combined_dhcp_overrides);

--- a/tests/generator/test_common.py
+++ b/tests/generator/test_common.py
@@ -296,7 +296,6 @@ UseMTU=true
   version: 2
   ethernets:
     engreen:
-      dhcp4: yes
       critical: yes
 ''')
 
@@ -304,13 +303,10 @@ UseMTU=true
 Name=engreen
 
 [Network]
-DHCP=ipv4
 LinkLocalAddressing=ipv6
 
 [DHCP]
 CriticalConnection=true
-RouteMetric=100
-UseMTU=true
 '''})
 
     def test_dhcp_identifier_mac(self):


### PR DESCRIPTION
## Description
This change allows the `critical` option to be used without `dhcp4` or `dhcp6` also being enabled. My understanding is that the underlying networkd option `CriticalConnection` also can prevent static IPs being dropped, not just ones assigned via DHCP. In my case, I needed to prevent IPs being assigned by keepalived from being dropped.

## Checklist

- [*] Runs `make check` successfully.
- [*] Retains 100% code coverage (`make check-coverage`).
- [*] New/changed keys in YAML format are documented.

