### PR TITLE
Implement WiFi flags for bssid/band/channel

### DIFF
--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -638,6 +638,10 @@ wpasupplicant installed if you let the ``networkd`` renderer handle wifi.
           numbers overlap between bands, this property takes effect only if
           the ``band`` property is set, too.
 
+     ``seen-bssids`` (sequence of scalars)
+     :    A list of BSSIDs (each BSSID formatted as a MAC address) that have
+          been detected as part of the Wi-Fi network.
+
 ## Properties for device type ``bridges:``
 
 ``interfaces`` (sequence of scalars)

--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -624,6 +624,20 @@ wpasupplicant installed if you let the ``networkd`` renderer handle wifi.
           and ``adhoc`` (peer to peer networks without a central access point).
           ``ap`` is only supported with NetworkManager.
 
+     ``bssid`` (scalar)
+     :    If specified, directs the device to only associate with the given
+          access point.
+
+     ``band`` (scalar)
+     :    Possible bands are ``a`` (for 5GHz 802.11a) and ``bg``
+          (for 2.4GHz 802.11), do not restrict the 802.11 frequency band of the
+          network if unset (the default).
+
+     ``channel`` (scalar)
+     :    Wireless channel to use for the Wi-Fi connection. Because channel
+          numbers overlap between bands, this property takes effect only if
+          the ``band`` property is set, too.
+
 ## Properties for device type ``bridges:``
 
 ``interfaces`` (sequence of scalars)

--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -638,12 +638,6 @@ wpasupplicant installed if you let the ``networkd`` renderer handle wifi.
           numbers overlap between bands, this property takes effect only if
           the ``band`` property is also set.
 
-     ``seen-bssids`` (sequence of scalars)
-     :    A list of BSSIDs (each BSSID formatted as a MAC address) that have
-          been detected as part of the Wi-Fi network. This property is only
-          meant for reading and reflects an internal state of NetworkManager.
-          The changes you make to this property will not be preserved.
-
 ## Properties for device type ``bridges:``
 
 ``interfaces`` (sequence of scalars)

--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -640,8 +640,9 @@ wpasupplicant installed if you let the ``networkd`` renderer handle wifi.
 
      ``seen-bssids`` (sequence of scalars)
      :    A list of BSSIDs (each BSSID formatted as a MAC address) that have
-          been detected as part of the Wi-Fi network. This is only supported
-          with NetworkManager.
+          been detected as part of the Wi-Fi network. This is a read-only
+          option, used only to track NetworkManager's state when using the
+          netplan read-write plugin.
 
 ## Properties for device type ``bridges:``
 

--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -640,7 +640,8 @@ wpasupplicant installed if you let the ``networkd`` renderer handle wifi.
 
      ``seen-bssids`` (sequence of scalars)
      :    A list of BSSIDs (each BSSID formatted as a MAC address) that have
-          been detected as part of the Wi-Fi network.
+          been detected as part of the Wi-Fi network. This is only supported
+          with NetworkManager.
 
 ## Properties for device type ``bridges:``
 

--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -629,20 +629,20 @@ wpasupplicant installed if you let the ``networkd`` renderer handle wifi.
           access point.
 
      ``band`` (scalar)
-     :    Possible bands are ``a`` (for 5GHz 802.11a) and ``bg``
+     :    Possible bands are ``5GHz`` (for 5GHz 802.11a) and ``2.4GHz``
           (for 2.4GHz 802.11), do not restrict the 802.11 frequency band of the
           network if unset (the default).
 
      ``channel`` (scalar)
      :    Wireless channel to use for the Wi-Fi connection. Because channel
           numbers overlap between bands, this property takes effect only if
-          the ``band`` property is set, too.
+          the ``band`` property is also set.
 
      ``seen-bssids`` (sequence of scalars)
      :    A list of BSSIDs (each BSSID formatted as a MAC address) that have
-          been detected as part of the Wi-Fi network. This is a read-only
-          option, used only to track NetworkManager's state when using the
-          netplan read-write plugin.
+          been detected as part of the Wi-Fi network. This property is only
+          meant for reading and reflects an internal state of NetworkManager.
+          The changes you make to this property will not be preserved.
 
 ## Properties for device type ``bridges:``
 

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -821,32 +821,29 @@ write_wpa_conf(const NetplanNetDefinition* def, const char* rootdir)
             if (ap->bssid) {
                 g_string_append_printf(s, "  bssid=%s\n", ap->bssid);
             }
