### PR TITLE
Change "networks:" typo to "network:".

### DIFF
--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -144,7 +144,7 @@ Virtual devices
 
 :   Use the given networking backend for this definition. Currently supported are
     ``networkd`` and ``NetworkManager``. This property can be specified globally
-    in ``networks:``, for a device type (in e. g. ``ethernets:``) or
+    in ``network:``, for a device type (in e. g. ``ethernets:``) or
     for a particular device definition. Default is ``networkd``.
 
     The ``renderer`` property has one additional acceptable value for vlan objects

--- a/src/parse.c
+++ b/src/parse.c
@@ -1829,7 +1829,7 @@ initialize_dhcp_overrides(NetplanDHCPOverrides* overrides)
 }
 
 /**
- * Callback for a net device type entry like "ethernets:" in "networks:"
+ * Callback for a net device type entry like "ethernets:" in "network:"
  * @data: netdef_type (as pointer)
  */
 static gboolean


### PR DESCRIPTION
## Description
Fix typo in documentation where "networks:" should be "network:".

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Closes an open bug in Launchpad.

