### PR TITLE
Add `hidden` to connect to non-broadcast SSIDs

### DIFF
--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -671,6 +671,12 @@ wpasupplicant installed if you let the ``networkd`` renderer handle wifi.
           numbers overlap between bands, this property takes effect only if
           the ``band`` property is also set.
 
+     ``hidden_ssid`` (bool)
+     :    Set to ``true`` to change the SSID scan technique for connecting to 
+          hidden WiFi networks. Note this may have slower performance compared
+          to ``false`` (the default) when connecting to publicly broadcast
+          SSIDs.
+
 ``wakeonwlan`` (sequence of scalars)
 
 :    This enables WakeOnWLan on supported devices. Not all drivers support all

--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -671,7 +671,7 @@ wpasupplicant installed if you let the ``networkd`` renderer handle wifi.
           numbers overlap between bands, this property takes effect only if
           the ``band`` property is also set.
 
-     ``hidden_ssid`` (bool)
+     ``hidden-ssid`` (bool)
      :    Set to ``true`` to change the SSID scan technique for connecting to 
           hidden WiFi networks. Note this may have slower performance compared
           to ``false`` (the default) when connecting to publicly broadcast

--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -671,7 +671,7 @@ wpasupplicant installed if you let the ``networkd`` renderer handle wifi.
           numbers overlap between bands, this property takes effect only if
           the ``band`` property is also set.
 
-     ``hidden-ssid`` (bool)
+     ``hidden`` (bool)
      :    Set to ``true`` to change the SSID scan technique for connecting to 
           hidden WiFi networks. Note this may have slower performance compared
           to ``false`` (the default) when connecting to publicly broadcast

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -863,7 +863,7 @@ write_wpa_conf(const NetplanNetDefinition* def, const char* rootdir)
             if (ap->bssid) {
                 g_string_append_printf(s, "  bssid=%s\n", ap->bssid);
             }
