### PR TITLE
Add IPv6 addr-gen-mode field for NM backend

### DIFF
--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -239,7 +239,7 @@ Virtual devices
 
     Example: ``addresses: [192.168.14.2/24, "2001:1::1/64"]``
 
-``addr-gen-mode`` (scalar)
+``ipv6-address-generation`` (scalar)
 
 :   Configure method for creating the address for use with RFC4862 IPv6
     Stateless Address Autoconfiguration. Possible values are ``eui64``

--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -239,6 +239,12 @@ Virtual devices
 
     Example: ``addresses: [192.168.14.2/24, "2001:1::1/64"]``
 
+``addr-gen-mode`` (scalar)
+
+:   Configure method for creating the address for use with RFC4862 IPv6
+    Stateless Address Autoconfiguration. Possible values are ``eui64``
+    or ``stable-privacy``.
+
 ``gateway4``, ``gateway6`` (scalar)
 
 :   Set default gateway for IPv4/6, for manual address configuration. This

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -487,7 +487,7 @@ write_network_file(const NetplanNetDefinition* def, const char* rootdir, const c
     if (def->ip6_addresses)
         for (unsigned i = 0; i < def->ip6_addresses->len; ++i)
             g_string_append_printf(network, "Address=%s\n", g_array_index(def->ip6_addresses, char*, i));
-    if (def->addr_gen_mode) {
+    if (def->ip6_addr_gen_mode) {
         /* TODO: Figure out how we can configure ipv6-address-generation for networkd.
          *       IPv6Token= seems to be the corresponding option, but it doesn't do
          *       exactly what we need and has quite some restrictions, c.f.:

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -487,6 +487,13 @@ write_network_file(const NetplanNetDefinition* def, const char* rootdir, const c
     if (def->ip6_addresses)
         for (unsigned i = 0; i < def->ip6_addresses->len; ++i)
             g_string_append_printf(network, "Address=%s\n", g_array_index(def->ip6_addresses, char*, i));
+    if (def->addr_gen_mode) {
+        /* TODO: figure out if/how we can configure addr-gen-mode for networkd
+         *       IPv6Token= might be an option:
+         *       https://www.freedesktop.org/software/systemd/man/systemd.network.html */
+        g_fprintf(stderr, "ERROR: %s: addr-gen-mode is not supported by networkd\n", def->id);
+        exit(1);
+    }
     if (def->accept_ra == NETPLAN_RA_MODE_ENABLED)
         g_string_append_printf(network, "IPv6AcceptRA=yes\n");
     else if (def->accept_ra == NETPLAN_RA_MODE_DISABLED)

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -488,10 +488,12 @@ write_network_file(const NetplanNetDefinition* def, const char* rootdir, const c
         for (unsigned i = 0; i < def->ip6_addresses->len; ++i)
             g_string_append_printf(network, "Address=%s\n", g_array_index(def->ip6_addresses, char*, i));
     if (def->addr_gen_mode) {
-        /* TODO: figure out if/how we can configure addr-gen-mode for networkd
-         *       IPv6Token= might be an option:
-         *       https://www.freedesktop.org/software/systemd/man/systemd.network.html */
-        g_fprintf(stderr, "ERROR: %s: addr-gen-mode is not supported by networkd\n", def->id);
+        /* TODO: Figure out how we can configure ipv6-address-generation for networkd.
+         *       IPv6Token= seems to be the corresponding option, but it doesn't do
+         *       exactly what we need and has quite some restrictions, c.f.:
+         *       https://github.com/systemd/systemd/issues/4625
+         *       https://github.com/systemd/systemd/pull/14415 */
+        g_fprintf(stderr, "ERROR: %s: ipv6-address-generation is not supported by networkd\n", def->id);
         exit(1);
     }
     if (def->accept_ra == NETPLAN_RA_MODE_ENABLED)

--- a/src/nm.c
+++ b/src/nm.c
@@ -631,7 +631,7 @@ write_nm_conf_access_point(NetplanNetDefinition* def, const char* rootdir, const
 
     if (def->dhcp6 || def->ip6_addresses || def->gateway6 || def->ip6_nameservers || def->addr_gen_mode) {
         g_string_append(s, "\n[ipv6]\n");
-        g_string_append(s, (def->dhcp6 || def->addr_gen_mode) ? "method=auto\n" : "method=manual\n");
+        g_string_append(s, def->dhcp6 ? "method=auto\n" : "method=manual\n");
         if (def->ip6_addresses)
             for (unsigned i = 0; i < def->ip6_addresses->len; ++i)
                 g_string_append_printf(s, "address%i=%s\n", i+1, g_array_index(def->ip6_addresses, char*, i));

--- a/src/nm.c
+++ b/src/nm.c
@@ -629,14 +629,14 @@ write_nm_conf_access_point(NetplanNetDefinition* def, const char* rootdir, const
     if (def->dhcp4 && def->dhcp4_overrides.metric != NETPLAN_METRIC_UNSPEC)
         g_string_append_printf(s, "route-metric=%u\n", def->dhcp4_overrides.metric);
 
-    if (def->dhcp6 || def->ip6_addresses || def->gateway6 || def->ip6_nameservers || def->addr_gen_mode) {
+    if (def->dhcp6 || def->ip6_addresses || def->gateway6 || def->ip6_nameservers || def->ip6_addr_gen_mode) {
         g_string_append(s, "\n[ipv6]\n");
         g_string_append(s, def->dhcp6 ? "method=auto\n" : "method=manual\n");
         if (def->ip6_addresses)
             for (unsigned i = 0; i < def->ip6_addresses->len; ++i)
                 g_string_append_printf(s, "address%i=%s\n", i+1, g_array_index(def->ip6_addresses, char*, i));
-        if (def->addr_gen_mode) {
-            g_string_append_printf(s, "addr-gen-mode=%s\n", addr_gen_mode_str(def->addr_gen_mode));
+        if (def->ip6_addr_gen_mode) {
+            g_string_append_printf(s, "addr-gen-mode=%s\n", addr_gen_mode_str(def->ip6_addr_gen_mode));
         }
         if (def->ip6_privacy)
             g_string_append(s, "ip6-privacy=2\n");

--- a/src/nm.c
+++ b/src/nm.c
@@ -139,6 +139,24 @@ wifi_mode_str(const NetplanWifiMode mode)
     }
 }
 
+/**
+ * Return NM addr-gen-mode string.
+ */
+static const char*
+addr_gen_mode_str(const NetplanAddrGenMode mode)
+{
+    switch (mode) {
+        case NETPLAN_ADDRGEN_EUI64:
+            return "0";
+        case NETPLAN_ADDRGEN_STABLEPRIVACY:
+            return "1";
+        // LCOV_EXCL_START
+        default:
+            g_assert_not_reached();
+        // LCOV_EXCL_STOP
+    }
+}
+
 static void
 write_search_domains(const NetplanNetDefinition* def, GString *s)
 {
@@ -611,12 +629,15 @@ write_nm_conf_access_point(NetplanNetDefinition* def, const char* rootdir, const
     if (def->dhcp4 && def->dhcp4_overrides.metric != NETPLAN_METRIC_UNSPEC)
         g_string_append_printf(s, "route-metric=%u\n", def->dhcp4_overrides.metric);
 
-    if (def->dhcp6 || def->ip6_addresses || def->gateway6 || def->ip6_nameservers) {
+    if (def->dhcp6 || def->ip6_addresses || def->gateway6 || def->ip6_nameservers || def->addr_gen_mode) {
         g_string_append(s, "\n[ipv6]\n");
-        g_string_append(s, def->dhcp6 ? "method=auto\n" : "method=manual\n");
+        g_string_append(s, (def->dhcp6 || def->addr_gen_mode) ? "method=auto\n" : "method=manual\n");
         if (def->ip6_addresses)
             for (unsigned i = 0; i < def->ip6_addresses->len; ++i)
                 g_string_append_printf(s, "address%i=%s\n", i+1, g_array_index(def->ip6_addresses, char*, i));
+        if (def->addr_gen_mode) {
+            g_string_append_printf(s, "addr-gen-mode=%s\n", addr_gen_mode_str(def->addr_gen_mode));
+        }
         if (def->ip6_privacy)
             g_string_append(s, "ip6-privacy=2\n");
         if (def->gateway6)

--- a/src/parse.c
+++ b/src/parse.c
@@ -433,9 +433,9 @@ handle_netdef_addrgen(yaml_document_t* doc, yaml_node_t* node, const void* _, GE
 {
     g_assert(cur_netdef);
     if (strcmp(scalar(node), "eui64") == 0)
-        cur_netdef->addr_gen_mode = NETPLAN_ADDRGEN_EUI64;
+        cur_netdef->ip6_addr_gen_mode = NETPLAN_ADDRGEN_EUI64;
     else if (strcmp(scalar(node), "stable-privacy") == 0)
-        cur_netdef->addr_gen_mode = NETPLAN_ADDRGEN_STABLEPRIVACY;
+        cur_netdef->ip6_addr_gen_mode = NETPLAN_ADDRGEN_STABLEPRIVACY;
     else
         return yaml_error(node, error, "unknown ipv6-address-generation '%s'", scalar(node));
     return TRUE;

--- a/src/parse.c
+++ b/src/parse.c
@@ -437,7 +437,7 @@ handle_netdef_addrgen(yaml_document_t* doc, yaml_node_t* node, const void* _, GE
     else if (strcmp(scalar(node), "stable-privacy") == 0)
         cur_netdef->addr_gen_mode = NETPLAN_ADDRGEN_STABLEPRIVACY;
     else
-        return yaml_error(node, error, "unknown addr-gen-mode '%s'", scalar(node));
+        return yaml_error(node, error, "unknown ipv6-address-generation '%s'", scalar(node));
     return TRUE;
 }
 
@@ -1573,7 +1573,6 @@ static const mapping_entry_handler dhcp6_overrides_handlers[] = {
 /* Handlers shared by all link types */
 #define COMMON_LINK_HANDLERS                                                                  \
     {"accept-ra", YAML_SCALAR_NODE, handle_accept_ra},                                        \
-    {"addr-gen-mode", YAML_SCALAR_NODE, handle_netdef_addrgen},                               \
     {"addresses", YAML_SEQUENCE_NODE, handle_addresses},                                      \
     {"critical", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(critical)},        \
     {"dhcp4", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(dhcp4)},              \
@@ -1583,6 +1582,7 @@ static const mapping_entry_handler dhcp6_overrides_handlers[] = {
     {"dhcp6-overrides", YAML_MAPPING_NODE, NULL, dhcp6_overrides_handlers},                   \
     {"gateway4", YAML_SCALAR_NODE, handle_gateway4},                                          \
     {"gateway6", YAML_SCALAR_NODE, handle_gateway6},                                          \
+    {"ipv6-address-generation", YAML_SCALAR_NODE, handle_netdef_addrgen},                               \
     {"ipv6-mtu", YAML_SCALAR_NODE, handle_netdef_guint, NULL, netdef_offset(ipv6_mtubytes)},  \
     {"ipv6-privacy", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(ip6_privacy)}, \
     {"link-local", YAML_SEQUENCE_NODE, handle_link_local},                                    \

--- a/src/parse.c
+++ b/src/parse.c
@@ -428,6 +428,19 @@ handle_netdef_ip6(yaml_document_t* doc, yaml_node_t* node, const void* data, GEr
     return TRUE;
 }
 
+static gboolean
+handle_netdef_addrgen(yaml_document_t* doc, yaml_node_t* node, const void* _, GError** error)
+{
+    g_assert(cur_netdef);
+    if (strcmp(scalar(node), "eui64") == 0)
+        cur_netdef->addr_gen_mode = NETPLAN_ADDRGEN_EUI64;
+    else if (strcmp(scalar(node), "stable-privacy") == 0)
+        cur_netdef->addr_gen_mode = NETPLAN_ADDRGEN_STABLEPRIVACY;
+    else
+        return yaml_error(node, error, "unknown addr-gen-mode '%s'", scalar(node));
+    return TRUE;
+}
+
 
 /****************************************************
  * Grammar and handlers for network config "match" entry
@@ -1560,6 +1573,7 @@ static const mapping_entry_handler dhcp6_overrides_handlers[] = {
 /* Handlers shared by all link types */
 #define COMMON_LINK_HANDLERS                                                                  \
     {"accept-ra", YAML_SCALAR_NODE, handle_accept_ra},                                        \
+    {"addr-gen-mode", YAML_SCALAR_NODE, handle_netdef_addrgen},                               \
     {"addresses", YAML_SEQUENCE_NODE, handle_addresses},                                      \
     {"critical", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(critical)},        \
     {"dhcp4", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(dhcp4)},              \

--- a/src/parse.h
+++ b/src/parse.h
@@ -208,7 +208,7 @@ struct net_definition {
     GArray* ip4_addresses;
     GArray* ip6_addresses;
     gboolean ip6_privacy;
-    guint addr_gen_mode;
+    guint ip6_addr_gen_mode;
     char* gateway4;
     char* gateway6;
     GArray* ip4_nameservers;

--- a/src/parse.h
+++ b/src/parse.h
@@ -79,6 +79,12 @@ typedef enum {
     NETPLAN_OPTIONAL_STATIC  = 1<<4,
 } NetplanOptionalAddressFlag;
 
+typedef enum {
+    NETPLAN_ADDRGEN_DEFAULT,
+    NETPLAN_ADDRGEN_EUI64,
+    NETPLAN_ADDRGEN_STABLEPRIVACY,
+} NetplanAddrGenMode;
+
 struct NetplanOptionalAddressType {
     char* name;
     NetplanOptionalAddressFlag flag;
@@ -202,6 +208,7 @@ struct net_definition {
     GArray* ip4_addresses;
     GArray* ip6_addresses;
     gboolean ip6_privacy;
+    guint addr_gen_mode;
     char* gateway4;
     char* gateway6;
     GArray* ip4_nameservers;

--- a/tests/generator/test_common.py
+++ b/tests/generator/test_common.py
@@ -724,6 +724,46 @@ method=auto
 method=auto
 '''})
 
+    def test_ip6_addr_gen_mode(self):
+        self.generate('''network:
+  version: 2
+  renderer: NetworkManager
+  ethernets:
+    engreen:
+      addr-gen-mode: stable-privacy
+    enblue:
+      addr-gen-mode: eui64''')
+        self.assert_nm({'engreen': '''[connection]
+id=netplan-engreen
+type=ethernet
+interface-name=engreen
+
+[ethernet]
+wake-on-lan=0
+
+[ipv4]
+method=link-local
+
+[ipv6]
+method=auto
+addr-gen-mode=1
+''',
+                        'enblue': '''[connection]
+id=netplan-enblue
+type=ethernet
+interface-name=enblue
+
+[ethernet]
+wake-on-lan=0
+
+[ipv4]
+method=link-local
+
+[ipv6]
+method=auto
+addr-gen-mode=0
+'''})
+
     def test_eth_manual_addresses(self):
         self.generate('''network:
   version: 2

--- a/tests/generator/test_common.py
+++ b/tests/generator/test_common.py
@@ -730,8 +730,10 @@ method=auto
   renderer: NetworkManager
   ethernets:
     engreen:
+      dhcp6: yes
       addr-gen-mode: stable-privacy
     enblue:
+      dhcp6: yes
       addr-gen-mode: eui64''')
         self.assert_nm({'engreen': '''[connection]
 id=netplan-engreen

--- a/tests/generator/test_common.py
+++ b/tests/generator/test_common.py
@@ -731,10 +731,10 @@ method=auto
   ethernets:
     engreen:
       dhcp6: yes
-      addr-gen-mode: stable-privacy
+      ipv6-address-generation: stable-privacy
     enblue:
       dhcp6: yes
-      addr-gen-mode: eui64''')
+      ipv6-address-generation: eui64''')
         self.assert_nm({'engreen': '''[connection]
 id=netplan-engreen
 type=ethernet

--- a/tests/generator/test_errors.py
+++ b/tests/generator/test_errors.py
@@ -288,6 +288,23 @@ class TestConfigErrors(TestBase):
         - 2001::1/''', expect_fail=True)
         self.assertIn("invalid prefix length in address '2001::1/'", err)
 
+    def test_invalid_addr_gen_mode(self):
+        err = self.generate('''network:
+  version: 2
+  renderer: NetworkManager
+  ethernets:
+    engreen:
+      addr-gen-mode: 0''', expect_fail=True)
+        self.assertIn("unknown addr-gen-mode '0'", err)
+
+    def test_addr_gen_mode_not_supported(self):
+        err = self.generate('''network:
+  version: 2
+  ethernets:
+    engreen:
+      addr-gen-mode: eui64''', expect_fail=True)
+        self.assertIn("ERROR: engreen: addr-gen-mode is not supported by networkd", err)
+
     def test_invalid_gateway4(self):
         for a in ['300.400.1.1', '1.2.3', '192.168.14.1/24']:
             err = self.generate('''network:

--- a/tests/generator/test_errors.py
+++ b/tests/generator/test_errors.py
@@ -294,16 +294,16 @@ class TestConfigErrors(TestBase):
   renderer: NetworkManager
   ethernets:
     engreen:
-      addr-gen-mode: 0''', expect_fail=True)
-        self.assertIn("unknown addr-gen-mode '0'", err)
+      ipv6-address-generation: 0''', expect_fail=True)
+        self.assertIn("unknown ipv6-address-generation '0'", err)
 
     def test_addr_gen_mode_not_supported(self):
         err = self.generate('''network:
   version: 2
   ethernets:
     engreen:
-      addr-gen-mode: eui64''', expect_fail=True)
-        self.assertIn("ERROR: engreen: addr-gen-mode is not supported by networkd", err)
+      ipv6-address-generation: eui64''', expect_fail=True)
+        self.assertIn("ERROR: engreen: ipv6-address-generation is not supported by networkd", err)
 
     def test_invalid_gateway4(self):
         for a in ['300.400.1.1', '1.2.3', '192.168.14.1/24']:


### PR DESCRIPTION
## Description
Allow to choose the configure method for creating the address for use with RFC4862 IPv6 Stateless Address Autoconfiguration. Possible values are: `eui64` or `stable-privacy`. If unset, the backend's default value stays in place.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [x] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Closes an open bug in Launchpad.

