### PR TITLE
networkd: set MTUBytes= in .network files as well

### DIFF
--- a/src/networkd.c
+++ b/src/networkd.c
@@ -448,6 +448,9 @@ write_network_file(net_definition* def, const char* rootdir, const char* path)
         }
     }
 
+    if (def->mtubytes) {
+        g_string_append_printf(link, "MTUBytes=%d\n", def->mtubytes);
+    }
 
     if (def->dhcp4 && def->dhcp6)
         g_string_append(network, "DHCP=yes\n");

--- a/tests/generator/test_common.py
+++ b/tests/generator/test_common.py
@@ -104,13 +104,26 @@ ConfigureWithoutCarrier=yes
             'bond0.network': '''[Match]
 Name=bond0
 
+[Link]
+MTUBytes=9000
+
 [Network]
 LinkLocalAddressing=ipv6
 ConfigureWithoutCarrier=yes
 VLAN=bond0.108
 ''',
             'eth1.link': '[Match]\nOriginalName=eth1\n\n[Link]\nWakeOnLan=off\nMTUBytes=9000\n',
-            'eth1.network': '[Match]\nName=eth1\n\n[Network]\nLinkLocalAddressing=no\nIPv6MTUBytes=2000\nBond=bond0\n'
+            'eth1.network': '''[Match]
+Name=eth1
+
+[Link]
+MTUBytes=9000
+
+[Network]
+LinkLocalAddressing=no
+IPv6MTUBytes=2000
+Bond=bond0
+'''
         })
         self.assert_networkd_udev(None)
 

--- a/tests/generator/test_ethernets.py
+++ b/tests/generator/test_ethernets.py
@@ -58,6 +58,9 @@ unmanaged-devices+=interface-name:eth0,''')
                               'eth1.network': '''[Match]
 Name=eth1
 
+[Link]
+MTUBytes=1280
+
 [Network]
 LinkLocalAddressing=ipv6
 '''})


### PR DESCRIPTION
This will account for virtual devices or cases where running in containers.

Signed-off-by: Mathieu Trudel-Lapierre <mathieu.trudel-lapierre@canonical.com>


## Description


## Checklist

- [ ] Runs `make check` successfully.
- [ ] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Closes an open bug in Launchpad.

