### PR TITLE
Call daemon-reload after we touched systemd unit files (LP: #1874494)

### DIFF
--- a/netplan/cli/commands/apply.py
+++ b/netplan/cli/commands/apply.py
@@ -175,6 +175,10 @@ class NetplanApply(utils.NetplanCommand):
 
         # (re)start backends
         if restart_networkd:
+            # Running 'systemctl daemon-reload' will re-run the netplan systemd generator,
+            # so let's make sure we only run it iff we're willing to run 'netplan generate'
+            if run_generate:
+                utils.systemctl_daemon_reload()
             netplan_wpa = [os.path.basename(f) for f in glob.glob('/run/systemd/system/*.wants/netplan-wpa-*.service')]
             utils.systemctl_networkd('start', sync=sync, extra_services=netplan_wpa)
         if restart_nm:

--- a/netplan/cli/commands/apply.py
+++ b/netplan/cli/commands/apply.py
@@ -108,6 +108,10 @@ class NetplanApply(utils.NetplanCommand):
         # stop backends
         if restart_networkd:
             logging.debug('netplan generated networkd configuration changed, restarting networkd')
+            # Running 'systemctl daemon-reload' will re-run the netplan systemd generator,
+            # so let's make sure we only run it iff we're willing to run 'netplan generate'
+            if run_generate:
+                utils.systemctl_daemon_reload()
             wpa_services = ['netplan-wpa-*.service']
             # Historically (up to v0.98) we had netplan-wpa@*.service files, in case of an
             # upgraded system, we need to make sure to stop those.
@@ -175,10 +179,6 @@ class NetplanApply(utils.NetplanCommand):
 
         # (re)start backends
         if restart_networkd:
-            # Running 'systemctl daemon-reload' will re-run the netplan systemd generator,
-            # so let's make sure we only run it iff we're willing to run 'netplan generate'
-            if run_generate:
-                utils.systemctl_daemon_reload()
             netplan_wpa = [os.path.basename(f) for f in glob.glob('/run/systemd/system/*.wants/netplan-wpa-*.service')]
             utils.systemctl_networkd('start', sync=sync, extra_services=netplan_wpa)
         if restart_nm:

--- a/netplan/cli/utils.py
+++ b/netplan/cli/utils.py
@@ -93,6 +93,11 @@ def systemctl_is_active(unit_pattern):  # pragma: nocover (covered in autopkgtes
     return False
 
 
+def systemctl_daemon_reload():  # pragma: nocover (covered in autopkgtest)
+    '''Reload systemd unit files from disk and re-calculate its dependencies'''
+    subprocess.check_call(['systemctl', 'daemon-reload'])
+
+
 def get_interface_driver_name(interface, only_down=False):  # pragma: nocover (covered in autopkgtest)
     devdir = os.path.join('/sys/class/net', interface)
     if only_down:

--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -352,7 +352,9 @@ class IntegrationTestsBase(unittest.TestCase):
         '''Generate config, launch and settle NM and networkd'''
 
         # regenerate netplan config
-        subprocess.check_call(['netplan', 'apply'])
+        out = subprocess.check_output(['netplan', 'apply'], universal_newlines=True)
+        if 'Run \'systemctl daemon-reload\' to reload units.' in out:
+            self.fail('systemd units changed without reload')
         # start NM so that we can verify that it does not manage anything
         subprocess.check_call(['systemctl', 'start', '--no-block', 'NetworkManager.service'])
         # wait until networkd is done


### PR DESCRIPTION
##  Description
When running `netplan apply` systemd unit files might be created/deleted/changed on disk. We need to run `systemctl daemon-reload`, to make systemd aware of those new units and calculate the new unit/service dependencies. Otherwise it will throw warnings at us:
```
ubuntu@ubuntu:~$ sudo netplan apply
Warning: The unit file, source configuration file or drop-ins of netplan-wpa-wlan0.service changed on disk. Run 'systemctl daemon-reload' to reload units.
Warning: The unit file, source configuration file or drop-ins of netplan-wpa-wlan0.service changed on disk. Run 'systemctl daemon-reload' to reload units.
```

Fixes: https://bugs.launchpad.net/ubuntu/+source/netplan.io/+bug/1874494

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [x] \(Optional\) Closes an open bug in Launchpad.