-            if (ap->band) {
-                if (ap->band == NETPLAN_WIFI_BAND_24) {
-                    // initialize frequency hashtable
-                    if(!wifi_frequency_24)
-                        wifi_get_freq24(1);
-                    if (ap->channel) {
-                        g_string_append_printf(s, "  freq_list=%d\n", wifi_get_freq24(ap->channel));
-                    } else {
-                        g_string_append_printf(s, "  freq_list=");
-                        g_hash_table_foreach(wifi_frequency_24, wifi_append_freq, s);
-                        // overwrite last whitespace with newline
-                        s = g_string_overwrite(s, s->len-1, "\n");
-                    }
+            if (ap->band == NETPLAN_WIFI_BAND_24) {
+                // initialize 2.4GHz frequency hashtable
+                if(!wifi_frequency_24)
+                    wifi_get_freq24(1);
+                if (ap->channel) {
+                    g_string_append_printf(s, "  freq_list=%d\n", wifi_get_freq24(ap->channel));
+                } else {
+                    g_string_append_printf(s, "  freq_list=");
+                    g_hash_table_foreach(wifi_frequency_24, wifi_append_freq, s);
+                    // overwrite last whitespace with newline
+                    s = g_string_overwrite(s, s->len-1, "\n");
                 }
-                if (ap->band == NETPLAN_WIFI_BAND_5) {
-                    // initialize frequency hashtable
-                    if(!wifi_frequency_5)
-                        wifi_get_freq5(7);
-                    if (ap->channel) {
-                        g_string_append_printf(s, "  freq_list=%d\n", wifi_get_freq5(ap->channel));
-                    } else {
-                        g_string_append_printf(s, "  freq_list=");
-                        g_hash_table_foreach(wifi_frequency_5, wifi_append_freq, s);
-                        // overwrite last whitespace with newline
-                        s = g_string_overwrite(s, s->len-1, "\n");
-                    }
+            } else if (ap->band == NETPLAN_WIFI_BAND_5) {
+                // initialize 5GHz frequency hashtable
+                if(!wifi_frequency_5)
+                    wifi_get_freq5(7);
+                if (ap->channel) {
+                    g_string_append_printf(s, "  freq_list=%d\n", wifi_get_freq5(ap->channel));
+                } else {
+                    g_string_append_printf(s, "  freq_list=");
+                    g_hash_table_foreach(wifi_frequency_5, wifi_append_freq, s);
+                    // overwrite last whitespace with newline
+                    s = g_string_overwrite(s, s->len-1, "\n");
                 }
             }
             if (ap->seen_bssids) {

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -29,6 +29,15 @@
 #include "parse.h"
 #include "util.h"
 
+/**
+ * Append WiFi frequencies to wpa_supplicant's freq_list=
+ */
+static void
+wifi_append_freq(gpointer key, gpointer value, gpointer user_data)
+{
+    GString* s = user_data;
+    g_string_append_printf(s, "%d ", GPOINTER_TO_INT(value));
+}
 
 /**
  * Append [Match] section of @def to @s.
@@ -809,6 +818,41 @@ write_wpa_conf(const NetplanNetDefinition* def, const char* rootdir)
         g_hash_table_iter_init(&iter, def->access_points);
         while (g_hash_table_iter_next(&iter, NULL, (gpointer) &ap)) {
             g_string_append_printf(s, "network={\n  ssid=\"%s\"\n", ap->ssid);
+            if (ap->bssid) {
+                g_string_append_printf(s, "  bssid=%s\n", ap->bssid);
+            }
+            if (ap->band) {
+                if (ap->band == NETPLAN_WIFI_BAND_24) {
+                    // initialize frequency hashtable
+                    if(!wifi_frequency_24)
+                        wifi_get_freq24(1);
+                    if (ap->channel) {
+                        g_string_append_printf(s, "  freq_list=%d\n", wifi_get_freq24(ap->channel));
+                    } else {
+                        g_string_append_printf(s, "  freq_list=");
+                        g_hash_table_foreach(wifi_frequency_24, wifi_append_freq, s);
+                        // overwrite last whitespace with newline
+                        s = g_string_overwrite(s, s->len-1, "\n");
+                    }
+                }
+                if (ap->band == NETPLAN_WIFI_BAND_5) {
+                    // initialize frequency hashtable
+                    if(!wifi_frequency_5)
+                        wifi_get_freq5(7);
+                    if (ap->channel) {
+                        g_string_append_printf(s, "  freq_list=%d\n", wifi_get_freq5(ap->channel));
+                    } else {
+                        g_string_append_printf(s, "  freq_list=");
+                        g_hash_table_foreach(wifi_frequency_5, wifi_append_freq, s);
+                        // overwrite last whitespace with newline
+                        s = g_string_overwrite(s, s->len-1, "\n");
+                    }
+                }
+            }
+            if (ap->seen_bssids) {
+                g_fprintf(stderr, "ERROR: %s: networkd backend does not support the collection of seen bssids\n", def->id);
+                exit(1);
+            }
             switch (ap->mode) {
                 case NETPLAN_WIFI_MODE_INFRASTRUCTURE:
                     /* default in wpasupplicant */

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -846,10 +846,6 @@ write_wpa_conf(const NetplanNetDefinition* def, const char* rootdir)
                     s = g_string_overwrite(s, s->len-1, "\n");
                 }
             }
-            if (ap->seen_bssids) {
-                g_fprintf(stderr, "ERROR: %s: networkd backend does not support the collection of seen bssids\n", def->id);
-                exit(1);
-            }
             switch (ap->mode) {
                 case NETPLAN_WIFI_MODE_INFRASTRUCTURE:
                     /* default in wpasupplicant */

--- a/src/nm.c
+++ b/src/nm.c
@@ -679,6 +679,13 @@ write_nm_conf_access_point(NetplanNetDefinition* def, const char* rootdir, const
                 g_string_append_printf(s, "channel=%u\n", ap->channel);
             }
         }
+        if (ap->seen_bssids) {
+            g_string_append_printf(s, "seen-bssids=");
+            for (unsigned i = 0; i < ap->seen_bssids->len; ++i) {
+                g_string_append_printf(s, "%s;", g_array_index(ap->seen_bssids, char*, i));
+            }
+            g_string_append_printf(s, "\n");
+        }
         if (ap->has_auth) {
             write_wifi_auth_parameters(&ap->auth, s);
         }

--- a/src/nm.c
+++ b/src/nm.c
@@ -684,13 +684,6 @@ write_nm_conf_access_point(NetplanNetDefinition* def, const char* rootdir, const
                 g_string_append_printf(s, "channel=%u\n", ap->channel);
             }
         }
-        if (ap->seen_bssids) {
-            g_string_append_printf(s, "seen-bssids=");
-            for (unsigned i = 0; i < ap->seen_bssids->len; ++i) {
-                g_string_append_printf(s, "%s;", g_array_index(ap->seen_bssids, char*, i));
-            }
-            g_string_append_printf(s, "\n");
-        }
         if (ap->has_auth) {
             write_wifi_auth_parameters(&ap->auth, s);
         }

--- a/src/nm.c
+++ b/src/nm.c
@@ -674,8 +674,13 @@ write_nm_conf_access_point(NetplanNetDefinition* def, const char* rootdir, const
         }
         if (ap->band == NETPLAN_WIFI_BAND_5 || ap->band == NETPLAN_WIFI_BAND_24) {
             g_string_append_printf(s, "band=%s\n", wifi_band_str(ap->band));
+            /* Channel is only unambiguous, if band is set. */
             if (ap->channel) {
-                /* Channel is only unambiguous, if band is set. */
+                /* Validate WiFi channel */
+                if (ap->band == NETPLAN_WIFI_BAND_5)
+                    wifi_get_freq5(ap->channel);
+                else
+                    wifi_get_freq24(ap->channel);
                 g_string_append_printf(s, "channel=%u\n", ap->channel);
             }
         }

--- a/src/nm.c
+++ b/src/nm.c
@@ -139,6 +139,24 @@ wifi_mode_str(const NetplanWifiMode mode)
     }
 }
 
