### PR TITLE
Implement DBus try-commit handling

### DIFF
--- a/netplan/cli/commands/try_command.py
+++ b/netplan/cli/commands/try_command.py
@@ -76,6 +76,7 @@ class NetplanTry(utils.NetplanCommand):
 
             # we really don't want to be interrupted while doing backup/revert operations
             signal.signal(signal.SIGINT, self._signal_handler)
+            signal.signal(signal.SIGUSR1, self._signal_handler)
 
             self.backup()
             self.setup()
@@ -175,6 +176,9 @@ class NetplanTry(utils.NetplanCommand):
             return False
         return True
 
-    def _signal_handler(self, signal, frame):  # pragma: nocover (requires user input)
-        if self.configuration_changed:
-            raise netplan.terminal.InputRejected()
+    def _signal_handler(self, sig, frame):  # pragma: nocover (requires user input)
+        if sig == signal.SIGUSR1:
+            raise netplan.terminal.InputAccepted()
+        else:
+            if self.configuration_changed:
+                raise netplan.terminal.InputRejected()

--- a/netplan/terminal.py
+++ b/netplan/terminal.py
@@ -117,10 +117,9 @@ class Terminal(object):
             - dest: if set, save settings to this dict
         """
         orig_flags = fcntl.fcntl(self.fd, fcntl.F_GETFL)
+        orig_term = None
         if sys.stdin.isatty():
             orig_term = termios.tcgetattr(self.fd)
-        else:
-            orig_term = None
         if dest is not None:
             dest.update({'flags': orig_flags,
                          'term': orig_term})

--- a/netplan/terminal.py
+++ b/netplan/terminal.py
@@ -38,16 +38,18 @@ class Terminal(object):
         self.save()
 
     def enable_echo(self):
-        attrs = termios.tcgetattr(self.fd)
-        attrs[3] = attrs[3] | termios.ICANON
-        attrs[3] = attrs[3] | termios.ECHO
-        termios.tcsetattr(self.fd, termios.TCSANOW, attrs)
+        if sys.stdin.isatty():
+            attrs = termios.tcgetattr(self.fd)
+            attrs[3] = attrs[3] | termios.ICANON
+            attrs[3] = attrs[3] | termios.ECHO
+            termios.tcsetattr(self.fd, termios.TCSANOW, attrs)
 
     def disable_echo(self):
-        attrs = termios.tcgetattr(self.fd)
-        attrs[3] = attrs[3] & ~termios.ICANON
-        attrs[3] = attrs[3] & ~termios.ECHO
-        termios.tcsetattr(self.fd, termios.TCSANOW, attrs)
+        if sys.stdin.isatty():
+            attrs = termios.tcgetattr(self.fd)
+            attrs[3] = attrs[3] & ~termios.ICANON
+            attrs[3] = attrs[3] & ~termios.ECHO
+            termios.tcsetattr(self.fd, termios.TCSANOW, attrs)
 
     def enable_nonblocking_io(self):
         flags = fcntl.fcntl(self.fd, fcntl.F_GETFL)
@@ -115,7 +117,10 @@ class Terminal(object):
             - dest: if set, save settings to this dict
         """
         orig_flags = fcntl.fcntl(self.fd, fcntl.F_GETFL)
-        orig_term = termios.tcgetattr(self.fd)
+        if sys.stdin.isatty():
+            orig_term = termios.tcgetattr(self.fd)
+        else:
+            orig_term = None
         if dest is not None:
             dest.update({'flags': orig_flags,
                          'term': orig_term})
@@ -138,7 +143,8 @@ class Terminal(object):
         else:
             orig_term = self.orig_term
             orig_flags = self.orig_flags
-        termios.tcsetattr(self.fd, termios.TCSAFLUSH, orig_term)
+        if sys.stdin.isatty():
+            termios.tcsetattr(self.fd, termios.TCSAFLUSH, orig_term)
         fcntl.fcntl(self.fd, fcntl.F_SETFL, orig_flags)
 
 

--- a/netplan/terminal.py
+++ b/netplan/terminal.py
@@ -38,18 +38,16 @@ class Terminal(object):
         self.save()
 
     def enable_echo(self):
