### PR TITLE
Fix LP#1874377: Not connect to WiFi after 'netplan apply'

### DIFF
--- a/netplan/cli/commands/apply.py
+++ b/netplan/cli/commands/apply.py
@@ -109,6 +109,9 @@ class NetplanApply(utils.NetplanCommand):
         if restart_networkd:
             logging.debug('netplan generated networkd configuration changed, restarting networkd')
             utils.systemctl_networkd('stop', sync=sync, extra_services=['netplan-wpa-*.service'])
+            # Historically (up to v0.98) we had netplan-wpa@*.service files, in case of an
+            # upgraded system, we need to make sure to stop those.
+            utils.systemctl_networkd('stop', sync=sync, extra_services=['netplan-wpa@*.service'])
         else:
             logging.debug('no netplan generated networkd configuration exists')
 

--- a/netplan/cli/commands/apply.py
+++ b/netplan/cli/commands/apply.py
@@ -108,7 +108,7 @@ class NetplanApply(utils.NetplanCommand):
         # stop backends
         if restart_networkd:
             logging.debug('netplan generated networkd configuration changed, restarting networkd')
-            utils.systemctl_networkd('stop', sync=sync, extra_services=['netplan-wpa@*.service'])
+            utils.systemctl_networkd('stop', sync=sync, extra_services=['netplan-wpa-*.service'])
         else:
             logging.debug('no netplan generated networkd configuration exists')
 
@@ -169,7 +169,7 @@ class NetplanApply(utils.NetplanCommand):
 
         # (re)start backends
         if restart_networkd:
-            netplan_wpa = [os.path.basename(f) for f in glob.glob('/run/systemd/system/*.wants/netplan-wpa@*.service')]
+            netplan_wpa = [os.path.basename(f) for f in glob.glob('/run/systemd/system/*.wants/netplan-wpa-*.service')]
             utils.systemctl_networkd('start', sync=sync, extra_services=netplan_wpa)
         if restart_nm:
             utils.systemctl_network_manager('start', sync=sync)

--- a/netplan/cli/commands/apply.py
+++ b/netplan/cli/commands/apply.py
@@ -108,13 +108,13 @@ class NetplanApply(utils.NetplanCommand):
         # stop backends
         if restart_networkd:
             logging.debug('netplan generated networkd configuration changed, restarting networkd')
-            utils.systemctl_networkd('stop', sync=sync, extra_services=['netplan-wpa-*.service'])
+            wpa_services = ['netplan-wpa-*.service']
             # Historically (up to v0.98) we had netplan-wpa@*.service files, in case of an
             # upgraded system, we need to make sure to stop those.
-            try:
-                utils.systemctl_networkd('stop', sync=sync, extra_services=['netplan-wpa@*.service'])
-            except subprocess.CalledProcessError:
-                logging.debug('could not stop historical "netplan-wpa@*" systemd service')
+            if utils.systemctl_is_active('netplan-wpa@*.service'):
+                wpa_services.insert(0, 'netplan-wpa@*.service')
+            utils.systemctl_networkd('stop', sync=sync, extra_services=wpa_services)
+
         else:
             logging.debug('no netplan generated networkd configuration exists')
 

--- a/netplan/cli/commands/apply.py
+++ b/netplan/cli/commands/apply.py
@@ -111,7 +111,10 @@ class NetplanApply(utils.NetplanCommand):
             utils.systemctl_networkd('stop', sync=sync, extra_services=['netplan-wpa-*.service'])
             # Historically (up to v0.98) we had netplan-wpa@*.service files, in case of an
             # upgraded system, we need to make sure to stop those.
-            utils.systemctl_networkd('stop', sync=sync, extra_services=['netplan-wpa@*.service'])
+            try:
+                utils.systemctl_networkd('stop', sync=sync, extra_services=['netplan-wpa@*.service'])
+            except subprocess.CalledProcessError:
+                logging.debug('could not stop historical "netplan-wpa@*" systemd service')
         else:
             logging.debug('no netplan generated networkd configuration exists')
 

--- a/netplan/cli/utils.py
+++ b/netplan/cli/utils.py
@@ -86,6 +86,13 @@ def systemctl_networkd(action, sync=False, extra_services=[]):  # pragma: nocove
     subprocess.check_call(command)
 
 
+def systemctl_is_active(unit_pattern):  # pragma: nocover (covered in autopkgtest)
+    '''Return True if at least one matching unit is running'''
+    if subprocess.call(['systemctl', '--quiet', 'is-active', unit_pattern]) == 0:
+        return True
+    return False
+
+
 def get_interface_driver_name(interface, only_down=False):  # pragma: nocover (covered in autopkgtest)
     devdir = os.path.join('/sys/class/net', interface)
     if only_down:

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -992,6 +992,9 @@ cleanup_networkd_conf(const char* rootdir)
     unlink_glob(rootdir, "/run/netplan/wpa-*.conf");
     unlink_glob(rootdir, "/run/systemd/system/netplan-wpa-*.service");
     unlink_glob(rootdir, "/run/udev/rules.d/99-netplan-*");
+    /* Historically (up to v0.98) we had netplan-wpa@*.service files, in case of an
+     * upgraded system, we need to make sure to clean those up. */
+    unlink_glob(rootdir, "/run/systemd/system/systemd-networkd.service.wants/netplan-wpa@*.service");
 }
 
 /**

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -990,6 +990,7 @@ cleanup_networkd_conf(const char* rootdir)
 {
     unlink_glob(rootdir, "/run/systemd/network/10-netplan-*");
     unlink_glob(rootdir, "/run/netplan/wpa-*.conf");
+    unlink_glob(rootdir, "/run/systemd/system/systemd-networkd.service.wants/netplan-wpa-*.service");
     unlink_glob(rootdir, "/run/systemd/system/netplan-wpa-*.service");
     unlink_glob(rootdir, "/run/udev/rules.d/99-netplan-*");
     /* Historically (up to v0.98) we had netplan-wpa@*.service files, in case of an

--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -93,7 +93,7 @@ class IntegrationTestsBase(unittest.TestCase):
             pass
 
     def tearDown(self):
-        subprocess.call(['systemctl', 'stop', 'NetworkManager', 'systemd-networkd', 'netplan-wpa@*',
+        subprocess.call(['systemctl', 'stop', 'NetworkManager', 'systemd-networkd', 'netplan-wpa-*',
                                               'systemd-networkd.socket'])
         # NM has KillMode=process and leaks dhclient processes
         subprocess.call(['systemctl', 'kill', 'NetworkManager'])


### PR DESCRIPTION
## Description
Seems like the 'netplan apply' command was not properly adopted in https://github.com/CanonicalLtd/netplan/pull/109 when wired wpa_supplicant support was introduced.

Fixes: https://bugs.launchpad.net/ubuntu/+source/netplan.io/+bug/1874377

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [x] \(Optional\) Closes an open bug in Launchpad.