+/**
+ * Return NM wifi "band=" string.
+ */
+static const char*
+wifi_band_str(const NetplanWifiBand band)
+{
+    switch (band) {
+        case NETPLAN_WIFI_BAND_5:
+            return "a";
+        case NETPLAN_WIFI_BAND_24:
+            return "bg";
+        // LCOV_EXCL_START
+        default:
+            g_assert_not_reached();
+        // LCOV_EXCL_STOP
+    }
+}
+
 static void
 write_search_domains(const NetplanNetDefinition* def, GString *s)
 {
@@ -651,6 +669,16 @@ write_nm_conf_access_point(NetplanNetDefinition* def, const char* rootdir, const
         conf_path = g_strjoin(NULL, "run/NetworkManager/system-connections/netplan-", def->id, "-", escaped_ssid, ".nmconnection", NULL);
 
         g_string_append_printf(s, "\n[wifi]\nssid=%s\nmode=%s\n", ap->ssid, wifi_mode_str(ap->mode));
+        if (ap->bssid) {
+            g_string_append_printf(s, "bssid=%s\n", ap->bssid);
+        }
+        if (ap->band == NETPLAN_WIFI_BAND_5 || ap->band == NETPLAN_WIFI_BAND_24) {
+            g_string_append_printf(s, "band=%s\n", wifi_band_str(ap->band));
+            if (ap->channel) {
+                /* Channel is only unambiguous, if band is set. */
+                g_string_append_printf(s, "channel=%u\n", ap->channel);
+            }
+        }
         if (ap->has_auth) {
             write_wifi_auth_parameters(&ap->auth, s);
         }

--- a/src/parse.c
+++ b/src/parse.c
@@ -617,9 +617,9 @@ static gboolean
 handle_access_point_band(yaml_document_t* doc, yaml_node_t* node, const void* _, GError** error)
 {
     g_assert(cur_access_point);
-    if (strcmp(scalar(node), "a") == 0)
+    if (strcmp(scalar(node), "5GHz") == 0 || strcmp(scalar(node), "5G") == 0)
         cur_access_point->band = NETPLAN_WIFI_BAND_5;
-    else if (strcmp(scalar(node), "bg") == 0)
+    else if (strcmp(scalar(node), "2.4GHz") == 0 || strcmp(scalar(node), "2.4G") == 0)
         cur_access_point->band = NETPLAN_WIFI_BAND_24;
     else
         return yaml_error(node, error, "unknown wifi band '%s'", scalar(node));

--- a/src/parse.c
+++ b/src/parse.c
@@ -626,38 +626,12 @@ handle_access_point_band(yaml_document_t* doc, yaml_node_t* node, const void* _,
     return TRUE;
 }
 
-static gboolean
-handle_access_point_bssids(yaml_document_t* doc, yaml_node_t* node, const void* _, GError** error)
-{
-    for (yaml_node_item_t *i = node->data.sequence.items.start; i < node->data.sequence.items.top; i++) {
-        g_autofree char* addr = NULL;
-        yaml_node_t *entry = yaml_document_get_node(doc, *i);
-        assert_type(entry, YAML_SCALAR_NODE);
-
-        addr = g_strdup(scalar(entry));
-
-        /* is it a MAC address? */
-        if (is_mac_address(addr)) {
-            if (!cur_access_point->seen_bssids)
-                cur_access_point->seen_bssids = g_array_new(FALSE, FALSE, sizeof(char*));
-            char* s = g_strdup(scalar(entry));
-            g_array_append_val(cur_access_point->seen_bssids, s);
-            continue;
-        }
-
-        return yaml_error(node, error, "malformed bssid %s, must be XX:XX:XX:XX:XX:XX", scalar(entry));
-    }
-
-    return TRUE;
-}
-
 static const mapping_entry_handler wifi_access_point_handlers[] = {
     {"band", YAML_SCALAR_NODE, handle_access_point_band},
     {"bssid", YAML_SCALAR_NODE, handle_access_point_mac, NULL, access_point_offset(bssid)},
     {"channel", YAML_SCALAR_NODE, handle_access_point_guint, NULL, access_point_offset(channel)},
     {"mode", YAML_SCALAR_NODE, handle_access_point_mode},
     {"password", YAML_SCALAR_NODE, handle_access_point_password},
-    {"seen-bssids", YAML_SEQUENCE_NODE, handle_access_point_bssids},
     {"auth", YAML_MAPPING_NODE, handle_access_point_auth},
     {NULL}
 };

--- a/src/parse.c
+++ b/src/parse.c
@@ -626,12 +626,38 @@ handle_access_point_band(yaml_document_t* doc, yaml_node_t* node, const void* _,
     return TRUE;
 }
 
+static gboolean
+handle_access_point_bssids(yaml_document_t* doc, yaml_node_t* node, const void* _, GError** error)
+{
+    for (yaml_node_item_t *i = node->data.sequence.items.start; i < node->data.sequence.items.top; i++) {
+        g_autofree char* addr = NULL;
+        yaml_node_t *entry = yaml_document_get_node(doc, *i);
+        assert_type(entry, YAML_SCALAR_NODE);
+
+        addr = g_strdup(scalar(entry));
+
+        /* is it a MAC address? */
+        if (is_mac_address(addr)) {
+            if (!cur_access_point->seen_bssids)
+                cur_access_point->seen_bssids = g_array_new(FALSE, FALSE, sizeof(char*));
+            char* s = g_strdup(scalar(entry));
+            g_array_append_val(cur_access_point->seen_bssids, s);
+            continue;
+        }
+
+        return yaml_error(node, error, "malformed bssid %s, must be XX:XX:XX:XX:XX:XX", scalar(entry));
+    }
+
+    return TRUE;
+}
+
 static const mapping_entry_handler wifi_access_point_handlers[] = {
     {"band", YAML_SCALAR_NODE, handle_access_point_band},
     {"bssid", YAML_SCALAR_NODE, handle_access_point_mac, NULL, access_point_offset(bssid)},
     {"channel", YAML_SCALAR_NODE, handle_access_point_guint, NULL, access_point_offset(channel)},
     {"mode", YAML_SCALAR_NODE, handle_access_point_mode},
     {"password", YAML_SCALAR_NODE, handle_access_point_password},
+    {"seen-bssids", YAML_SEQUENCE_NODE, handle_access_point_bssids},
     {"auth", YAML_MAPPING_NODE, handle_access_point_auth},
     {NULL}
 };

--- a/src/parse.h
+++ b/src/parse.h
@@ -338,6 +338,7 @@ typedef struct {
     NetplanWifiBand band;
     char* bssid;
     guint channel;
+    GArray* seen_bssids;
 
     NetplanAuthenticationSettings auth;
     gboolean has_auth;

--- a/src/parse.h
+++ b/src/parse.h
@@ -244,8 +244,8 @@ struct net_definition {
     gboolean emit_lldp;
 
 
-    /* these properties are only valid for ND_WIFI */
-    GHashTable* access_points; /* SSID → wifi_access_point* */
+    /* these properties are only valid for NETPLAN_DEF_TYPE_WIFI */
+    GHashTable* access_points; /* SSID → NetplanWifiAccessPoint* */
 
     struct {
         char* mode;
@@ -326,9 +326,18 @@ typedef enum {
     NETPLAN_WIFI_MODE_AP
 } NetplanWifiMode;
 
+typedef enum {
+    NETPLAN_WIFI_BAND_DEFAULT,
+    NETPLAN_WIFI_BAND_5,
+    NETPLAN_WIFI_BAND_24
+} NetplanWifiBand;
+
 typedef struct {
     NetplanWifiMode mode;
     char* ssid;
+    NetplanWifiBand band;
+    char* bssid;
+    guint channel;
 
     NetplanAuthenticationSettings auth;
     gboolean has_auth;

--- a/src/parse.h
+++ b/src/parse.h
@@ -338,7 +338,6 @@ typedef struct {
     NetplanWifiBand band;
     char* bssid;
     guint channel;
-    GArray* seen_bssids;
 
     NetplanAuthenticationSettings auth;
     gboolean has_auth;

--- a/src/util.c
+++ b/src/util.c
@@ -126,8 +126,10 @@ wifi_get_freq5(int channel)
                        155, 157, 159, 161, 165, 169, 173 };
     gboolean found = FALSE;
     for (unsigned i = 0; i < sizeof(channels) / sizeof(int); i++) {
-        if (channel == channels[i])
+        if (channel == channels[i]) {
             found = TRUE;
+            break;
+        }
     }
     if (!found) {
         g_fprintf(stderr, "ERROR: invalid 5GHz WiFi channel: %d\n", channel);

--- a/src/util.c
+++ b/src/util.c
@@ -86,3 +86,63 @@ unlink_glob(const char* rootdir, const char* _glob)
     for (size_t i = 0; i < gl.gl_pathc; ++i)
         unlink(gl.gl_pathv[i]);
 }
+
+/**
+ * Get the frequency of a given 2.4GHz WiFi channel
+ */
+int
+wifi_get_freq24(int channel)
+{
+    if (channel < 1 || channel > 14) {
+        g_fprintf(stderr, "ERROR: invalid 2.4GHz WiFi channel: %d\n", channel);
+        exit(1);
+    }
+
+    if (!wifi_frequency_24) {
+        wifi_frequency_24 = g_hash_table_new(g_direct_hash, g_direct_equal);
+        /* Initialize 2.4GHz frequencies, as of:
+         * https://en.wikipedia.org/wiki/List_of_WLAN_channels#2.4_GHz_(802.11b/g/n/ax) */
+        for (unsigned i = 0; i < 13; i++) {
+            g_hash_table_insert(wifi_frequency_24, GINT_TO_POINTER(i+1),
+                                GINT_TO_POINTER(2412+i*5));
+        }
+        g_hash_table_insert(wifi_frequency_24, GINT_TO_POINTER(14),
+                            GINT_TO_POINTER(2484));
+    }
+    return GPOINTER_TO_INT(g_hash_table_lookup(wifi_frequency_24,
+                           GINT_TO_POINTER(channel)));
+}
+
+/**
+ * Get the frequency of a given 5GHz WiFi channel
+ */
+int
+wifi_get_freq5(int channel)
+{
+    int channels[] = { 7, 8, 9, 11, 12, 16, 32, 34, 36, 38, 40, 42, 44, 46, 48,
+                       50, 52, 54, 56, 58, 60, 62, 64, 68, 96, 100, 102, 104,
+                       106, 108, 110, 112, 114, 116, 118, 120, 122, 124, 126,
+                       128, 132, 134, 136, 138, 140, 142, 144, 149, 151, 153,
+                       155, 157, 159, 161, 165, 169, 173 };
+    gboolean found = FALSE;
+    for (unsigned i = 0; i < sizeof(channels) / sizeof(int); i++) {
+        if (channel == channels[i])
+            found = TRUE;
+    }
+    if (!found) {
+        g_fprintf(stderr, "ERROR: invalid 5GHz WiFi channel: %d\n", channel);
+        exit(1);
+    }
+    if (!wifi_frequency_5) {
+        wifi_frequency_5 = g_hash_table_new(g_direct_hash, g_direct_equal);
+        /* Initialize 5GHz frequencies, as of:
+         * https://en.wikipedia.org/wiki/List_of_WLAN_channels#5.0_GHz_(802.11j)_WLAN
+         * Skipping channels 183-196. They are valid only in Japan with registration needed */
+        for (unsigned i = 0; i < sizeof(channels) / sizeof(int); i++) {
+            g_hash_table_insert(wifi_frequency_5, GINT_TO_POINTER(channels[i]),
+                                GINT_TO_POINTER(5000+channels[i]*5));
+        }
+    }
+    return GPOINTER_TO_INT(g_hash_table_lookup(wifi_frequency_5,
+                           GINT_TO_POINTER(channel)));
+}

--- a/src/util.h
+++ b/src/util.h
@@ -17,6 +17,12 @@
 
 #pragma once
 
+GHashTable* wifi_frequency_24;
+GHashTable* wifi_frequency_5;
+
 void safe_mkdir_p_dir(const char* file_path);
 void g_string_free_to_file(GString* s, const char* rootdir, const char* path, const char* suffix);
 void unlink_glob(const char* rootdir, const char* _glob);
+
+int wifi_get_freq24(int channel);
+int wifi_get_freq5(int channel);

--- a/src/validation.c
+++ b/src/validation.c
@@ -57,23 +57,6 @@ is_ip6_address(const char* address)
     return FALSE;
 }
 
-gboolean
-is_mac_address(const char* address)
-{
-    static regex_t re;
-    static gboolean re_inited = FALSE;
-
-    if (!re_inited) {
-        g_assert(regcomp(&re, "^[[:xdigit:]][[:xdigit:]]:[[:xdigit:]][[:xdigit:]]:[[:xdigit:]][[:xdigit:]]:[[:xdigit:]][[:xdigit:]]:[[:xdigit:]][[:xdigit:]]:[[:xdigit:]][[:xdigit:]]$", REG_EXTENDED|REG_NOSUB) == 0);
-        re_inited = TRUE;
-    }
-
-    if (regexec(&re, address, 0, NULL, 0) != 0)
-        return FALSE;
-
-    return TRUE;
-}
-
 /************************************************
  * Validation for grammar and backend rules.
  ************************************************/

--- a/src/validation.c
+++ b/src/validation.c
@@ -19,6 +19,7 @@
 #include <glib/gstdio.h>
 #include <gio/gio.h>
 #include <arpa/inet.h>
+#include <regex.h>
 
 #include <yaml.h>
 
@@ -54,6 +55,23 @@ is_ip6_address(const char* address)
         return TRUE;
 
     return FALSE;
+}
+
+gboolean
+is_mac_address(const char* address)
+{
+    static regex_t re;
+    static gboolean re_inited = FALSE;
+
+    if (!re_inited) {
+        g_assert(regcomp(&re, "^[[:xdigit:]][[:xdigit:]]:[[:xdigit:]][[:xdigit:]]:[[:xdigit:]][[:xdigit:]]:[[:xdigit:]][[:xdigit:]]:[[:xdigit:]][[:xdigit:]]:[[:xdigit:]][[:xdigit:]]$", REG_EXTENDED|REG_NOSUB) == 0);
+        re_inited = TRUE;
+    }
+
+    if (regexec(&re, address, 0, NULL, 0) != 0)
+        return FALSE;
+
+    return TRUE;
 }
 
 /************************************************

--- a/src/validation.h
+++ b/src/validation.h
@@ -22,7 +22,6 @@
 
 gboolean is_ip4_address(const char* address);
 gboolean is_ip6_address(const char* address);
-gboolean is_mac_address(const char* address);
 
 gboolean
 validate_netdef_grammar(NetplanNetDefinition* nd, yaml_node_t* node, GError** error);

--- a/src/validation.h
+++ b/src/validation.h
@@ -22,6 +22,7 @@
 
 gboolean is_ip4_address(const char* address);
 gboolean is_ip6_address(const char* address);
+gboolean is_mac_address(const char* address);
 
 gboolean
 validate_netdef_grammar(NetplanNetDefinition* nd, yaml_node_t* node, GError** error);

--- a/tests/generator/test_errors.py
+++ b/tests/generator/test_errors.py
@@ -220,6 +220,16 @@ class TestConfigErrors(TestBase):
           band: bogus''', expect_fail=True)
         self.assertIn("unknown wifi band 'bogus'", err)
 
+    def test_wifi_ap_malformed_bssid(self):
+        err = self.generate('''network:
+  version: 2
+  wifis:
+    wl0:
+      access-points:
+        workplace:
+          seen-bssids: ["00:11:22:33:44:55", "xx:yy:zz:aa:bb:cc"]''', expect_fail=True)
+        self.assertIn("malformed bssid xx:yy:zz:aa:bb:cc, must be XX:XX:XX:XX:XX:XX", err)
+
     def test_invalid_ipv4_address(self):
         err = self.generate('''network:
   version: 2

--- a/tests/generator/test_errors.py
+++ b/tests/generator/test_errors.py
@@ -210,6 +210,16 @@ class TestConfigErrors(TestBase):
           mode: bogus''', expect_fail=True)
         self.assertIn("unknown wifi mode 'bogus'", err)
 
+    def test_wifi_ap_unknown_band(self):
+        err = self.generate('''network:
+  version: 2
+  wifis:
+    wl0:
+      access-points:
+        workplace:
+          band: bogus''', expect_fail=True)
+        self.assertIn("unknown wifi band 'bogus'", err)
+
     def test_invalid_ipv4_address(self):
         err = self.generate('''network:
   version: 2

--- a/tests/generator/test_errors.py
+++ b/tests/generator/test_errors.py
@@ -243,6 +243,7 @@ class TestConfigErrors(TestBase):
     def test_wifi_ap_invalid_freq24(self):
         err = self.generate('''network:
   version: 2
+  renderer: NetworkManager
   wifis:
     wl0:
       access-points:

--- a/tests/generator/test_errors.py
+++ b/tests/generator/test_errors.py
@@ -230,6 +230,38 @@ class TestConfigErrors(TestBase):
           seen-bssids: ["00:11:22:33:44:55", "xx:yy:zz:aa:bb:cc"]''', expect_fail=True)
         self.assertIn("malformed bssid xx:yy:zz:aa:bb:cc, must be XX:XX:XX:XX:XX:XX", err)
 
+    def test_wifi_ap_bssids_not_supported(self):
+        err = self.generate('''network:
+  version: 2
+  wifis:
+    wl0:
+      access-points:
+        workplace:
+          seen-bssids: ["00:11:22:33:44:55", "de:ad:be:ef:ca:fe"]''', expect_fail=True)
+        self.assertIn("ERROR: wl0: networkd backend does not support the collection of seen bssids", err)
+
+    def test_wifi_ap_invalid_freq24(self):
+        err = self.generate('''network:
+  version: 2
+  wifis:
+    wl0:
+      access-points:
+        workplace:
+          band: bg
+          channel: 15''', expect_fail=True)
+        self.assertIn("ERROR: invalid 2.4GHz WiFi channel: 15", err)
+
+    def test_wifi_ap_invalid_freq5(self):
+        err = self.generate('''network:
+  version: 2
+  wifis:
+    wl0:
+      access-points:
+        workplace:
+          band: a
+          channel: 14''', expect_fail=True)
+        self.assertIn("ERROR: invalid 5GHz WiFi channel: 14", err)
+
     def test_invalid_ipv4_address(self):
         err = self.generate('''network:
   version: 2

--- a/tests/generator/test_errors.py
+++ b/tests/generator/test_errors.py
@@ -248,7 +248,7 @@ class TestConfigErrors(TestBase):
     wl0:
       access-points:
         workplace:
-          band: bg
+          band: 2.4GHz
           channel: 15''', expect_fail=True)
         self.assertIn("ERROR: invalid 2.4GHz WiFi channel: 15", err)
 
@@ -259,7 +259,7 @@ class TestConfigErrors(TestBase):
     wl0:
       access-points:
         workplace:
-          band: a
+          band: 5GHz
           channel: 14''', expect_fail=True)
         self.assertIn("ERROR: invalid 5GHz WiFi channel: 14", err)
 

--- a/tests/generator/test_errors.py
+++ b/tests/generator/test_errors.py
@@ -220,26 +220,6 @@ class TestConfigErrors(TestBase):
           band: bogus''', expect_fail=True)
         self.assertIn("unknown wifi band 'bogus'", err)
 
-    def test_wifi_ap_malformed_bssid(self):
-        err = self.generate('''network:
-  version: 2
-  wifis:
-    wl0:
-      access-points:
-        workplace:
-          seen-bssids: ["00:11:22:33:44:55", "xx:yy:zz:aa:bb:cc"]''', expect_fail=True)
-        self.assertIn("malformed bssid xx:yy:zz:aa:bb:cc, must be XX:XX:XX:XX:XX:XX", err)
-
-    def test_wifi_ap_bssids_not_supported(self):
-        err = self.generate('''network:
-  version: 2
-  wifis:
-    wl0:
-      access-points:
-        workplace:
-          seen-bssids: ["00:11:22:33:44:55", "de:ad:be:ef:ca:fe"]''', expect_fail=True)
-        self.assertIn("ERROR: wl0: networkd backend does not support the collection of seen bssids", err)
-
     def test_wifi_ap_invalid_freq24(self):
         err = self.generate('''network:
   version: 2

--- a/tests/generator/test_wifis.py
+++ b/tests/generator/test_wifis.py
@@ -194,7 +194,7 @@ class TestNetworkManager(TestBase):
           password: "c0mpany1"
           bssid: de:ad:be:ef:ca:fe
           band: a
-          channel: 22
+          channel: 100
         channel-no-band:
           channel: 22
         band-no-channel:
@@ -246,7 +246,7 @@ ssid=workplace
 mode=infrastructure
 bssid=de:ad:be:ef:ca:fe
 band=a
-channel=22
+channel=100
 
 [wifi-security]
 key-mgmt=wpa-psk

--- a/tests/generator/test_wifis.py
+++ b/tests/generator/test_wifis.py
@@ -145,8 +145,18 @@ class TestNetworkManager(TestBase):
       access-points:
         "Joe's Home":
           password: "s0s3kr1t"
+          bssid: 00:11:22:33:44:55
+          band: bg
+          channel: 11
         workplace:
           password: "c0mpany1"
+          bssid: de:ad:be:ef:ca:fe
+          band: a
+          channel: 22
+        channel-no-band:
+          channel: 22
+        band-no-channel:
+          band: a
       dhcp4: yes''')
 
         self.assert_nm({'wl0-Joe%27s%20Home': '''[connection]
@@ -166,6 +176,9 @@ method=ignore
 [wifi]
 ssid=Joe's Home
 mode=infrastructure
+bssid=00:11:22:33:44:55
+band=bg
+channel=11
 
 [wifi-security]
 key-mgmt=wpa-psk
@@ -188,10 +201,50 @@ method=ignore
 [wifi]
 ssid=workplace
 mode=infrastructure
+bssid=de:ad:be:ef:ca:fe
+band=a
+channel=22
 
 [wifi-security]
 key-mgmt=wpa-psk
 psk=c0mpany1
+''',
+                        'wl0-channel-no-band': '''[connection]
+id=netplan-wl0-channel-no-band
+type=wifi
+interface-name=wl0
+
+[ethernet]
+wake-on-lan=0
+
+[ipv4]
+method=auto
+
+[ipv6]
+method=ignore
+
+[wifi]
+ssid=channel-no-band
+mode=infrastructure
+''',
+                        'wl0-band-no-channel': '''[connection]
+id=netplan-wl0-band-no-channel
+type=wifi
+interface-name=wl0
+
+[ethernet]
+wake-on-lan=0
+
+[ipv4]
+method=auto
+
+[ipv6]
+method=ignore
+
+[wifi]
+ssid=band-no-channel
+mode=infrastructure
+band=a
 '''})
         self.assert_networkd({})
         self.assert_nm_udev(None)

--- a/tests/generator/test_wifis.py
+++ b/tests/generator/test_wifis.py
@@ -32,10 +32,22 @@ class TestNetworkd(TestBase):
       access-points:
         "Joe's Home":
           password: "s0s3kr1t"
+          bssid: 00:11:22:33:44:55
+          band: bg
+          channel: 11
         workplace:
           password: "c0mpany1"
+          bssid: de:ad:be:ef:ca:fe
+          band: a
+          channel: 100
         peer2peer:
           mode: adhoc
+        channel-no-band:
+          channel: 7
+        band-no-channel:
+          band: bg
+        band-no-channel2:
+          band: a
       dhcp4: yes''')
 
         self.assert_networkd({'wl0.network': ND_WIFI_DHCP4 % 'wl0'})
@@ -49,6 +61,28 @@ unmanaged-devices+=interface-name:wl0,''')
             new_config = f.read()
             self.assertIn('''
 network={
+  ssid="band-no-channel2"
+  freq_list=5610 5310 5620 5320 5630 5640 5340 5035 5040 5045 5055 5060 5660 5680 5670 5080 5690 5700 5710 5720 5825 5745 5755 \
+5805 5765 5160 5775 5170 5480 5180 5795 5190 5500 5200 5510 5210 5520 5220 5530 5230 5540 5240 5550 5250 5560 5260 5570 5270 \
+5580 5280 5590 5290 5600 5300 5865 5845 5785
+  key_mgmt=NONE
+}
+''', new_config)
+            self.assertIn('''
+network={
+  ssid="band-no-channel"
+  freq_list=2412 2417 2422 2427 2432 2442 2447 2437 2452 2457 2462 2467 2472 2484
+  key_mgmt=NONE
+}
+''', new_config)
+            self.assertIn('''
+network={
+  ssid="channel-no-band"
+  key_mgmt=NONE
+}
+''', new_config)
+            self.assertIn('''
+network={
   ssid="peer2peer"
   mode=1
   key_mgmt=NONE
@@ -57,6 +91,8 @@ network={
             self.assertIn('''
 network={
   ssid="workplace"
+  bssid=de:ad:be:ef:ca:fe
+  freq_list=5500
   key_mgmt=WPA-PSK
   psk="c0mpany1"
 }
@@ -64,6 +100,8 @@ network={
             self.assertIn('''
 network={
   ssid="Joe's Home"
+  bssid=00:11:22:33:44:55
+  freq_list=2462
   key_mgmt=WPA-PSK
   psk="s0s3kr1t"
 }

--- a/tests/generator/test_wifis.py
+++ b/tests/generator/test_wifis.py
@@ -33,21 +33,21 @@ class TestNetworkd(TestBase):
         "Joe's Home":
           password: "s0s3kr1t"
           bssid: 00:11:22:33:44:55
-          band: bg
+          band: 2.4GHz
           channel: 11
         workplace:
           password: "c0mpany1"
           bssid: de:ad:be:ef:ca:fe
-          band: a
+          band: 5GHz
           channel: 100
         peer2peer:
           mode: adhoc
         channel-no-band:
           channel: 7
         band-no-channel:
-          band: bg
+          band: 2.4G
         band-no-channel2:
-          band: a
+          band: 5G
       dhcp4: yes''')
 
         self.assert_networkd({'wl0.network': ND_WIFI_DHCP4 % 'wl0'})
@@ -184,7 +184,7 @@ class TestNetworkManager(TestBase):
         "Joe's Home":
           password: "s0s3kr1t"
           bssid: 00:11:22:33:44:55
-          band: bg
+          band: 2.4GHz
           channel: 11
           seen-bssids:
             - de:ad:be:ef:ca:fe
@@ -193,12 +193,12 @@ class TestNetworkManager(TestBase):
         workplace:
           password: "c0mpany1"
           bssid: de:ad:be:ef:ca:fe
-          band: a
+          band: 5GHz
           channel: 100
         channel-no-band:
           channel: 22
         band-no-channel:
-          band: a
+          band: 5GHz
       dhcp4: yes''')
 
         self.assert_nm({'wl0-Joe%27s%20Home': '''[connection]

--- a/tests/generator/test_wifis.py
+++ b/tests/generator/test_wifis.py
@@ -186,10 +186,6 @@ class TestNetworkManager(TestBase):
           bssid: 00:11:22:33:44:55
           band: 2.4GHz
           channel: 11
-          seen-bssids:
-            - de:ad:be:ef:ca:fe
-            - 00:11:22:33:44:55
-            - 55:44:33:22:11:00
         workplace:
           password: "c0mpany1"
           bssid: de:ad:be:ef:ca:fe
@@ -221,7 +217,6 @@ mode=infrastructure
 bssid=00:11:22:33:44:55
 band=bg
 channel=11
-seen-bssids=de:ad:be:ef:ca:fe;00:11:22:33:44:55;55:44:33:22:11:00;
 
 [wifi-security]
 key-mgmt=wpa-psk

--- a/tests/generator/test_wifis.py
+++ b/tests/generator/test_wifis.py
@@ -148,6 +148,10 @@ class TestNetworkManager(TestBase):
           bssid: 00:11:22:33:44:55
           band: bg
           channel: 11
+          seen-bssids:
+            - de:ad:be:ef:ca:fe
+            - 00:11:22:33:44:55
+            - 55:44:33:22:11:00
         workplace:
           password: "c0mpany1"
           bssid: de:ad:be:ef:ca:fe
@@ -179,6 +183,7 @@ mode=infrastructure
 bssid=00:11:22:33:44:55
 band=bg
 channel=11
+seen-bssids=de:ad:be:ef:ca:fe;00:11:22:33:44:55;55:44:33:22:11:00;
 
 [wifi-security]
 key-mgmt=wpa-psk


### PR DESCRIPTION
## Description
This PR implements the following WiFi fields, required by the "NetworkManager readwrite plugin" spec, for the `nm` and `networkd` backends. systemd-networkd does not support _seen-bssids_.

- band
- bssid
- channel
- seen-bssids

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [x] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Closes an open bug in Launchpad.

