### PR TITLE
Initial support for GSM modems for NetworkManager backend – 2

### DIFF
--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -30,7 +30,7 @@ either of those directories shadows a file with the same name in
 The top-level node in a netplan configuration file is a ``network:`` mapping
 that contains ``version: 2`` (the YAML currently being used by curtin, MaaS,
 etc. is version 1), and then device definitions grouped by their type, such as
-``ethernets:``, ``wifis:``, or ``bridges:``. These are the types that our
+``ethernets:``, ``gsms:``, ``wifis:``, or ``bridges:``. These are the types that our
 renderer can understand and are supported by our backends.
 
 Each type block contains device definitions as a map where the keys (called
@@ -52,7 +52,7 @@ and the ID field has a different interpretation for each:
 
 Physical devices
 
-:   (Examples: ethernet, wifi) These can dynamically come and go between
+:   (Examples: ethernet, gsm, wifi) These can dynamically come and go between
     reboots and even during runtime (hotplugging). In the generic case, they
     can be selected by ``match:`` rules on desired properties, such as name/name
     pattern, MAC address, driver, or device paths. In general these will match
@@ -547,6 +547,45 @@ interfaces, as well as individual wifi networks, by means of the ``auth`` block.
 ## Properties for device type ``ethernets:``
 Ethernet device definitions do not support any specific properties beyond the
 common ones described above.
+
+## Properties for device type ``gsms:``
+GSM modem configuration is only supported for the ``NetworkManager`` backend. ``systemd-networkd`` does
+not support GSM modems.
+
+``apn`` (scalar)
+:    Set the carrier APN (Access Point Name). This can be omitted if ``auto-config`` is enabled.
+
+``auto-config`` (bool)
+:    Specify whether to try and autoconfigure the modem by doing a lookup of the carrier
+     against the Mobile Broadband Provider database. This may not work for all carriers.
+
+``device-id`` (scalar)
+:    Specify the device ID (as given by the WWAN management service) of the modem to match.
+     This can be found using ``mmcli``.
+
+``network-id`` (scalar)
+:    Specify the Network ID (GSM LAI format). If this is specified, the device will not roam networks.
+
+``password`` (scalar)
+:    Specify the password used to authenticate with the carrier network. This can be omitted
+     if ``auto-config`` is enabled.
+
+``pin`` (scalar)
+:    Specify the SIM PIN to allow it to operate if a PIN is set.
+
+``sim-id`` (scalar)
+:    Specify the SIM unique identifier (as given by the WWAN management service) which this
+     connection applies to. If given, the connection will apply to any device also allowed by
+     ``device-id`` which contains a SIM card matching the given identifier.
+
+``sim-operator-id`` (scalar)
+:    Specify the MCC/MNC string (such as "310260" or "21601") which identifies the carrier that
+     this connection should apply to. If given, the connection will apply to any device also
+     allowed by ``device-id`` and ``sim-id`` which contains a SIM card provisioned by the given operator.
+
+``username`` (scalar)
+:    Specify the username used to authentiate with the carrier network. This can be omitted if
+     ``auto-config`` is enabled.
 
 ## Properties for device type ``wifis:``
 Note that ``systemd-networkd`` does not natively support wifi, so you need

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -841,6 +841,11 @@ write_networkd_conf(net_definition* def, const char* rootdir)
         return FALSE;
     }
 
