### PR TITLE
Add option `emit-lldp` for networkd backend

### DIFF
--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -135,7 +135,7 @@ Virtual devices
 
 ``emit-lldp`` (bool)
 
-:    (networkd backend only) Whether to emit LLDP packets. Off by default
+:    (networkd backend only) Whether to emit LLDP packets. Off by default.
 
 
 ## Common properties for all device types

--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -133,6 +133,10 @@ Virtual devices
 
 :    Enable wake on LAN. Off by default.
 
+``emit-lldp`` (bool)
+
+:    (networkd backend only) Whether to emit LLDP packets. Off by default
+
 
 ## Common properties for all device types
 

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -452,6 +452,10 @@ write_network_file(net_definition* def, const char* rootdir, const char* path)
         g_string_append_printf(link, "MTUBytes=%d\n", def->mtubytes);
     }
 
+    if (def->emit_lldp) {
+        g_string_append(network, "EmitLLDP=true\n");
+    }
+
     if (def->dhcp4 && def->dhcp6)
         g_string_append(network, "DHCP=yes\n");
     else if (def->dhcp4)

--- a/src/parse.c
+++ b/src/parse.c
@@ -1576,7 +1576,8 @@ const mapping_entry_handler dhcp6_overrides_handlers[] = {
 #define PHYSICAL_LINK_HANDLERS                                                           \
     {"match", YAML_MAPPING_NODE, handle_match},                                          \
     {"set-name", YAML_SCALAR_NODE, handle_netdef_str, NULL, netdef_offset(set_name)},    \
-    {"wakeonlan", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(wake_on_lan)}
+    {"wakeonlan", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(wake_on_lan)}, \
+    {"emit-lldp", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(emit_lldp)}
 
 const mapping_entry_handler ethernet_def_handlers[] = {
     COMMON_LINK_HANDLERS,

--- a/src/parse.h
+++ b/src/parse.h
@@ -234,6 +234,8 @@ typedef struct net_definition {
     } match;
     gboolean has_match;
     gboolean wake_on_lan;
+    gboolean emit_lldp;
+
 
     /* these properties are only valid for ND_WIFI */
     GHashTable* access_points; /* SSID → wifi_access_point* */

--- a/tests/generator/test_ethernets.py
+++ b/tests/generator/test_ethernets.py
@@ -46,6 +46,22 @@ unmanaged-devices+=interface-name:eth0,''')
         # should not allow NM to manage everything
         self.assertFalse(os.path.exists(self.nm_enable_all_conf))
 
+    def test_eth_lldp(self):
+        self.generate('''network:
+  version: 2
+  ethernets:
+    eth0:
+      dhcp4: n
+      emit-lldp: true''')
+
+        self.assert_networkd({'eth0.network': '''[Match]
+Name=eth0
+
+[Network]
+EmitLLDP=true
+LinkLocalAddressing=ipv6
+'''})
+
     def test_eth_mtu(self):
         self.generate('''network:
   version: 2


### PR DESCRIPTION
## Description
It is actually sadly not possible to say to networkd to send lldp packets on its interfaces. This is really useful in a profesional environment.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [x] New/changed keys in YAML format are documented.
- [x] \(Optional\) Closes an open bug in Launchpad.[BUG 1862607](https://bugs.launchpad.net/netplan/+bug/1862607)