-            if (ap->hidden_ssid) {
+            if (ap->hidden) {
                 g_string_append(s, "  scan_ssid=1\n");
             }
             if (ap->band == NETPLAN_WIFI_BAND_24) {

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -863,6 +863,9 @@ write_wpa_conf(const NetplanNetDefinition* def, const char* rootdir)
             if (ap->bssid) {
                 g_string_append_printf(s, "  bssid=%s\n", ap->bssid);
             }
+            if (ap->hidden_ssid) {
+                g_string_append(s, "  scan_ssid=1\n");
+            }
             if (ap->band == NETPLAN_WIFI_BAND_24) {
                 // initialize 2.4GHz frequency hashtable
                 if(!wifi_frequency_24)

--- a/src/nm.c
+++ b/src/nm.c
@@ -701,7 +701,7 @@ write_nm_conf_access_point(NetplanNetDefinition* def, const char* rootdir, const
             g_string_append_printf(s, "bssid=%s\n", ap->bssid);
         }
         if (ap->hidden) {
-            g_string_append(s, "hidden=TRUE\n");
+            g_string_append(s, "hidden=true\n");
         }
         if (ap->band == NETPLAN_WIFI_BAND_5 || ap->band == NETPLAN_WIFI_BAND_24) {
             g_string_append_printf(s, "band=%s\n", wifi_band_str(ap->band));

--- a/src/nm.c
+++ b/src/nm.c
@@ -700,6 +700,9 @@ write_nm_conf_access_point(NetplanNetDefinition* def, const char* rootdir, const
         if (ap->bssid) {
             g_string_append_printf(s, "bssid=%s\n", ap->bssid);
         }
+        if (ap->hidden) {
+            g_string_append(s, "hidden=TRUE\n");
+        }
         if (ap->band == NETPLAN_WIFI_BAND_5 || ap->band == NETPLAN_WIFI_BAND_24) {
             g_string_append_printf(s, "band=%s\n", wifi_band_str(ap->band));
             /* Channel is only unambiguous, if band is set. */

--- a/src/parse.c
+++ b/src/parse.c
@@ -665,7 +665,7 @@ handle_access_point_band(yaml_document_t* doc, yaml_node_t* node, const void* _,
 static const mapping_entry_handler wifi_access_point_handlers[] = {
     {"band", YAML_SCALAR_NODE, handle_access_point_band},
     {"bssid", YAML_SCALAR_NODE, handle_access_point_mac, NULL, access_point_offset(bssid)},
-    {"hidden-ssid", YAML_SCALAR_NODE, handle_access_point_bool, NULL, access_point_offset(hidden_ssid)},
+    {"hidden", YAML_SCALAR_NODE, handle_access_point_bool, NULL, access_point_offset(hidden)},
     {"channel", YAML_SCALAR_NODE, handle_access_point_guint, NULL, access_point_offset(channel)},
     {"mode", YAML_SCALAR_NODE, handle_access_point_mode},
     {"password", YAML_SCALAR_NODE, handle_access_point_password},

--- a/src/parse.c
+++ b/src/parse.c
@@ -317,6 +317,34 @@ handle_generic_mac(yaml_document_t* doc, yaml_node_t* node, void* entryptr, cons
     return handle_generic_str(doc, node, entryptr, data, error);
 }
 
+/*
+ * Handler for setting a boolean field from a scalar node, inside a given struct
+ * @entryptr: pointer to the beginning of the to-be-modified data structure
+ * @data: offset into entryptr struct where the boolean field to write is located
+*/
+static gboolean
+handle_generic_bool(yaml_document_t* doc, yaml_node_t* node, void* entryptr, const void* data, GError** error)
+{
+    guint offset = GPOINTER_TO_UINT(data);
+    gboolean v;
+
+    if (g_ascii_strcasecmp(scalar(node), "true") == 0 ||
+        g_ascii_strcasecmp(scalar(node), "on") == 0 ||
+        g_ascii_strcasecmp(scalar(node), "yes") == 0 ||
+        g_ascii_strcasecmp(scalar(node), "y") == 0)
+        v = TRUE;
+    else if (g_ascii_strcasecmp(scalar(node), "false") == 0 ||
+        g_ascii_strcasecmp(scalar(node), "off") == 0 ||
+        g_ascii_strcasecmp(scalar(node), "no") == 0 ||
+        g_ascii_strcasecmp(scalar(node), "n") == 0)
+        v = FALSE;
+    else
+        return yaml_error(node, error, "invalid boolean value '%s'", scalar(node));
+
+    *((gboolean*) ((void*) entryptr + offset)) = v;
+    return TRUE;
+}
+
 /**
  * Generic handler for setting a cur_netdef string field from a scalar node
  * @data: offset into NetplanNetDefinition where the const char* field to write is
@@ -381,24 +409,7 @@ handle_netdef_mac(yaml_document_t* doc, yaml_node_t* node, const void* data, GEr
 static gboolean
 handle_netdef_bool(yaml_document_t* doc, yaml_node_t* node, const void* data, GError** error)
 {
-    guint offset = GPOINTER_TO_UINT(data);
-    gboolean v;
-
-    if (g_ascii_strcasecmp(scalar(node), "true") == 0 ||
-        g_ascii_strcasecmp(scalar(node), "on") == 0 ||
-        g_ascii_strcasecmp(scalar(node), "yes") == 0 ||
-        g_ascii_strcasecmp(scalar(node), "y") == 0)
-        v = TRUE;
-    else if (g_ascii_strcasecmp(scalar(node), "false") == 0 ||
-        g_ascii_strcasecmp(scalar(node), "off") == 0 ||
-        g_ascii_strcasecmp(scalar(node), "no") == 0 ||
-        g_ascii_strcasecmp(scalar(node), "n") == 0)
-        v = FALSE;
-    else
-        return yaml_error(node, error, "invalid boolean value '%s'", scalar(node));
-
-    *((gboolean*) ((void*) cur_netdef + offset)) = v;
-    return TRUE;
+    return handle_generic_bool(doc, node, cur_netdef, data, error);
 }
 
 /**
@@ -573,29 +584,6 @@ get_default_backend_for_type(NetplanDefType type)
 }
 
 static gboolean
-handle_access_point_bool(yaml_document_t* doc, yaml_node_t* node, const void* data, GError** error)
-{
-    guint offset = GPOINTER_TO_UINT(data);
-    gboolean v;
-
-    if (g_ascii_strcasecmp(scalar(node), "true") == 0 ||
-        g_ascii_strcasecmp(scalar(node), "on") == 0 ||
-        g_ascii_strcasecmp(scalar(node), "yes") == 0 ||
-        g_ascii_strcasecmp(scalar(node), "y") == 0)
-        v = TRUE;
-    else if (g_ascii_strcasecmp(scalar(node), "false") == 0 ||
-        g_ascii_strcasecmp(scalar(node), "off") == 0 ||
-        g_ascii_strcasecmp(scalar(node), "no") == 0 ||
-        g_ascii_strcasecmp(scalar(node), "n") == 0)
-        v = FALSE;
-    else
-        return yaml_error(node, error, "invalid boolean value '%s'", scalar(node));
-
-    *((gboolean*) ((void*) cur_access_point + offset)) = v;
-    return TRUE;
-}
-
-static gboolean
 handle_access_point_guint(yaml_document_t* doc, yaml_node_t* node, const void* data, GError** error)
 {
     return handle_generic_guint(doc, node, cur_access_point, data, error);
@@ -605,6 +593,12 @@ static gboolean
 handle_access_point_mac(yaml_document_t* doc, yaml_node_t* node, const void* data, GError** error)
 {
     return handle_generic_mac(doc, node, cur_access_point, data, error);
+}
+
+static gboolean
+handle_access_point_bool(yaml_document_t* doc, yaml_node_t* node, const void* data, GError** error)
+{
+    return handle_generic_bool(doc, node, cur_access_point, data, error);
 }
 
 static gboolean
@@ -1100,24 +1094,7 @@ check_and_set_family(int family, guint* dest)
 static gboolean
 handle_routes_bool(yaml_document_t* doc, yaml_node_t* node, const void* data, GError** error)
 {
-    guint offset = GPOINTER_TO_UINT(data);
-    gboolean v;
-
-    if (g_ascii_strcasecmp(scalar(node), "true") == 0 ||
-        g_ascii_strcasecmp(scalar(node), "on") == 0 ||
-        g_ascii_strcasecmp(scalar(node), "yes") == 0 ||
-        g_ascii_strcasecmp(scalar(node), "y") == 0)
-        v = TRUE;
-    else if (g_ascii_strcasecmp(scalar(node), "false") == 0 ||
-        g_ascii_strcasecmp(scalar(node), "off") == 0 ||
-        g_ascii_strcasecmp(scalar(node), "no") == 0 ||
-        g_ascii_strcasecmp(scalar(node), "n") == 0)
-        v = FALSE;
-    else
-        return yaml_error(node, error, "invalid boolean value '%s'", scalar(node));
-
-    *((gboolean*) ((void*) cur_route + offset)) = v;
-    return TRUE;
+    return handle_generic_bool(doc, node, cur_route, data, error);
 }
 
 static gboolean

--- a/src/parse.c
+++ b/src/parse.c
@@ -665,7 +665,7 @@ handle_access_point_band(yaml_document_t* doc, yaml_node_t* node, const void* _,
 static const mapping_entry_handler wifi_access_point_handlers[] = {
     {"band", YAML_SCALAR_NODE, handle_access_point_band},
     {"bssid", YAML_SCALAR_NODE, handle_access_point_mac, NULL, access_point_offset(bssid)},
-    {"hidden_ssid", YAML_SCALAR_NODE, handle_access_point_bool, NULL, access_point_offset(hidden_ssid)},
+    {"hidden-ssid", YAML_SCALAR_NODE, handle_access_point_bool, NULL, access_point_offset(hidden_ssid)},
     {"channel", YAML_SCALAR_NODE, handle_access_point_guint, NULL, access_point_offset(channel)},
     {"mode", YAML_SCALAR_NODE, handle_access_point_mode},
     {"password", YAML_SCALAR_NODE, handle_access_point_password},

--- a/src/parse.c
+++ b/src/parse.c
@@ -573,6 +573,29 @@ get_default_backend_for_type(NetplanDefType type)
 }
 
 static gboolean
+handle_access_point_bool(yaml_document_t* doc, yaml_node_t* node, const void* data, GError** error)
+{
+    guint offset = GPOINTER_TO_UINT(data);
+    gboolean v;
+
+    if (g_ascii_strcasecmp(scalar(node), "true") == 0 ||
+        g_ascii_strcasecmp(scalar(node), "on") == 0 ||
+        g_ascii_strcasecmp(scalar(node), "yes") == 0 ||
+        g_ascii_strcasecmp(scalar(node), "y") == 0)
+        v = TRUE;
+    else if (g_ascii_strcasecmp(scalar(node), "false") == 0 ||
+        g_ascii_strcasecmp(scalar(node), "off") == 0 ||
+        g_ascii_strcasecmp(scalar(node), "no") == 0 ||
+        g_ascii_strcasecmp(scalar(node), "n") == 0)
+        v = FALSE;
+    else
+        return yaml_error(node, error, "invalid boolean value '%s'", scalar(node));
+
+    *((gboolean*) ((void*) cur_access_point + offset)) = v;
+    return TRUE;
+}
+
+static gboolean
 handle_access_point_guint(yaml_document_t* doc, yaml_node_t* node, const void* data, GError** error)
 {
     return handle_generic_guint(doc, node, cur_access_point, data, error);
@@ -642,6 +665,7 @@ handle_access_point_band(yaml_document_t* doc, yaml_node_t* node, const void* _,
 static const mapping_entry_handler wifi_access_point_handlers[] = {
     {"band", YAML_SCALAR_NODE, handle_access_point_band},
     {"bssid", YAML_SCALAR_NODE, handle_access_point_mac, NULL, access_point_offset(bssid)},
+    {"hidden_ssid", YAML_SCALAR_NODE, handle_access_point_bool, NULL, access_point_offset(hidden_ssid)},
     {"channel", YAML_SCALAR_NODE, handle_access_point_guint, NULL, access_point_offset(channel)},
     {"mode", YAML_SCALAR_NODE, handle_access_point_mode},
     {"password", YAML_SCALAR_NODE, handle_access_point_password},

--- a/src/parse.h
+++ b/src/parse.h
@@ -368,6 +368,7 @@ typedef struct {
     char* ssid;
     NetplanWifiBand band;
     char* bssid;
+    gboolean hidden_ssid;
     guint channel;
 
     NetplanAuthenticationSettings auth;

--- a/src/parse.h
+++ b/src/parse.h
@@ -368,7 +368,7 @@ typedef struct {
     char* ssid;
     NetplanWifiBand band;
     char* bssid;
-    gboolean hidden_ssid;
+    gboolean hidden;
     guint channel;
 
     NetplanAuthenticationSettings auth;

--- a/tests/generator/test_errors.py
+++ b/tests/generator/test_errors.py
@@ -250,7 +250,7 @@ class TestConfigErrors(TestBase):
     wl0:
       access-points:
         hidden:
-          hidden_ssid: maybe''', expect_fail=True)
+          hidden-ssid: maybe''', expect_fail=True)
         self.assertIn("invalid boolean value 'maybe'", err)
 
     def test_invalid_ipv4_address(self):

--- a/tests/generator/test_errors.py
+++ b/tests/generator/test_errors.py
@@ -243,6 +243,16 @@ class TestConfigErrors(TestBase):
           channel: 14''', expect_fail=True)
         self.assertIn("ERROR: invalid 5GHz WiFi channel: 14", err)
 
+    def test_wifi_invalid_hidden_ssid(self):
+        err = self.generate('''network:
+  version: 2
+  wifis:
+    wl0:
+      access-points:
+        hidden:
+          hidden_ssid: maybe''', expect_fail=True)
+        self.assertIn("invalid boolean value 'maybe'", err)
+
     def test_invalid_ipv4_address(self):
         err = self.generate('''network:
   version: 2

--- a/tests/generator/test_errors.py
+++ b/tests/generator/test_errors.py
@@ -243,14 +243,14 @@ class TestConfigErrors(TestBase):
           channel: 14''', expect_fail=True)
         self.assertIn("ERROR: invalid 5GHz WiFi channel: 14", err)
 
-    def test_wifi_invalid_hidden_ssid(self):
+    def test_wifi_invalid_hidden(self):
         err = self.generate('''network:
   version: 2
   wifis:
     wl0:
       access-points:
         hidden:
-          hidden-ssid: maybe''', expect_fail=True)
+          hidden: maybe''', expect_fail=True)
         self.assertIn("invalid boolean value 'maybe'", err)
 
     def test_invalid_ipv4_address(self):

--- a/tests/generator/test_wifis.py
+++ b/tests/generator/test_wifis.py
@@ -43,10 +43,10 @@ class TestNetworkd(TestBase):
         peer2peer:
           mode: adhoc
         hidden-y:
-          hidden_ssid: y
+          hidden-ssid: y
           password: "0bscur1ty"
         hidden-n:
-          hidden_ssid: n
+          hidden-ssid: n
           password: "5ecur1ty"
         channel-no-band:
           channel: 7

--- a/tests/generator/test_wifis.py
+++ b/tests/generator/test_wifis.py
@@ -42,6 +42,9 @@ class TestNetworkd(TestBase):
           channel: 100
         peer2peer:
           mode: adhoc
+        hidden:
+          hidden_ssid: true
+          password: "c0mpany1"
         channel-no-band:
           channel: 7
         band-no-channel:
@@ -59,6 +62,7 @@ unmanaged-devices+=interface-name:wl0,''')
         # generates wpa config and enables wpasupplicant unit
         with open(os.path.join(self.workdir.name, 'run/netplan/wpa-wl0.conf')) as f:
             new_config = f.read()
+            print(new_config)
 
             network = 'ssid="{}"\n  freq_list='.format('band-no-channel2')
             freqs_5GHz = [5610, 5310, 5620, 5320, 5630, 5640, 5340, 5035, 5040, 5045, 5055, 5060, 5660, 5680, 5670, 5080, 5690,

--- a/tests/generator/test_wifis.py
+++ b/tests/generator/test_wifis.py
@@ -42,9 +42,12 @@ class TestNetworkd(TestBase):
           channel: 100
         peer2peer:
           mode: adhoc
-        hidden:
-          hidden_ssid: true
+        hidden-y:
+          hidden_ssid: y
           password: "0bscur1ty"
+        hidden-n:
+          hidden_ssid: n
+          password: "5ecur1ty"
         channel-no-band:
           channel: 7
         band-no-channel:
@@ -97,10 +100,17 @@ network={
 ''', new_config)
             self.assertIn('''
 network={
-  ssid="hidden"
+  ssid="hidden-y"
   scan_ssid=1
   key_mgmt=WPA-PSK
   psk="0bscur1ty"
+}
+''', new_config)
+            self.assertIn('''
+network={
+  ssid="hidden-n"
+  key_mgmt=WPA-PSK
+  psk="5ecur1ty"
 }
 ''', new_config)
             self.assertIn('''

--- a/tests/generator/test_wifis.py
+++ b/tests/generator/test_wifis.py
@@ -44,7 +44,7 @@ class TestNetworkd(TestBase):
           mode: adhoc
         hidden:
           hidden_ssid: true
-          password: "c0mpany1"
+          password: "0bscur1ty"
         channel-no-band:
           channel: 7
         band-no-channel:
@@ -62,7 +62,6 @@ unmanaged-devices+=interface-name:wl0,''')
         # generates wpa config and enables wpasupplicant unit
         with open(os.path.join(self.workdir.name, 'run/netplan/wpa-wl0.conf')) as f:
             new_config = f.read()
-            print(new_config)
 
             network = 'ssid="{}"\n  freq_list='.format('band-no-channel2')
             freqs_5GHz = [5610, 5310, 5620, 5320, 5630, 5640, 5340, 5035, 5040, 5045, 5055, 5060, 5660, 5680, 5670, 5080, 5690,
@@ -94,6 +93,14 @@ network={
   ssid="peer2peer"
   mode=1
   key_mgmt=NONE
+}
+''', new_config)
+            self.assertIn('''
+network={
+  ssid="hidden"
+  scan_ssid=1
+  key_mgmt=WPA-PSK
+  psk="0bscur1ty"
 }
 ''', new_config)
             self.assertIn('''

--- a/tests/generator/test_wifis.py
+++ b/tests/generator/test_wifis.py
@@ -43,10 +43,10 @@ class TestNetworkd(TestBase):
         peer2peer:
           mode: adhoc
         hidden-y:
-          hidden-ssid: y
+          hidden: y
           password: "0bscur1ty"
         hidden-n:
-          hidden-ssid: n
+          hidden: n
           password: "5ecur1ty"
         channel-no-band:
           channel: 7
@@ -294,6 +294,12 @@ class TestNetworkManager(TestBase):
           bssid: de:ad:be:ef:ca:fe
           band: 5GHz
           channel: 100
+        hidden-y:
+          hidden: y
+          password: "0bscur1ty"
+        hidden-n:
+          hidden: n
+          password: "5ecur1ty"
         channel-no-band:
           channel: 22
         band-no-channel:
@@ -349,6 +355,51 @@ channel=100
 [wifi-security]
 key-mgmt=wpa-psk
 psk=c0mpany1
+''',
+                        'wl0-hidden-y': '''[connection]
+id=netplan-wl0-hidden-y
+type=wifi
+interface-name=wl0
+
+[ethernet]
+wake-on-lan=0
+
+[ipv4]
+method=auto
+
+[ipv6]
+method=ignore
+
+[wifi]
+ssid=hidden-y
+mode=infrastructure
+hidden=TRUE
+
+[wifi-security]
+key-mgmt=wpa-psk
+psk=0bscur1ty
+''',
+                        'wl0-hidden-n': '''[connection]
+id=netplan-wl0-hidden-n
+type=wifi
+interface-name=wl0
+
+[ethernet]
+wake-on-lan=0
+
+[ipv4]
+method=auto
+
+[ipv6]
+method=ignore
+
+[wifi]
+ssid=hidden-n
+mode=infrastructure
+
+[wifi-security]
+key-mgmt=wpa-psk
+psk=5ecur1ty
 ''',
                         'wl0-channel-no-band': '''[connection]
 id=netplan-wl0-channel-no-band


### PR DESCRIPTION
## Description
We got bit this week by not being able to connect to a "hidden" WiFi network with Netplan. A quick search brought up this top result, and we were able to work around the issue with the posted hack:
https://askubuntu.com/questions/1111494/netplan-not-connecting-to-hidden-ssid-server-18-04-1-lts

I'm a first-time contributor, but it didn't take me too long to get this working. The existing code is pleasantly clear and organized! I did notice some repeated code in the `handle_[foo]_bool` methods - I think this is now the third such method. Should some of this logic be moved into a `handle_generic_bool` function? I'm also not familiar with the other backends, so please let me know if there is work to be done to make this more broadly applicable.

The first two checklist items are pending, as I did this development in Docker and could not get the `TestNetplanDBus` tests to pass. I will try to do this in a VM but other feedback is appreciated in the meantime.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [x] New/changed keys in YAML format are documented.
- [x] \(Optional\) Closes an open bug in Launchpad: [#1866100](https://bugs.launchpad.net/netplan/+bug/1866100)

