### PR TITLE
Add `phase2` keyword to `auth` section

### DIFF
--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -540,6 +540,9 @@ interfaces, as well as individual wifi networks, by means of the ``auth`` block.
      :    Password to use to decrypt the private key specified in
           ``client-key`` if it is encrypted.
 
+     ``phase2-auth`` (scalar)
+     :    Phase 2 authentication mechanism.
+
 
 ## Properties for device type ``ethernets:``
 Ethernet device definitions do not support any specific properties beyond the

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -726,6 +726,10 @@ append_wpa_auth_conf(GString* s, const authentication_settings* auth)
     if (auth->client_key_password) {
         g_string_append_printf(s, "  private_key_passwd=\"%s\"\n", auth->client_key_password);
     }
+    if (auth->phase2_auth) {
+        g_string_append_printf(s, "  phase2=\"auth=%s\"\n", auth->phase2_auth);
+    }
+
 }
 
 static void

--- a/src/nm.c
+++ b/src/nm.c
@@ -320,6 +320,10 @@ write_dot1x_auth_parameters(const authentication_settings* auth, GString *s)
     if (auth->client_key_password) {
         g_string_append_printf(s, "private-key-password=%s\n", auth->client_key_password);
     }
+    if (auth->phase2_auth) {
+        g_string_append_printf(s, "phase2-auth=%s\n", auth->phase2_auth);
+    }
+
 }
 
 static void

--- a/src/parse.c
+++ b/src/parse.c
@@ -496,6 +496,7 @@ const mapping_entry_handler auth_handlers[] = {
     {"client-certificate", YAML_SCALAR_NODE, handle_auth_str, NULL, auth_offset(client_certificate)},
     {"client-key", YAML_SCALAR_NODE, handle_auth_str, NULL, auth_offset(client_key)},
     {"client-key-password", YAML_SCALAR_NODE, handle_auth_str, NULL, auth_offset(client_key_password)},
+    {"phase2-auth", YAML_SCALAR_NODE, handle_auth_str, NULL, auth_offset(phase2_auth)},
     {NULL}
 };
 

--- a/src/parse.h
+++ b/src/parse.h
@@ -154,6 +154,7 @@ typedef struct authentication_settings {
     char* client_certificate;
     char* client_key;
     char* client_key_password;
+    char* phase2_auth;
 } authentication_settings;
 
 /* Fields below are valid for dhcp4 and dhcp6 unless otherwise noted. */

--- a/tests/generator/test_auth.py
+++ b/tests/generator/test_auth.py
@@ -174,6 +174,7 @@ network={
         client-certificate: /etc/ssl/cust-crt.pem
         client-key: /etc/ssl/cust-key.pem
         client-key-password: "d3cryptPr1v4t3K3y"
+        phase2-auth: MSCHAPV2
       dhcp4: yes
       ''')
 
@@ -196,6 +197,7 @@ network={
   client_cert="/etc/ssl/cust-crt.pem"
   private_key="/etc/ssl/cust-key.pem"
   private_key_passwd="d3cryptPr1v4t3K3y"
+  phase2="auth=MSCHAPV2"
 }
 ''')
             self.assertEqual(stat.S_IMODE(os.fstat(f.fileno()).st_mode), 0o600)
@@ -249,6 +251,7 @@ class TestNetworkManager(TestBase):
             client-certificate: /etc/ssl/cust-crt.pem
             client-key: /etc/ssl/cust-key.pem
             client-key-password: "d3cryptPr1v4t3K3y"
+            phase2-auth: MSCHAPV2
         opennet:
           auth:
             key-management: none
@@ -413,6 +416,7 @@ ca-cert=/etc/ssl/cust-cacrt.pem
 client-cert=/etc/ssl/cust-crt.pem
 private-key=/etc/ssl/cust-key.pem
 private-key-password=d3cryptPr1v4t3K3y
+phase2-auth=MSCHAPV2
 ''',
                         'wl0-opennet': '''[connection]
 id=netplan-wl0-opennet


### PR DESCRIPTION
## Description

For corporate wired 802.1x networks, a common config is PEAP plus an
MSCHAPv2 phase2. This is supported by wpa_supplicant, and NM, but not
netplan. This adds support for that.

Signed-off-by: Phil Dibowitz <phil@ipom.com>

## Checklist

- [X] Runs `make check` successfully.
- [X] Retains 100% code coverage (`make check-coverage`).
- [X] New/changed keys in YAML format are documented.
- [x] \(Optional\) Closes an open bug in Launchpad.