-        if sys.stdin.isatty():
-            attrs = termios.tcgetattr(self.fd)
-            attrs[3] = attrs[3] | termios.ICANON
-            attrs[3] = attrs[3] | termios.ECHO
-            termios.tcsetattr(self.fd, termios.TCSANOW, attrs)
+        attrs = termios.tcgetattr(self.fd)
+        attrs[3] = attrs[3] | termios.ICANON
+        attrs[3] = attrs[3] | termios.ECHO
+        termios.tcsetattr(self.fd, termios.TCSANOW, attrs)
 
     def disable_echo(self):
-        if sys.stdin.isatty():
-            attrs = termios.tcgetattr(self.fd)
-            attrs[3] = attrs[3] & ~termios.ICANON
-            attrs[3] = attrs[3] & ~termios.ECHO
-            termios.tcsetattr(self.fd, termios.TCSANOW, attrs)
+        attrs = termios.tcgetattr(self.fd)
+        attrs[3] = attrs[3] & ~termios.ICANON
+        attrs[3] = attrs[3] & ~termios.ECHO
+        termios.tcsetattr(self.fd, termios.TCSANOW, attrs)
 
     def enable_nonblocking_io(self):
         flags = fcntl.fcntl(self.fd, fcntl.F_GETFL)
@@ -117,10 +115,7 @@ class Terminal(object):
             - dest: if set, save settings to this dict
         """
         orig_flags = fcntl.fcntl(self.fd, fcntl.F_GETFL)
-        if sys.stdin.isatty():
-            orig_term = termios.tcgetattr(self.fd)
-        else:
-            orig_term = None
+        orig_term = termios.tcgetattr(self.fd)
         if dest is not None:
             dest.update({'flags': orig_flags,
                          'term': orig_term})
@@ -143,8 +138,7 @@ class Terminal(object):
         else:
             orig_term = self.orig_term
             orig_flags = self.orig_flags
-        if sys.stdin.isatty():
-            termios.tcsetattr(self.fd, termios.TCSAFLUSH, orig_term)
+        termios.tcsetattr(self.fd, termios.TCSAFLUSH, orig_term)
         fcntl.fcntl(self.fd, fcntl.F_SETFL, orig_flags)
 
 

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -30,10 +30,8 @@ static int
 send_config_changed_signal(sd_bus *bus)
 {
     sd_bus_message *msg = NULL;
-    int r = sd_bus_message_new_signal(bus, &msg,
-                                      "/io/netplan/Netplan",
-                                      "io.netplan.Netplan",
-                                      "Changed");
+    int r = sd_bus_message_new_signal(bus, &msg, "/io/netplan/Netplan",
+                                      "io.netplan.Netplan", "Changed");
     if (r < 0) {
         fprintf(stderr, "Could not create .Changed() signal: %s\n", strerror(-r));
         return r;

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -104,7 +104,7 @@ static int method_apply(sd_bus_message *m, void *userdata, sd_bus_error *ret_err
     gchar *argv[] = {SBINDIR "/" "netplan", "apply", NULL};
 
     // for tests only: allow changing what netplan to run
-    if (getuid() != 0 && getenv("DBUS_TEST_NETPLAN_CMD") != 0) {
+    if (getenv("DBUS_TEST_NETPLAN_CMD") != 0) {
        argv[0] = getenv("DBUS_TEST_NETPLAN_CMD");
     }
 
@@ -175,7 +175,7 @@ static int method_get(sd_bus_message *m, void *userdata, sd_bus_error *ret_error
     gchar *argv[] = {SBINDIR "/" "netplan", "get", "all", NULL};
 
     // for tests only: allow changing what netplan to run
-    if (getuid() != 0 && getenv("DBUS_TEST_NETPLAN_CMD") != 0)
+    if (getenv("DBUS_TEST_NETPLAN_CMD") != 0)
        argv[0] = getenv("DBUS_TEST_NETPLAN_CMD");
 
     g_spawn_sync("/", argv, NULL, 0, NULL, NULL, &stdout, &stderr, &exit_status, &err);
@@ -209,7 +209,7 @@ static int method_set(sd_bus_message *m, void *userdata, sd_bus_error *ret_error
     gchar *argv[] = {SBINDIR "/" "netplan", "set", config_delta, origin, NULL};
 
     // for tests only: allow changing what netplan to run
-    if (getuid() != 0 && getenv("DBUS_TEST_NETPLAN_CMD") != 0)
+    if (getenv("DBUS_TEST_NETPLAN_CMD") != 0)
        argv[0] = getenv("DBUS_TEST_NETPLAN_CMD");
 
     g_spawn_sync("/", argv, NULL, 0, NULL, NULL, &stdout, &stderr, &exit_status, &err);
@@ -250,7 +250,7 @@ static int method_try(sd_bus_message *m, void *userdata, sd_bus_error *ret_error
     gchar *argv[] = {SBINDIR "/" "netplan", "try", timeout, NULL};
 
     // for tests only: allow changing what netplan to run
-    if (getuid() != 0 && getenv("DBUS_TEST_NETPLAN_CMD") != 0)
+    if (getenv("DBUS_TEST_NETPLAN_CMD") != 0)
        argv[0] = getenv("DBUS_TEST_NETPLAN_CMD");
 
     /* Launch 'netplan try' child process */

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -349,6 +349,7 @@ int main(int argc, char *argv[]) {
         fprintf(stderr, "Failed mainloop: %s\n", strerror(-r));
 finish:
     g_free(data);
+    sd_event_unref(event);
     sd_bus_slot_unref(slot);
     sd_bus_unref(bus);
 

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -18,6 +18,9 @@
  * correctly capture tests being run over a DBus bus.
  */
 
+static gint _try_child_stdin = -1;
+static GPid _try_child_pid = -1;
+
 static int method_apply(sd_bus_message *m, void *userdata, sd_bus_error *ret_error) {
     g_autoptr(GError) err = NULL;
     g_autofree gchar *stdout = NULL;
@@ -146,12 +149,98 @@ static int method_set(sd_bus_message *m, void *userdata, sd_bus_error *ret_error
     return sd_bus_reply_method_return(m, "b", true);
 }
 
+static int method_try(sd_bus_message *m, void *userdata, sd_bus_error *ret_error) {
+    g_autoptr(GError) err = NULL;
+    const char *key1 = NULL, *key2 = NULL;
+    char *val1 = NULL, *val2 = NULL;
+    gchar *config_file = NULL;
+    gchar *timeout = NULL;
+
+    /* Read optional arguments: "timeout" and/or "config-file" */
+    sd_bus_message_read (m, "a{ss}", 2, &key1, &val1, &key2, &val2);
+    if (!g_strcmp0(key1, "timeout"))
+        timeout = val1;
+    else if (!g_strcmp0(key1, "config-file"))
+        config_file = val1;
+
+    if (!g_strcmp0(key2, "timeout"))
+        timeout = val2;
+    else if (!g_strcmp0(key2, "config-file"))
+        config_file = val2;
+
+    gchar *argv[] = {SBINDIR "/" "netplan", "try", NULL, NULL, NULL, NULL, NULL};
+
+    /* Fill the NULLs with optional args */
+    unsigned i = 2;
+    if (timeout != NULL) {
+        argv[i++] = "--timeout";
+        argv[i++] = timeout;
+    }
+    if (config_file != NULL) {
+        argv[i++] = "--config-file";
+        argv[i++] = config_file;
+    }
+
+    // for tests only: allow changing what netplan to run
+    if (getuid() != 0 && getenv("DBUS_TEST_NETPLAN_CMD") != 0) {
+       argv[0] = getenv("DBUS_TEST_NETPLAN_CMD");
+    }
+
+    // TODO: stdout & stderr to /dev/null flags
+    g_spawn_async_with_pipes("/", argv, NULL, G_SPAWN_DO_NOT_REAP_CHILD, NULL, NULL, &_try_child_pid, &_try_child_stdin, NULL, NULL, &err);
+    if (err != NULL) {
+        return sd_bus_error_setf(ret_error, SD_BUS_ERROR_FAILED, "cannot run netplan try: %s", err->message);
+    }
+
+    // TODO: return child_pid and child_stdin
+    return sd_bus_reply_method_return(m, "b", true);
+}
+
+static int method_try_commit(sd_bus_message *m, void *userdata, sd_bus_error *ret_error) {
+    GError *error = NULL;
+    GIOChannel *stdin = NULL;
+    int status = -1;
+
+    // TODO: consume child_pid and child_stdin as args instead of global var
+    if (_try_child_pid < 0 || waitpid (_try_child_pid, &status, WNOHANG) < 0) {
+        /* Child does not exist or already exited ... */
+        return sd_bus_reply_method_return(m, "b", false);
+    }
+
+    /* Create input channel and send carriage return (i.e. "ENTER") */
+    stdin = g_io_channel_unix_new (_try_child_stdin);
+    g_io_channel_write_chars (stdin, "\n", 1, NULL, &error);
+    if (error != NULL) {
+        return sd_bus_error_setf(ret_error, SD_BUS_ERROR_FAILED, "cannot COMMIT netplan try: %s", error->message);
+    }
+    g_io_channel_shutdown (stdin, TRUE, &error);
+    if (error != NULL) {
+        return sd_bus_error_setf(ret_error, SD_BUS_ERROR_FAILED, "cannot COMMIT netplan try: %s", error->message);
+    }
+
+    waitpid (_try_child_pid, &status, 0);
+    g_spawn_check_exit_status(status, &error);
+    if (error != NULL) {
+        return sd_bus_error_setf(ret_error, SD_BUS_ERROR_FAILED, "netplan try failed: %s", error->message);
+    }
+    if (!WIFEXITED(status)) {
+        return sd_bus_error_setf(ret_error, SD_BUS_ERROR_FAILED, "netplan try failed: %s", "IFEXITED");
+    }
+    printf("Child exited with status code %d\n", WEXITSTATUS(status));
+
+    g_spawn_close_pid (_try_child_pid);
+
+    return sd_bus_reply_method_return(m, "b", true);
+}
+
 static const sd_bus_vtable netplan_vtable[] = {
     SD_BUS_VTABLE_START(0),
     SD_BUS_METHOD("Apply", "", "b", method_apply, 0),
     SD_BUS_METHOD("Info", "", "a(sv)", method_info, 0),
     SD_BUS_METHOD("Get", "", "s", method_get, 0),
     SD_BUS_METHOD("Set", "ss", "b", method_set, 0),
+    SD_BUS_METHOD("Try", "a{ss}", "b", method_try, 0),
+    SD_BUS_METHOD("TryCommit", "", "b", method_try_commit, 0),
     SD_BUS_VTABLE_END
 };
 

--- a/tests/dbus/test_dbus.py
+++ b/tests/dbus/test_dbus.py
@@ -274,11 +274,11 @@ class TestNetplanDBus(unittest.TestCase):
         self.assertEqual("b true\n", output.decode("utf-8"))
 
         # FIXME: verify call stack
-        #self.assertEquals(self.mock_netplan_cmd.calls(), [
-        #        ["netplan", "try"],
-        #        ["netplan", "try", "--timeout", "10"],
-        #        ["netplan", "try", "--config-file", "./config.yaml", "--timeout", "10"],
-        #])
+        # self.assertEquals(self.mock_netplan_cmd.calls(), [
+        #         ["netplan", "try"],
+        #         ["netplan", "try", "--timeout", "10"],
+        #         ["netplan", "try", "--config-file", "./config.yaml", "--timeout", "10"],
+        # ])
 
     def test_netplan_dbus_no_such_command(self):
         p = subprocess.Popen(

--- a/tests/dbus/test_dbus.py
+++ b/tests/dbus/test_dbus.py
@@ -233,7 +233,7 @@ class TestNetplanDBus(unittest.TestCase):
             "io.netplan.Netplan",
             "/io/netplan/Netplan",
             "io.netplan.Netplan",
-            "TryCommit",
+            "Confirm",
         ]
         BUSCTL_NETPLAN_TRY = [
             "busctl", "call", "--system",
@@ -241,43 +241,20 @@ class TestNetplanDBus(unittest.TestCase):
             "/io/netplan/Netplan",
             "io.netplan.Netplan",
             "Try",
-            "a{ss}", "0",
-        ]
-        BUSCTL_NETPLAN_TRY1 = [
-            "busctl", "call", "--system",
-            "io.netplan.Netplan",
-            "/io/netplan/Netplan",
-            "io.netplan.Netplan",
-            "Try",
-            "a{ss}", "1", "timeout", "10",
-        ]
-        BUSCTL_NETPLAN_TRY2 = [
-            "busctl", "call", "--system",
-            "io.netplan.Netplan",
-            "/io/netplan/Netplan",
-            "io.netplan.Netplan",
-            "Try",
-            "a{ss}", "2", "config-file", "./config.yaml", "timeout", "10",
+            "u", "1",
         ]
 
-        # TODO: verify TryCommit returns "true" after a dbus call to "netplan try"
         output = subprocess.check_output(BUSCTL_NETPLAN_TRY_COMMIT)
         self.assertEqual("b false\n", output.decode("utf-8"))
 
         output = subprocess.check_output(BUSCTL_NETPLAN_TRY)
         self.assertEqual("b true\n", output.decode("utf-8"))
 
-        output = subprocess.check_output(BUSCTL_NETPLAN_TRY1)
-        self.assertEqual("b true\n", output.decode("utf-8"))
-
-        output = subprocess.check_output(BUSCTL_NETPLAN_TRY2)
-        self.assertEqual("b true\n", output.decode("utf-8"))
+        # TODO: verify Confirm/Apply returns "true" after a dbus call to "netplan try"
 
         # FIXME: verify call stack
         # self.assertEquals(self.mock_netplan_cmd.calls(), [
-        #         ["netplan", "try"],
-        #         ["netplan", "try", "--timeout", "10"],
-        #         ["netplan", "try", "--config-file", "./config.yaml", "--timeout", "10"],
+        #         ["netplan", "try", "--timeout", "1"],
         # ])
 
     def test_netplan_dbus_no_such_command(self):

--- a/tests/dbus/test_dbus.py
+++ b/tests/dbus/test_dbus.py
@@ -228,34 +228,41 @@ class TestNetplanDBus(unittest.TestCase):
         ])
 
     def test_netplan_dbus_try(self):
-        BUSCTL_NETPLAN_TRY_COMMIT = [
-            "busctl", "call", "--system",
-            "io.netplan.Netplan",
-            "/io/netplan/Netplan",
-            "io.netplan.Netplan",
-            "Confirm",
-        ]
         BUSCTL_NETPLAN_TRY = [
             "busctl", "call", "--system",
             "io.netplan.Netplan",
             "/io/netplan/Netplan",
             "io.netplan.Netplan",
-            "Try",
-            "u", "1",
+            "Try", "u", "5",
+        ]
+        BUSCTL_NETPLAN_CANCEL = [
+            "busctl", "call", "--system",
+            "io.netplan.Netplan",
+            "/io/netplan/Netplan",
+            "io.netplan.Netplan",
+            "Cancel",
+        ]
+        BUSCTL_NETPLAN_APPLY = [
+            "busctl", "call", "--system",
+            "io.netplan.Netplan",
+            "/io/netplan/Netplan",
+            "io.netplan.Netplan",
+            "Apply",
         ]
 
-        output = subprocess.check_output(BUSCTL_NETPLAN_TRY_COMMIT)
+        output = subprocess.check_output(BUSCTL_NETPLAN_CANCEL)
         self.assertEqual("b false\n", output.decode("utf-8"))
 
         output = subprocess.check_output(BUSCTL_NETPLAN_TRY)
         self.assertEqual("b true\n", output.decode("utf-8"))
 
-        # TODO: verify Confirm/Apply returns "true" after a dbus call to "netplan try"
+        output = subprocess.check_output(BUSCTL_NETPLAN_APPLY)
+        self.assertEqual("b true\n", output.decode("utf-8"))
 
-        # FIXME: verify call stack
-        # self.assertEquals(self.mock_netplan_cmd.calls(), [
-        #         ["netplan", "try", "--timeout", "1"],
-        # ])
+        self.assertEquals(self.mock_netplan_cmd.calls(), [
+                ["netplan", "try", "--timeout=5"],
+                ["netplan", "apply"],
+        ])
 
     def test_netplan_dbus_no_such_command(self):
         p = subprocess.Popen(

--- a/tests/dbus/test_dbus.py
+++ b/tests/dbus/test_dbus.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2019 Canonical, Ltd.
+# Copyright (C) 2019-2020 Canonical, Ltd.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -225,6 +225,21 @@ class TestNetplanDBus(unittest.TestCase):
         self.assertEquals(self.mock_netplan_cmd.calls(), [
                 ["netplan", "set", "ethernets.eth0={addresses: [5.6.7.8/24], dhcp4: false}",
                  "--origin-hint=99_snapd"],
+        ])
+
+    def test_netplan_dbus_try(self):
+        BUSCTL_NETPLAN_TRY = [
+            "busctl", "call", "--system",
+            "io.netplan.Netplan",
+            "/io/netplan/Netplan",
+            "io.netplan.Netplan",
+            "Try",
+            "a{ss}", "1", "timeout", "1",
+        ]
+        output = subprocess.check_output(BUSCTL_NETPLAN_TRY)
+        self.assertEqual("b true\n", output.decode("utf-8"))
+        self.assertEquals(self.mock_netplan_cmd.calls(), [
+                ["netplan", "try"],
         ])
 
     def test_netplan_dbus_no_such_command(self):

--- a/tests/dbus/test_dbus.py
+++ b/tests/dbus/test_dbus.py
@@ -228,19 +228,57 @@ class TestNetplanDBus(unittest.TestCase):
         ])
 
     def test_netplan_dbus_try(self):
+        BUSCTL_NETPLAN_TRY_COMMIT = [
+            "busctl", "call", "--system",
+            "io.netplan.Netplan",
+            "/io/netplan/Netplan",
+            "io.netplan.Netplan",
+            "TryCommit",
+        ]
         BUSCTL_NETPLAN_TRY = [
             "busctl", "call", "--system",
             "io.netplan.Netplan",
             "/io/netplan/Netplan",
             "io.netplan.Netplan",
             "Try",
-            "a{ss}", "1", "timeout", "1",
+            "a{ss}", "0",
         ]
+        BUSCTL_NETPLAN_TRY1 = [
+            "busctl", "call", "--system",
+            "io.netplan.Netplan",
+            "/io/netplan/Netplan",
+            "io.netplan.Netplan",
+            "Try",
+            "a{ss}", "1", "timeout", "10",
+        ]
+        BUSCTL_NETPLAN_TRY2 = [
+            "busctl", "call", "--system",
+            "io.netplan.Netplan",
+            "/io/netplan/Netplan",
+            "io.netplan.Netplan",
+            "Try",
+            "a{ss}", "2", "config-file", "./config.yaml", "timeout", "10",
+        ]
+
+        # TODO: verify TryCommit returns "true" after a dbus call to "netplan try"
+        output = subprocess.check_output(BUSCTL_NETPLAN_TRY_COMMIT)
+        self.assertEqual("b false\n", output.decode("utf-8"))
+
         output = subprocess.check_output(BUSCTL_NETPLAN_TRY)
         self.assertEqual("b true\n", output.decode("utf-8"))
-        self.assertEquals(self.mock_netplan_cmd.calls(), [
-                ["netplan", "try"],
-        ])
+
+        output = subprocess.check_output(BUSCTL_NETPLAN_TRY1)
+        self.assertEqual("b true\n", output.decode("utf-8"))
+
+        output = subprocess.check_output(BUSCTL_NETPLAN_TRY2)
+        self.assertEqual("b true\n", output.decode("utf-8"))
+
+        # FIXME: verify call stack
+        #self.assertEquals(self.mock_netplan_cmd.calls(), [
+        #        ["netplan", "try"],
+        #        ["netplan", "try", "--timeout", "10"],
+        #        ["netplan", "try", "--config-file", "./config.yaml", "--timeout", "10"],
+        #])
 
     def test_netplan_dbus_no_such_command(self):
         p = subprocess.Popen(

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -25,6 +25,7 @@ import unittest
 import netplan.terminal
 
 
+@unittest.skipUnless(sys.__stdin__.isatty(), "not supported when run from a script")
 class TestTerminal(unittest.TestCase):
 
     def setUp(self):

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -25,7 +25,6 @@ import unittest
 import netplan.terminal
 
 
-@unittest.skipUnless(sys.__stdin__.isatty(), "not supported when run from a script")
 class TestTerminal(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
## Description
Implement the `Try(uint32 timeoutInSeconds)` and `Cancel()` command inside `netplan-dbus` and adopt the `Apply()` command according to spec. "Try(...)" calls `netplan try`, keeping `stdin` open. The "Apply()" command uses the `SIGUSR1` signal, to send a confirmation to the `netplan try` process to confirm/commit the settings. The "Cancel()" command uses the `SIGINT` signal, to send a rejection to the `netplan try` child process.
The child process is being monitored, using events on the sd-event mainloop.

Codecov reports a reduced coverage, but that is only because the code in `terminal.py` cannot be tested from a script, as it uses the `isatty()` condition. And that part is excluded/skipped from our test-suite if run inside a script. If `make check-coverage` is executed locally, it retains 100% coverage.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Closes an open bug in Launchpad.

