### PR TITLE
Fix missing Require= in service unit

### DIFF
--- a/src/networkd.c
+++ b/src/networkd.c
@@ -782,7 +782,7 @@ write_wpa_unit(const NetplanNetDefinition* def, const char* rootdir)
     g_autofree char* path = g_strjoin(NULL, "/run/systemd/system/netplan-wpa-", stdouth, ".service", NULL);
     g_string_append_printf(s, "Description=WPA supplicant for netplan %s\n", stdouth);
     g_string_append(s, "DefaultDependencies=no\n");
-    g_string_append_printf(s, "Requires=sys-subsystem-net-devices-$s.device\n", stdouth);
+    g_string_append_printf(s, "Requires=sys-subsystem-net-devices-%s.device\n", stdouth);
     g_string_append_printf(s, "After=sys-subsystem-net-devices-%s.device\n", stdouth);
     g_string_append(s, "Before=network.target\nWants=network.target\n\n");
     g_string_append(s, "[Service]\nType=simple\n");

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -782,6 +782,7 @@ write_wpa_unit(const NetplanNetDefinition* def, const char* rootdir)
     g_autofree char* path = g_strjoin(NULL, "/run/systemd/system/netplan-wpa-", stdouth, ".service", NULL);
     g_string_append_printf(s, "Description=WPA supplicant for netplan %s\n", stdouth);
     g_string_append(s, "DefaultDependencies=no\n");
+    g_string_append_printf(s, "Requires=sys-subsystem-net-devices-$s.device\n", stdouth);
     g_string_append_printf(s, "After=sys-subsystem-net-devices-%s.device\n", stdouth);
     g_string_append(s, "Before=network.target\nWants=network.target\n\n");
     g_string_append(s, "[Service]\nType=simple\n");


### PR DESCRIPTION
## Description
 
Fix function _write_wpa_unit(..._ absence of derective "Require=" for systemd service Unit. 
It cause wpa_supplicant service to failed on boot.

## Checklist

Checklist for **aarch64** and **x64**

- [x] Runs `make check` successfully.
- [ ] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Closes an open bug in Launchpad.

