### PR TITLE
Implement WakeOnWLan for NM and networkd backends

### DIFF
--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -630,6 +630,14 @@ wpasupplicant installed if you let the ``networkd`` renderer handle wifi.
           and ``adhoc`` (peer to peer networks without a central access point).
           ``ap`` is only supported with NetworkManager.
 
+``wowlan`` (sequence of scalars)
+
+:    This enables WakeOnWLan on supported devices. Not all drivers support all
+     options. May be any combination of ``any``, ``disconnect``, ``magic_pkt``,
+     ``gtk_rekey_failure``, ``eap_identity_req``, ``four_way_handshake``,
+     ``rfkill_release``, ``tcp`` or ``ignore``. The value of ``tcp`` and
+     ``ignore`` is only supported with NetworkManager.
+
 ## Properties for device type ``bridges:``
 
 ``interfaces`` (sequence of scalars)

--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -630,13 +630,13 @@ wpasupplicant installed if you let the ``networkd`` renderer handle wifi.
           and ``adhoc`` (peer to peer networks without a central access point).
           ``ap`` is only supported with NetworkManager.
 
-``wowlan`` (sequence of scalars)
+``wakeonwlan`` (sequence of scalars)
 
 :    This enables WakeOnWLan on supported devices. Not all drivers support all
      options. May be any combination of ``any``, ``disconnect``, ``magic_pkt``,
      ``gtk_rekey_failure``, ``eap_identity_req``, ``four_way_handshake``,
