### PR TITLE
SR-IOV support for explicitly defining the VF count

### DIFF
--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -578,9 +578,11 @@ Example:
 
 ``virtual-functions`` (scalar)
 
-:    (SR-IOV devices only) Explicit number of Virtual Functions for the given
-     Physical Function. This is optional, as normally netplan will allocate as
-     many VFs as there are needed.
+:    (SR-IOV devices only) In certain special cases VFs might need to be
+     configured outside of netplan. For such configurations ``virtual-functions``
+     can be optionally used to set an explicit number of Virtual Functions for
+     the given Physical Function. This should be used for special cases only, as
+     normally netplan allocates as many VFs as there are needed.
 
 ## Properties for device type ``modems:``
 GSM/CDMA modem configuration is only supported for the ``NetworkManager`` backend. ``systemd-networkd`` does

--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -576,13 +576,14 @@ Example:
       enp1s16f1:
         link: enp1
 
-``virtual-functions`` (scalar)
+``virtual-function-count`` (scalar)
 
 :    (SR-IOV devices only) In certain special cases VFs might need to be
-     configured outside of netplan. For such configurations ``virtual-functions``
+     configured outside of netplan. For such configurations ``virtual-function-count``
      can be optionally used to set an explicit number of Virtual Functions for
-     the given Physical Function. This should be used for special cases only, as
-     normally netplan allocates as many VFs as there are needed.
+     the given Physical Function. If unset, the default is to create only as many
+     VFs as are defined in the netplan configuration. This should be used for special
+     cases only.
 
 ## Properties for device type ``modems:``
 GSM/CDMA modem configuration is only supported for the ``NetworkManager`` backend. ``systemd-networkd`` does

--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -576,6 +576,12 @@ Example:
       enp1s16f1:
         link: enp1
 
+``virtual-functions`` (scalar)
+
+:    (SR-IOV devices only) Explicit number of Virtual Functions for the given
+     Physical Function. This is optional, as normally netplan will allocate as
+     many VFs as there are needed.
+
 ## Properties for device type ``modems:``
 GSM/CDMA modem configuration is only supported for the ``NetworkManager`` backend. ``systemd-networkd`` does
 not support modems.