+    if (def->type == ND_GSM) {
+        g_fprintf(stderr, "ERROR: %s: networkd backend does not support GSM modem configuration\n", def->id);
+        exit(1);
+    }
+
     if (def->type == ND_WIFI || def->has_auth) {
         g_autofree char* link = g_strjoin(NULL, rootdir ?: "", "/run/systemd/system/systemd-networkd.service.wants/netplan-wpa-", def->id, ".service", NULL);
         g_autofree char* slink = g_strjoin(NULL, "/run/systemd/system/netplan-wpa-", def->id, ".service", NULL);

--- a/src/nm.c
+++ b/src/nm.c
@@ -79,6 +79,8 @@ type_str(netdef_type type)
     switch (type) {
         case ND_ETHERNET:
             return "ethernet";
+        case ND_GSM:
+            return "gsm";
         case ND_WIFI:
             return "wifi";
         case ND_BRIDGE:
@@ -422,6 +424,33 @@ write_nm_conf_access_point(net_definition* def, const char* rootdir, const wifi_
 
         if (def->type == ND_BRIDGE)
             write_bridge_params(def, s);
+    }
+    if (def->type == ND_GSM) {
+        g_string_append_printf(s, "\n[gsm]\n");
+
+        /* Use NetworkManager's auto configuration feature if no APN, username, or password is specified */
+        if (def->gsm_params.auto_config || (!def->gsm_params.apn &&
+                !def->gsm_params.username && !def->gsm_params.password)) {
+            g_string_append_printf(s, "auto-config=true\n");
+        } else {
+            if (def->gsm_params.apn)
+                g_string_append_printf(s, "apn=%s\n", def->gsm_params.apn);
+            if (def->gsm_params.password)
+                g_string_append_printf(s, "password=%s\n", def->gsm_params.password);
+            if (def->gsm_params.username)
+                g_string_append_printf(s, "username=%s\n", def->gsm_params.username);
+        }
+
+        if (def->gsm_params.device_id)
+            g_string_append_printf(s, "device-id=%s", def->gsm_params.device_id);
+        if (def->gsm_params.network_id)
+            g_string_append_printf(s, "network-id=%s\n", def->gsm_params.network_id);
+        if (def->gsm_params.pin)
+            g_string_append_printf(s, "pin=%s\n", def->gsm_params.pin);
+        if (def->gsm_params.sim_id)
+            g_string_append_printf(s, "sim-id=%s\n", def->gsm_params.sim_id);
+        if (def->gsm_params.sim_operator_id)
+            g_string_append_printf(s, "sim-operator-id=%s\n", def->gsm_params.sim_operator_id);
     }
     if (def->bridge) {
         g_string_append_printf(s, "slave-type=bridge\nmaster=%s\n", def->bridge);

--- a/src/nm.c
+++ b/src/nm.c
@@ -442,7 +442,7 @@ write_nm_conf_access_point(net_definition* def, const char* rootdir, const wifi_
         }
 
         if (def->gsm_params.device_id)
-            g_string_append_printf(s, "device-id=%s", def->gsm_params.device_id);
+            g_string_append_printf(s, "device-id=%s\n", def->gsm_params.device_id);
         if (def->gsm_params.network_id)
             g_string_append_printf(s, "network-id=%s\n", def->gsm_params.network_id);
         if (def->gsm_params.pin)

--- a/src/parse.c
+++ b/src/parse.c
@@ -1614,6 +1614,19 @@ const mapping_entry_handler vlan_def_handlers[] = {
     {NULL}
 };
 
+const mapping_entry_handler gsm_def_handlers[] = {
+    COMMON_LINK_HANDLERS,
+    {"apn", YAML_SCALAR_NODE, handle_netdef_str, NULL, netdef_offset(gsm_params.apn)},
+    {"auto-config", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(gsm_params.auto_config)},
+    {"device-id", YAML_SCALAR_NODE, handle_netdef_str, NULL, netdef_offset(gsm_params.device_id)},
+    {"network-id", YAML_SCALAR_NODE, handle_netdef_str, NULL, netdef_offset(gsm_params.network_id)},
+    {"password", YAML_SCALAR_NODE, handle_netdef_str, NULL, netdef_offset(gsm_params.password)},
+    {"pin", YAML_SCALAR_NODE, handle_netdef_str, NULL, netdef_offset(gsm_params.pin)},
+    {"sim-id", YAML_SCALAR_NODE, handle_netdef_str, NULL, netdef_offset(gsm_params.sim_id)},
+    {"sim-operator-id", YAML_SCALAR_NODE, handle_netdef_str, NULL, netdef_offset(gsm_params.sim_operator_id)},
+    {"username", YAML_SCALAR_NODE, handle_netdef_str, NULL, netdef_offset(gsm_params.username)},
+};
+
 const mapping_entry_handler tunnel_def_handlers[] = {
     COMMON_LINK_HANDLERS,
     {"mode", YAML_SCALAR_NODE, handle_tunnel_mode},
@@ -1736,6 +1749,7 @@ handle_network_type(yaml_document_t* doc, yaml_node_t* node, const void* data, G
             case ND_BOND: handlers = bond_def_handlers; break;
             case ND_BRIDGE: handlers = bridge_def_handlers; break;
             case ND_ETHERNET: handlers = ethernet_def_handlers; break;
+            case ND_GSM: handlers = gsm_def_handlers; break;
             case ND_TUNNEL: handlers = tunnel_def_handlers; break;
             case ND_VLAN: handlers = vlan_def_handlers; break;
             case ND_WIFI: handlers = wifi_def_handlers; break;
@@ -1766,6 +1780,7 @@ const mapping_entry_handler network_handlers[] = {
     {"version", YAML_SCALAR_NODE, handle_network_version},
     {"vlans", YAML_MAPPING_NODE, handle_network_type, NULL, GUINT_TO_POINTER(ND_VLAN)},
     {"wifis", YAML_MAPPING_NODE, handle_network_type, NULL, GUINT_TO_POINTER(ND_WIFI)},
+    {"gsms", YAML_MAPPING_NODE, handle_network_type, NULL, GUINT_TO_POINTER(ND_GSM)},
     {NULL}
 };
 

--- a/src/parse.h
+++ b/src/parse.h
@@ -43,6 +43,7 @@ typedef enum {
     /* physical devices */
     ND_ETHERNET,
     ND_WIFI,
+    ND_GSM,
     /* virtual devices */
     ND_VIRTUAL,
     ND_BRIDGE = ND_VIRTUAL,
@@ -261,6 +262,18 @@ typedef struct net_definition {
         char* learn_interval;
         char* primary_slave;
     } bond_params;
+
+    struct {
+        char* apn;
+        gboolean auto_config;
+        char* device_id;
+        char* network_id;
+        char* password;
+        char* pin;
+        char* sim_id;
+        char* sim_operator_id;
+        char* username;
+    } gsm_params;
 
     struct {
         char* ageing_time;

--- a/tests/generator/test_gsm.py
+++ b/tests/generator/test_gsm.py
@@ -1,0 +1,295 @@
+#
+# Tests for gsm devices config generated via netplan
+#
+# Copyright (C) 2020 Canonical, Ltd.
+# Author: Lukas Märdian <lukas.maerdian@canonical.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# import os #FIXME
+
+from .base import TestBase
+
+
+class TestNetworkd(TestBase):
+    '''networkd output'''
+
+    def test_not_supported(self):
+        # does not produce any output, but fails with:
+        # "networkd backend does not support GSM modem configuration"
+        err = self.generate('''network:
+  version: 2
+  gsms:
+    mobilephone:
+      auto-config: true''', expect_fail=True)
+        self.assertIn("ERROR: mobilephone: networkd backend does not support GSM modem configuration", err)
+
+        self.assert_networkd({})
+        self.assert_nm({})
+
+
+class TestNetworkManager(TestBase):
+    '''networkmanager output'''
+
+    def test_gsm_auto_config(self):
+        self.generate('''network:
+  version: 2
+  renderer: NetworkManager
+  gsms:
+    mobilephone:
+      auto-config: true''')
+        self.assert_nm({'mobilephone': '''[connection]
+id=netplan-mobilephone
+type=gsm
+interface-name=mobilephone
+
+[gsm]
+auto-config=true
+
+[ethernet]
+wake-on-lan=0
+
+[ipv4]
+method=link-local
+
+[ipv6]
+method=ignore
+'''})
+        self.assert_networkd({})
+        self.assert_nm_udev(None)
+
+    def test_gsm_auto_config_implicit(self):
+        self.generate('''network:
+  version: 2
+  renderer: NetworkManager
+  gsms:
+    mobilephone:
+      pin: "1234"''')
+        self.assert_nm({'mobilephone': '''[connection]
+id=netplan-mobilephone
+type=gsm
+interface-name=mobilephone
+
+[gsm]
+auto-config=true
+pin=1234
+
+[ethernet]
+wake-on-lan=0
+
+[ipv4]
+method=link-local
+
+[ipv6]
+method=ignore
+'''})
+        self.assert_networkd({})
+        self.assert_nm_udev(None)
+
+    def test_gsm_apn(self):
+        self.generate('''network:
+  version: 2
+  renderer: NetworkManager
+  gsms:
+    mobilephone:
+      apn: internet''')
+        self.assert_nm({'mobilephone': '''[connection]
+id=netplan-mobilephone
+type=gsm
+interface-name=mobilephone
+
+[gsm]
+apn=internet
+
+[ethernet]
+wake-on-lan=0
+
+[ipv4]
+method=link-local
+
+[ipv6]
+method=ignore
+'''})
+        self.assert_networkd({})
+        self.assert_nm_udev(None)
+
+    def test_gsm_apn_username_password(self):
+        self.generate('''network:
+  version: 2
+  renderer: NetworkManager
+  gsms:
+    mobilephone:
+      apn: internet
+      username: some-user
+      password: some-pass''')
+        self.assert_nm({'mobilephone': '''[connection]
+id=netplan-mobilephone
+type=gsm
+interface-name=mobilephone
+
+[gsm]
+apn=internet
+password=some-pass
+username=some-user
+
+[ethernet]
+wake-on-lan=0
+
+[ipv4]
+method=link-local
+
+[ipv6]
+method=ignore
+'''})
+        self.assert_networkd({})
+        self.assert_nm_udev(None)
+
+    def test_gsm_device_id(self):
+        self.generate('''network:
+  version: 2
+  renderer: NetworkManager
+  gsms:
+    mobilephone:
+      device-id: test''')
+        self.assert_nm({'mobilephone': '''[connection]
+id=netplan-mobilephone
+type=gsm
+interface-name=mobilephone
+
+[gsm]
+auto-config=true
+device-id=test
+
+[ethernet]
+wake-on-lan=0
+
+[ipv4]
+method=link-local
+
+[ipv6]
+method=ignore
+'''})
+        self.assert_networkd({})
+        self.assert_nm_udev(None)
+
+    def test_gsm_network_id(self):
+        self.generate('''network:
+  version: 2
+  renderer: NetworkManager
+  gsms:
+    mobilephone:
+      network-id: test''')
+        self.assert_nm({'mobilephone': '''[connection]
+id=netplan-mobilephone
+type=gsm
+interface-name=mobilephone
+
+[gsm]
+auto-config=true
+network-id=test
+
+[ethernet]
+wake-on-lan=0
+
+[ipv4]
+method=link-local
+
+[ipv6]
+method=ignore
+'''})
+        self.assert_networkd({})
+        self.assert_nm_udev(None)
+
+    def test_gsm_pin(self):
+        self.generate('''network:
+  version: 2
+  renderer: NetworkManager
+  gsms:
+    mobilephone:
+      pin: 1234''')
+        self.assert_nm({'mobilephone': '''[connection]
+id=netplan-mobilephone
+type=gsm
+interface-name=mobilephone
+
+[gsm]
+auto-config=true
+pin=1234
+
+[ethernet]
+wake-on-lan=0
+
+[ipv4]
+method=link-local
+
+[ipv6]
+method=ignore
+'''})
+        self.assert_networkd({})
+        self.assert_nm_udev(None)
+
+    def test_gsm_sim_id(self):
+        self.generate('''network:
+  version: 2
+  renderer: NetworkManager
+  gsms:
+    mobilephone:
+      sim-id: test''')
+        self.assert_nm({'mobilephone': '''[connection]
+id=netplan-mobilephone
+type=gsm
+interface-name=mobilephone
+
+[gsm]
+auto-config=true
+sim-id=test
+
+[ethernet]
+wake-on-lan=0
+
+[ipv4]
+method=link-local
+
+[ipv6]
+method=ignore
+'''})
+        self.assert_networkd({})
+        self.assert_nm_udev(None)
+
+    def test_gsm_sim_operator_id(self):
+        self.generate('''network:
+  version: 2
+  renderer: NetworkManager
+  gsms:
+    mobilephone:
+      sim-operator-id: test''')
+        self.assert_nm({'mobilephone': '''[connection]
+id=netplan-mobilephone
+type=gsm
+interface-name=mobilephone
+
+[gsm]
+auto-config=true
+sim-operator-id=test
+
+[ethernet]
+wake-on-lan=0
+
+[ipv4]
+method=link-local
+
+[ipv6]
+method=ignore
+'''})
+        self.assert_networkd({})
+        self.assert_nm_udev(None)


### PR DESCRIPTION
## Description
This PR adds initial support for GSM modems for the NetworkManager renderer.
It is an update to PR #117 from @cedws 

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [x] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Closes an open bug in Launchpad.