-     ``rfkill_release``, ``tcp`` or ``ignore``. The value of ``tcp`` and
-     ``ignore`` is only supported with NetworkManager.
+     ``rfkill_release`` or ``tcp`` (NetworkManager only). Or the exclusive
+     ``default`` flag (the default).
 
 ## Properties for device type ``bridges:``
 

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -35,7 +35,7 @@
  */
 char *
 wifi_wowlan_str(NetplanWifiWowlanFlag flag) {
-    if (flag >= NETPLAN_WIFI_WOWLAN_TCP) {
+    if (flag & NETPLAN_WIFI_WOWLAN_TYPES[0].flag || flag >= NETPLAN_WIFI_WOWLAN_TCP) {
         g_fprintf(stderr, "ERROR: unsupported wowlan_trigger mask: 0x%x\n", flag);
         exit(1);
     }

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -36,7 +36,7 @@
 static void
 append_wifi_wowlan_flags(NetplanWifiWowlanFlag flag, GString* str) {
     if (flag & NETPLAN_WIFI_WOWLAN_TYPES[0].flag || flag >= NETPLAN_WIFI_WOWLAN_TCP) {
-        g_fprintf(stderr, "ERROR: unsupported wowlan_trigger mask: 0x%x\n", flag);
+        g_fprintf(stderr, "ERROR: unsupported wowlan_triggers mask: 0x%x\n", flag);
         exit(1);
     }
     for (unsigned i = 0; NETPLAN_WIFI_WOWLAN_TYPES[i].name != NULL; ++i) {

--- a/src/nm.c
+++ b/src/nm.c
@@ -532,6 +532,8 @@ write_nm_conf_access_point(NetplanNetDefinition* def, const char* rootdir, const
         if (def->mtubytes) {
             g_string_append_printf(link_str, "mtu=%d\n", def->mtubytes);
         }
+        if (def->wowlan && def->wowlan > NETPLAN_WIFI_WOWLAN_DEFAULT)
+            g_string_append_printf(link_str, "wake-on-wlan=%u\n", def->wowlan);
 
         if (link_str->len > 0) {
             switch (def->type) {

--- a/src/parse.c
+++ b/src/parse.c
@@ -635,7 +635,6 @@ struct NetplanWifiWowlanType NETPLAN_WIFI_WOWLAN_TYPES[] = {
     {"four_way_handshake", NETPLAN_WIFI_WOWLAN_4WAY_HANDSHAKE},
     {"rfkill_release",     NETPLAN_WIFI_WOWLAN_RFKILL_RELEASE},
     {"tcp",                NETPLAN_WIFI_WOWLAN_TCP},
-    {"ignore",             NETPLAN_WIFI_WOWLAN_IGNORE},
     {NULL},
 };
 
@@ -654,10 +653,11 @@ handle_wowlan(yaml_document_t* doc, yaml_node_t* node, const void* _, GError** e
                 break;
             }
         }
-        if (!found) {
-            return yaml_error(node, error, "invalid value for wowlan: '%s'", scalar(entry));
-        }
+        if (!found)
+            return yaml_error(node, error, "invalid value for wakeonwlan: '%s'", scalar(entry));
     }
+    if (cur_netdef->wowlan > NETPLAN_WIFI_WOWLAN_DEFAULT && cur_netdef->wowlan & NETPLAN_WIFI_WOWLAN_TYPES[0].flag)
+        return yaml_error(node, error, "'default' is an exclusive flag for wakeonwlan");
     return TRUE;
 }
 
@@ -1639,7 +1639,7 @@ static const mapping_entry_handler dhcp6_overrides_handlers[] = {
     {"match", YAML_MAPPING_NODE, handle_match},                                          \
     {"set-name", YAML_SCALAR_NODE, handle_netdef_str, NULL, netdef_offset(set_name)},    \
     {"wakeonlan", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(wake_on_lan)}, \
-    {"wowlan", YAML_SEQUENCE_NODE, handle_wowlan, NULL, netdef_offset(wowlan)},       \
+    {"wakeonwlan", YAML_SEQUENCE_NODE, handle_wowlan, NULL, netdef_offset(wowlan)},       \
     {"emit-lldp", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(emit_lldp)}
 
 static const mapping_entry_handler ethernet_def_handlers[] = {

--- a/src/parse.h
+++ b/src/parse.h
@@ -132,6 +132,25 @@ netplan_tunnel_mode_table[NETPLAN_TUNNEL_MODE_MAX_] = {
     [NETPLAN_TUNNEL_MODE_IP6GRETAP] = "ip6gretap",
 };
 
+typedef enum {
+    NETPLAN_WIFI_WOWLAN_DEFAULT           = 1<<0,
+    NETPLAN_WIFI_WOWLAN_ANY               = 1<<1,
+    NETPLAN_WIFI_WOWLAN_DISCONNECT        = 1<<2,
+    NETPLAN_WIFI_WOWLAN_MAGIC             = 1<<3,
+    NETPLAN_WIFI_WOWLAN_GTK_REKEY_FAILURE = 1<<4,
+    NETPLAN_WIFI_WOWLAN_EAP_IDENTITY_REQ  = 1<<5,
+    NETPLAN_WIFI_WOWLAN_4WAY_HANDSHAKE    = 1<<6,
+    NETPLAN_WIFI_WOWLAN_RFKILL_RELEASE    = 1<<7,
+    NETPLAN_WIFI_WOWLAN_TCP               = 1<<8,
+    NETPLAN_WIFI_WOWLAN_IGNORE            = 1<<15,
+} NetplanWifiWowlanFlag;
+
+struct NetplanWifiWowlanType {
+    char* name;
+    NetplanWifiWowlanFlag flag;
+};
+
+extern struct NetplanWifiWowlanType NETPLAN_WIFI_WOWLAN_TYPES[];
 
 typedef enum {
     NETPLAN_AUTH_KEY_MANAGEMENT_NONE,
@@ -248,6 +267,7 @@ struct net_definition {
     } match;
     gboolean has_match;
     gboolean wake_on_lan;
+    NetplanWifiWowlanFlag wowlan;
     gboolean emit_lldp;
 
 

--- a/src/parse.h
+++ b/src/parse.h
@@ -142,7 +142,6 @@ typedef enum {
     NETPLAN_WIFI_WOWLAN_4WAY_HANDSHAKE    = 1<<6,
     NETPLAN_WIFI_WOWLAN_RFKILL_RELEASE    = 1<<7,
     NETPLAN_WIFI_WOWLAN_TCP               = 1<<8,
-    NETPLAN_WIFI_WOWLAN_IGNORE            = 1<<15,
 } NetplanWifiWowlanFlag;
 
 struct NetplanWifiWowlanType {

--- a/tests/generator/test_wifis.py
+++ b/tests/generator/test_wifis.py
@@ -62,16 +62,16 @@ unmanaged-devices+=interface-name:wl0,''')
             self.assertIn('''
 network={
   ssid="band-no-channel2"
-  freq_list=5610 5310 5620 5320 5630 5640 5340 5035 5040 5045 5055 5060 5660 5680 5670 5080 5690 5700 5710 5720 5825 5745 5755 \
-5805 5765 5160 5775 5170 5480 5180 5795 5190 5500 5200 5510 5210 5520 5220 5530 5230 5540 5240 5550 5250 5560 5260 5570 5270 \
-5580 5280 5590 5290 5600 5300 5865 5845 5785
+  freq_list=5610 5250 5500 5805 5640 5280 5530 5170 5060 5310 5560 5200 5755 5700 5340 5035 5230 5480 5590 5785 5620 5260 5510 \
+5670 5040 5290 5540 5180 5845 5680 5320 5570 5210 5765 5710 5045 5600 5240 5795 5630 5270 5520 5160 5865 5660 5300 5550 5190 \
+5745 5080 5690 5580 5220 5775 5720 5055 5825
   key_mgmt=NONE
 }
 ''', new_config)
             self.assertIn('''
 network={
   ssid="band-no-channel"
-  freq_list=2412 2417 2422 2427 2432 2442 2447 2437 2452 2457 2462 2467 2472 2484
+  freq_list=2472 2437 2467 2432 2462 2427 2457 2422 2452 2412 2417 2447 2442 2484
   key_mgmt=NONE
 }
 ''', new_config)
@@ -496,7 +496,7 @@ mode=adhoc
   renderer: NetworkManager
   wifis:
     wl0:
-      wakeonwlan: [any, four_way_handshake, magic_pkt]
+      wakeonwlan: [any, tcp, four_way_handshake, magic_pkt]
       access-points:
         homenet: {mode: infrastructure}''')
 
@@ -509,7 +509,7 @@ interface-name=wl0
 wake-on-lan=0
 
 [802-11-wireless]
-wake-on-wlan=74
+wake-on-wlan=330
 
 [ipv4]
 method=link-local

--- a/tests/generator/test_wifis.py
+++ b/tests/generator/test_wifis.py
@@ -146,7 +146,6 @@ unmanaged-devices+=interface-name:wl0,''')
         - eap_identity_req
         - four_way_handshake
         - rfkill_release
-        - default
       access-points:
         homenet: {mode: infrastructure}''')
 
@@ -165,7 +164,7 @@ unmanaged-devices+=interface-name:wl0,''')
         with open(os.path.join(self.workdir.name, 'run/netplan/wpa-wl0.conf')) as f:
             new_config = f.read()
             self.assertIn('''
-wowlan_triggers=default any disconnect magic_pkt gtk_rekey_failure eap_identity_req four_way_handshake rfkill_release
+wowlan_triggers=any disconnect magic_pkt gtk_rekey_failure eap_identity_req four_way_handshake rfkill_release
 network={
   ssid="homenet"
   key_mgmt=NONE

--- a/tests/generator/test_wifis.py
+++ b/tests/generator/test_wifis.py
@@ -59,22 +59,16 @@ unmanaged-devices+=interface-name:wl0,''')
         # generates wpa config and enables wpasupplicant unit
         with open(os.path.join(self.workdir.name, 'run/netplan/wpa-wl0.conf')) as f:
             new_config = f.read()
-            self.assertIn('''
-network={
-  ssid="band-no-channel2"
-  freq_list=5610 5250 5500 5805 5640 5280 5530 5170 5060 5310 5560 5200 5755 5700 5340 5035 5230 5480 5590 5785 5620 5260 5510 \
-5670 5040 5290 5540 5180 5845 5680 5320 5570 5210 5765 5710 5045 5600 5240 5795 5630 5270 5520 5160 5865 5660 5300 5550 5190 \
-5745 5080 5690 5580 5220 5775 5720 5055 5825
-  key_mgmt=NONE
-}
-''', new_config)
-            self.assertIn('''
-network={
-  ssid="band-no-channel"
-  freq_list=2472 2437 2467 2432 2462 2427 2457 2422 2452 2412 2417 2447 2442 2484
-  key_mgmt=NONE
-}
-''', new_config)
+
+            freqs_5GHz = [5610, 5310, 5620, 5320, 5630, 5640, 5340, 5035, 5040, 5045, 5055, 5060, 5660, 5680, 5670, 5080, 5690,
+                          5700, 5710, 5720, 5825, 5745, 5755, 5805, 5765, 5160, 5775, 5170, 5480, 5180, 5795, 5190, 5500, 5200,
+                          5510, 5210, 5520, 5220, 5530, 5230, 5540, 5240, 5550, 5250, 5560, 5260, 5570, 5270, 5580, 5280, 5590,
+                          5290, 5600, 5300, 5865, 5845, 5785]
+            for freq in freqs_5GHz:
+                self.assertRegexpMatches(new_config, 'ssid="band-no-channel2"\n  freq_list=[ 0-9]*{}[ 0-9]*\n'.format(freq))
+            freqs_24GHz = [2412, 2417, 2422, 2427, 2432, 2442, 2447, 2437, 2452, 2457, 2462, 2467, 2472, 2484]
+            for freq in freqs_24GHz:
+                self.assertRegexpMatches(new_config, 'ssid="band-no-channel"\n  freq_list=[ 0-9]*{}[ 0-9]*\n'.format(freq))
             self.assertIn('''
 network={
   ssid="channel-no-band"

--- a/tests/generator/test_wifis.py
+++ b/tests/generator/test_wifis.py
@@ -60,15 +60,25 @@ unmanaged-devices+=interface-name:wl0,''')
         with open(os.path.join(self.workdir.name, 'run/netplan/wpa-wl0.conf')) as f:
             new_config = f.read()
 
+            network = 'ssid="{}"\n  freq_list='.format('band-no-channel2')
             freqs_5GHz = [5610, 5310, 5620, 5320, 5630, 5640, 5340, 5035, 5040, 5045, 5055, 5060, 5660, 5680, 5670, 5080, 5690,
                           5700, 5710, 5720, 5825, 5745, 5755, 5805, 5765, 5160, 5775, 5170, 5480, 5180, 5795, 5190, 5500, 5200,
                           5510, 5210, 5520, 5220, 5530, 5230, 5540, 5240, 5550, 5250, 5560, 5260, 5570, 5270, 5580, 5280, 5590,
                           5290, 5600, 5300, 5865, 5845, 5785]
+            freqs = new_config.split(network)
+            freqs = freqs[1].split('\n')[0]
+            self.assertEqual(len(freqs.split(' ')), len(freqs_5GHz))
             for freq in freqs_5GHz:
-                self.assertRegexpMatches(new_config, 'ssid="band-no-channel2"\n  freq_list=[ 0-9]*{}[ 0-9]*\n'.format(freq))
+                self.assertRegexpMatches(new_config, '{}[ 0-9]*{}[ 0-9]*\n'.format(network, freq))
+
+            network = 'ssid="{}"\n  freq_list='.format('band-no-channel')
             freqs_24GHz = [2412, 2417, 2422, 2427, 2432, 2442, 2447, 2437, 2452, 2457, 2462, 2467, 2472, 2484]
+            freqs = new_config.split(network)
+            freqs = freqs[1].split('\n')[0]
+            self.assertEqual(len(freqs.split(' ')), len(freqs_24GHz))
             for freq in freqs_24GHz:
-                self.assertRegexpMatches(new_config, 'ssid="band-no-channel"\n  freq_list=[ 0-9]*{}[ 0-9]*\n'.format(freq))
+                self.assertRegexpMatches(new_config, '{}[ 0-9]*{}[ 0-9]*\n'.format(network, freq))
+
             self.assertIn('''
 network={
   ssid="channel-no-band"


### PR DESCRIPTION
## Description
This implements the `wakeonwlan` setting, which can contain any combination of the following flags:

- any
- diconnect
- magic_pkt
- gtk_rekey_failure
- eap_identity_req
- four_way_handshake
- rfkill_release
- tcp (NM only)

Or the exclusive ``default`` flag, to fall back to system defaults.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [x] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Closes an open bug in Launchpad.