--- a/netplan/cli/sriov.py
+++ b/netplan/cli/sriov.py
@@ -71,7 +71,7 @@ def get_vf_count_and_functions(interfaces, config_manager,
 
         # we now also support explicitly stating how many VFs should be
         # allocated for a PF
-        explicit_num = settings.get('virtual-functions')
+        explicit_num = settings.get('virtual-function-count')
         if explicit_num:
             pf = _get_target_interface(interfaces, config_manager, ethernet, pfs)
             if pf:

--- a/src/parse.c
+++ b/src/parse.c
@@ -1726,6 +1726,7 @@ static const mapping_entry_handler ethernet_def_handlers[] = {
     PHYSICAL_LINK_HANDLERS,
     {"auth", YAML_MAPPING_NODE, handle_auth},
     {"link", YAML_SCALAR_NODE, handle_netdef_id_ref, NULL, netdef_offset(sriov_link)},
+    {"virtual-functions", YAML_SCALAR_NODE, handle_netdef_guint, NULL, netdef_offset(sriov_explicit_vf_count)},
     {NULL}
 };
 

--- a/src/parse.c
+++ b/src/parse.c
@@ -1726,7 +1726,7 @@ static const mapping_entry_handler ethernet_def_handlers[] = {
     PHYSICAL_LINK_HANDLERS,
     {"auth", YAML_MAPPING_NODE, handle_auth},
     {"link", YAML_SCALAR_NODE, handle_netdef_id_ref, NULL, netdef_offset(sriov_link)},
-    {"virtual-functions", YAML_SCALAR_NODE, handle_netdef_guint, NULL, netdef_offset(sriov_explicit_vf_count)},
+    {"virtual-function-count", YAML_SCALAR_NODE, handle_netdef_guint, NULL, netdef_offset(sriov_explicit_vf_count)},
     {NULL}
 };
 

--- a/src/parse.h
+++ b/src/parse.h
@@ -336,6 +336,7 @@ struct net_definition {
     /* these properties are only valid for SR-IOV NICs */
     struct net_definition* sriov_link;
     gboolean sriov_vlan_filter;
+    guint sriov_explicit_vf_count;
 
     union {
         struct NetplanNMSettings {

--- a/tests/generator/test_ethernets.py
+++ b/tests/generator/test_ethernets.py
@@ -106,6 +106,21 @@ LinkLocalAddressing=ipv6
 '''})
         self.assert_networkd_udev(None)
 
+    def test_eth_sriov_virtual_functions(self):
+        self.generate('''network:
+  version: 2
+  ethernets:
+    enp1:
+      virtual-functions: 8''')
+
+        self.assert_networkd({'enp1.network': '''[Match]
+Name=enp1
+
+[Network]
+LinkLocalAddressing=ipv6
+'''})
+        self.assert_networkd_udev(None)
+
     def test_eth_match_by_driver_rename(self):
         self.generate('''network:
   version: 2
@@ -380,6 +395,31 @@ method=ignore
 id=netplan-enp1s16f1
 type=ethernet
 interface-name=enp1s16f1
+
+[ethernet]
+wake-on-lan=0
+
+[ipv4]
+method=link-local
+
+[ipv6]
+method=ignore
+'''})
+
+    def test_eth_sriov_virtual_functions(self):
+        self.generate('''network:
+  version: 2
+  renderer: NetworkManager
+  ethernets:
+    enp1:
+      dhcp4: n
+      virtual-functions: 8''')
+
+        self.assert_networkd({})
+        self.assert_nm({'enp1': '''[connection]
+id=netplan-enp1
+type=ethernet
+interface-name=enp1
 
 [ethernet]
 wake-on-lan=0

--- a/tests/generator/test_ethernets.py
+++ b/tests/generator/test_ethernets.py
@@ -82,7 +82,7 @@ LinkLocalAddressing=ipv6
 '''})
         self.assert_networkd_udev(None)
 
-    def test_eth_sriov_link(self):
+    def test_eth_sriov_vlan_filterv_link(self):
         self.generate('''network:
   version: 2
   ethernets:
@@ -111,7 +111,7 @@ LinkLocalAddressing=ipv6
   version: 2
   ethernets:
     enp1:
-      virtual-functions: 8''')
+      virtual-function-count: 8''')
 
         self.assert_networkd({'enp1.network': '''[Match]
 Name=enp1
@@ -413,7 +413,7 @@ method=ignore
   ethernets:
     enp1:
       dhcp4: n
-      virtual-functions: 8''')
+      virtual-function-count: 8''')
 
         self.assert_networkd({})
         self.assert_nm({'enp1': '''[connection]

--- a/tests/test_sriov.py
+++ b/tests/test_sriov.py
@@ -131,7 +131,7 @@ class TestSRIOV(unittest.TestCase):
     enp0:
       mtu: 9000
     enp8:
-      virtual-functions: 7
+      virtual-function-count: 7
     enp9: {}
     wlp6s0: {}
     enp1s16f1:
@@ -223,7 +223,7 @@ class TestSRIOV(unittest.TestCase):
   ethernets:
     renderer: networkd
     enp1:
-      virtual-functions: 2
+      virtual-function-count: 2
       mtu: 9000
     enp1s16f1:
       link: enp1


### PR DESCRIPTION
## Description

This is a possible feature request to the just-landed SR-IOV support in netplan. This PR introduces an optional 'virtual-functions:' parameter that can be defined for physical functions to force the allocation of a given number of VFs, regardless of how many are actually used in the netplan config. There are of course safety checks to ensure that we can't request less VFs than actually needed in netplan.

This feature request came from the OpenStack team. We did consider such a thing originally, but then decided that it's better if we let netplan handle it. This PR adds this as an option (not recommended for everyday usage tho).

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [x] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Closes an open bug in Launchpad.

