### PR TITLE
Fix symbolic link of libnetplan.so installation in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ install: default
 	ln -srf $(DESTDIR)/$(ROOTLIBEXECDIR)/netplan/generate $(DESTDIR)/$(SYSTEMD_GENERATOR_DIR)/netplan
 	# lib
 	install -m 644 *.so.* $(DESTDIR)/$(LIBDIR)/
-	ln -snf $(DESTDIR)/$(LIBDIR)/libnetplan.so.$(NETPLAN_SOVER) $(DESTDIR)/$(LIBDIR)/libnetplan.so
+	ln -snf libnetplan.so.$(NETPLAN_SOVER) $(DESTDIR)/$(LIBDIR)/libnetplan.so
 	# headers, dev data
 	install -m 644 src/*.h $(DESTDIR)/$(INCLUDEDIR)/netplan/
 	# TODO: install pkg-config once available


### PR DESCRIPTION
## Description
Currently the symbolic link of the `netplan-dev` package installs an invalid link to an absolute location of the build environment/machine.

We need to fix the _Makefile_, to install a relative symbolic link instead:
`libnetplan.so -> libnetplan.so.0.0`

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Closes an open bug in Launchpad.

