### PR TITLE
Fix quotation of WPA PSK hex passthrough for networkd

### DIFF
--- a/examples/wireless_wpa_psk.yaml
+++ b/examples/wireless_wpa_psk.yaml
@@ -1,0 +1,14 @@
+network:
+  version: 2
+  renderer: networkd
+  wifis:
+    wlp2s0b1:
+      dhcp4: no
+      dhcp6: no
+      addresses: [192.168.0.21/24]
+      gateway4: 192.168.0.1
+      nameservers:
+        addresses: [192.168.0.1, 8.8.8.8]
+      access-points:
+        "network_ssid_name":
+          password: "hex:****************************************************************"

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -708,7 +708,11 @@ append_wpa_auth_conf(GString* s, const authentication_settings* auth)
     }
     if (auth->password) {
         if (auth->key_management == KEY_MANAGEMENT_WPA_PSK) {
-            g_string_append_printf(s, "  psk=\"%s\"\n", auth->password);
+            if (strncmp(auth->password, "hex:", 4) == 0 && strlen(auth->password) > 4) {
+                g_string_append_printf(s, "  psk=%s\n", 4 + auth->password);
+            } else {
+                g_string_append_printf(s, "  psk=\"%s\"\n", auth->password);
+            }
         } else {
             if (strncmp(auth->password, "hash:", 5) == 0) {
                 g_string_append_printf(s, "  password=%s\n", auth->password);

--- a/tests/generator/test_auth.py
+++ b/tests/generator/test_auth.py
@@ -36,6 +36,12 @@ class TestNetworkd(TestBase):
           auth:
             key-management: psk
             password: "4lsos3kr1t"
+        "BobsHome":
+          password: "hex:e03ce667c87bc81ca968d9120ca37f89eb09aec3c55b80386e5d772efd6b926e"
+        "BillsHome":
+          auth:
+            key-management: psk
+            password: "hex:db3b0acf5653aeaddd5fe034fb9f07175b2864f847b005aaa2f09182d9411b04"
         workplace:
           auth:
             key-management: eap
@@ -98,6 +104,20 @@ network={
   ssid="Luke's Home"
   key_mgmt=WPA-PSK
   psk="4lsos3kr1t"
+}
+''', new_config)
+            self.assertIn('''
+network={
+  ssid="BobsHome"
+  key_mgmt=WPA-PSK
+  psk=e03ce667c87bc81ca968d9120ca37f89eb09aec3c55b80386e5d772efd6b926e
+}
+''', new_config)
+            self.assertIn('''
+network={
+  ssid="BillsHome"
+  key_mgmt=WPA-PSK
+  psk=e03ce667c87bc81ca968d9120ca37f89eb09aec3c55b80386e5d772efd6b926e
 }
 ''', new_config)
             self.assertIn('''


### PR DESCRIPTION
## Description

This changeset provides the ability to supply a WPA PSK compatible hex string in the `netplan` YAML configuration, which then `networkd` can use for the `wpa_supplicant` configuration. Essentially, this ensures that a hex string, indicated by the prefix `hex:`, will be passed through unquoted to retain `wpa_supplicant` configuration compatibility

This directly addresses the `netplan` ticket here: https://bugs.launchpad.net/netplan/+bug/1867690

## Checklist

- [x] Runs `make check` successfully.
- [ ] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [x] \(Optional\) Closes an open bug in Launchpad.

