### PR TITLE
Adopt integration tests for NetworkManager v1.22 (focal)

### DIFF
--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -362,7 +362,7 @@ class IntegrationTestsBase(unittest.TestCase):
                                                 stderr=subprocess.PIPE, universal_newlines=True)
                 self.fail('timed out waiting for networkd to settle down:\n%s\n%s\n%s' % (st, st_e, st_e2))
 
-        if subprocess.call(['nm-online', '--quiet', '--timeout=120', '--wait-for-startup']) != 0:
+        if subprocess.call(['nm-online', '--quiet', '--timeout=240', '--wait-for-startup']) != 0:
             self.fail('timed out waiting for NetworkManager to settle down')
 
     def nm_wait_connected(self, iface, timeout):

--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -28,6 +28,7 @@ import subprocess
 import tempfile
 import unittest
 import shutil
+import gi
 
 test_backends = "networkd NetworkManager" if "NETPLAN_TEST_BACKENDS" not in os.environ else os.environ["NETPLAN_TEST_BACKENDS"]
 
@@ -364,6 +365,22 @@ class IntegrationTestsBase(unittest.TestCase):
 
         if subprocess.call(['nm-online', '--quiet', '--timeout=240', '--wait-for-startup']) != 0:
             self.fail('timed out waiting for NetworkManager to settle down')
+
+    def nm_online_full(self, iface, timeout=60):
+        '''Wait for NetworkManager connection to be completed (incl. IP4 & DHCP)'''
+
+        gi.require_version('NM', '1.0')
+        from gi.repository import NM
+        for t in range(timeout):
+            c = NM.Client.new(None)
+            con = c.get_device_by_iface(iface).get_active_connection()
+            if not con: self.fail('no active connection for %s by NM' % iface)
+            flags = NM.utils_enum_to_str(NM.ActivationStateFlags, con.get_state_flags())
+            if "ip4-ready" in flags:
+                break
+            time.sleep(1)
+        else:
+            self.fail('timed out waiting for %s to get ready by NM' % iface)
 
     def nm_wait_connected(self, iface, timeout):
         for t in range(timeout):

--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -374,7 +374,8 @@ class IntegrationTestsBase(unittest.TestCase):
         for t in range(timeout):
             c = NM.Client.new(None)
             con = c.get_device_by_iface(iface).get_active_connection()
-            if not con: self.fail('no active connection for %s by NM' % iface)
+            if not con:
+                self.fail('no active connection for %s by NM' % iface)
             flags = NM.utils_enum_to_str(NM.ActivationStateFlags, con.get_state_flags())
             if "ip4-ready" in flags:
                 break

--- a/tests/integration/ethernets.py
+++ b/tests/integration/ethernets.py
@@ -93,6 +93,8 @@ class _CommonTests():
         search: ["fakesuffix"]
 ''' % {'r': self.backend, 'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
         self.generate_and_settle()
+        if self.backend == 'NetworkManager':
+            self.nm_online_full(self.dev_e_client)
         self.assert_iface_up(self.dev_e_client,
                              ['inet 172.16.42.99/18',
                               'inet6 1234:ffff::42/64',


### PR DESCRIPTION
## Description
NetworkManager changed the "startup complete" behavior in v1.22, this is  why in some cases the test runs, even though the network is not yet fully up and running (i.e. only IPv6, not IPv4 & IPv6).

see: https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/commit/1e5206414af83ede1e4e1ff6f525161b83519845

This is why we use libnm and pygobject to check for the n-m internal NM_ACTIVATION_STATE_FLAG_IP4_READY flag via d-bus, instead of just waiting for the `nm-online` binary ("startup complete" state).

In order to make the tests run, we **need the following dependencies** inside the Debian package (`debian/tests/control`), for the "ethernets" test:
    +  libnm0,
    +  python3-gi,
    +  gir1.2-nm-1.0,

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Closes an open bug in Launchpad.

