### PR TITLE
Don't fail if same primary slave was set before (LP: #1817651)

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -1483,7 +1483,10 @@ handle_bond_primary_slave(yaml_document_t* doc, yaml_node_t* node, const void* d
     if (!component) {
         add_missing_node(node);
     } else {
-        if (cur_netdef->bond_params.primary_slave)
+        /* If this is not the primary pass, the primary slave might already be equally set. */
+        if (!g_strcmp0(cur_netdef->bond_params.primary_slave, scalar(node))) {
+            return TRUE;
+        } else if (cur_netdef->bond_params.primary_slave)
             return yaml_error(node, error, "%s: bond already has a primary slave: %s",
                               cur_netdef->id, cur_netdef->bond_params.primary_slave);
 


### PR DESCRIPTION
## Description
The netplan parser might run multiple passes, if unknown interfaces/netdefs are detected during a prior pass. In that case it would fail to set a bond's primary slave, because it was set before (to the same interface).

Fixes: https://bugs.launchpad.net/ubuntu/+source/netplan.io/+bug/1817651

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [x] \(Optional\) Closes an open bug in Launchpad.

