### PR TITLE
[WIP] Initial first-try framework for OpenVSwitch schema

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ libnetplan.so.$(NETPLAN_SOVER): parse.o util.o validation.o error.o
 	ln -snf libnetplan.so.$(NETPLAN_SOVER) libnetplan.so
 
 #generate: src/generate.[hc] src/parse.[hc] src/util.[hc] src/networkd.[hc] src/nm.[hc] src/validation.[hc] src/error.[hc]
-generate: libnetplan.so.$(NETPLAN_SOVER) nm.o networkd.o generate.o
+generate: libnetplan.so.$(NETPLAN_SOVER) nm.o networkd.o openvswitch.o generate.o
 	$(CC) $(BUILDFLAGS) $(CFLAGS) $(LDFLAGS) -o $@ $^ -L. -lnetplan `pkg-config --cflags --libs glib-2.0 gio-2.0 yaml-0.1 uuid`
 
 netplan-dbus: src/dbus.c src/_features.h

--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -137,6 +137,17 @@ Virtual devices
 
 :    (networkd backend only) Whether to emit LLDP packets. Off by default.
 
+``openvswitch`` (mapping)
+
+:    TODO: This is just a stub - we'll update it once we have more OVS structure
+     defined.
+
+     ``external-ids`` (mapping)
+     :   Passed-through directly to OpenVSwitch
+
+     ``other-config`` (mapping)
+     :   Passed-through directly to OpenVSwitch
+
 
 ## Common properties for all device types
 

--- a/src/generate.c
+++ b/src/generate.c
@@ -30,6 +30,7 @@
 #include "parse.h"
 #include "networkd.h"
 #include "nm.h"
+#include "openvswitch.h"
 
 static gchar* rootdir;
 static gchar** files;
@@ -55,7 +56,9 @@ nd_iterator_list(gpointer value, gpointer user_data)
 {
     if (write_networkd_conf((NetplanNetDefinition*) value, (const char*) user_data))
         any_networkd = TRUE;
+
     write_nm_conf((NetplanNetDefinition*) value, (const char*) user_data);
+    write_ovs_conf((NetplanNetDefinition*) value, (const char*) user_data);
 }
 
 
@@ -246,6 +249,7 @@ int main(int argc, char** argv)
     /* Clean up generated config from previous runs */
     cleanup_networkd_conf(rootdir);
     cleanup_nm_conf(rootdir);
+    cleanup_ovs_conf(rootdir);
 
     if (mapping_iface && netdefs) {
         return find_interface(mapping_iface);
@@ -256,6 +260,7 @@ int main(int argc, char** argv)
         g_debug("Generating output files..");
         g_list_foreach (netdefs_ordered, nd_iterator_list, rootdir);
         write_nm_conf_finish(rootdir);
+        write_ovs_conf_finish(rootdir);
         /* We may have written .rules & .link files, thus we must
          * invalidate udevd cache of its config as by default it only
          * invalidates cache at most every 3 seconds. Not sure if this

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -812,19 +812,8 @@ write_wpa_unit(const NetplanNetDefinition* def, const char* rootdir)
 {
     g_autoptr(GError) err = NULL;
     g_autofree gchar *stdouth = NULL;
-    g_autofree gchar *stderrh = NULL;
-    gint exit_status = 0;
 
-    gchar *argv[] = {"bin" "/" "systemd-escape", def->id, NULL};
-    g_spawn_sync("/", argv, NULL, 0, NULL, NULL, &stdouth, &stderrh, &exit_status, &err);
-    g_spawn_check_exit_status(exit_status, &err);
-    if (err != NULL) {
-        // LCOV_EXCL_START
-        g_fprintf(stderr, "failed to ask systemd to escape %s; exit %d\nstdout: '%s'\nstderr: '%s'", def->id, exit_status, stdouth, stderrh);
-        exit(1);
-        // LCOV_EXCL_STOP
-    }
-    g_strstrip(stdouth);
+    stdouth = systemd_escape(def->id);
 
     GString* s = g_string_new("[Unit]\n");
     g_autofree char* path = g_strjoin(NULL, "/run/systemd/system/netplan-wpa-", stdouth, ".service", NULL);

--- a/src/openvswitch.c
+++ b/src/openvswitch.c
@@ -1,0 +1,146 @@
+/*
+ * Copyright (C) 2020 Canonical, Ltd.
+ * Author: Łukasz 'sil2100' Zemczak <lukasz.zemczak@ubuntu.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <unistd.h>
+#include <errno.h>
+
+#include <glib.h>
+#include <glib/gprintf.h>
+
+#include "openvswitch.h"
+#include "parse.h"
+#include "util.h"
+
+static void
+write_ovs_systemd_unit(const char* id, const GString* cmds, const char* rootdir)
+{
+    g_autofree char* link = g_strjoin(NULL, rootdir ?: "", "/run/systemd/system/systemd-networkd.service.wants/netplan-ovs-", id, ".service", NULL);
+    g_autofree char* slink = g_strjoin(NULL, "/run/systemd/system/netplan-ovs-", id, ".service", NULL);
+    g_autofree char* path = g_strjoin(NULL, "/run/systemd/system/netplan-ovs-", id, ".service", NULL);
+
+    GString* s = g_string_new("[Unit]\n");
+    g_string_append_printf(s, "Description=OpenVSwitch configuration for %s\n", id);
+    g_string_append(s, "DefaultDependencies=no\n");
+    g_string_append_printf(s, "Requires=sys-subsystem-net-devices-%s.device\n", id);
+    g_string_append_printf(s, "After=sys-subsystem-net-devices-%s.device\n", id);
+    g_string_append(s, "Before=network.target\nWants=network.target\n\n");
+
+    g_string_append(s, "[Service]\nType=oneshot\n");
+    g_string_append(s, cmds->str);
+
+    g_string_free_to_file(s, rootdir, path, NULL);
+
+    safe_mkdir_p_dir(link);
+    if (symlink(slink, link) < 0 && errno != EEXIST) {
+        // LCOV_EXCL_START
+        g_fprintf(stderr, "failed to create enablement symlink: %m\n");
+        exit(1);
+        // LCOV_EXCL_STOP
+    }
+}
+
+#define OPENVSWITCH_OVS_VSCTL "/usr/bin/ovs-vsctl"
+#define append_systemd_cmd(s, command, ...) \
+{ \
+    g_string_append(s, "ExecStart="); \
+    g_string_append_printf(s, command, __VA_ARGS__); \
+    g_string_append(s, "\n"); \
+}
+
+static char*
+netplan_type_to_table_name(const NetplanDefType type)
+{
+    switch (type) {
+        case NETPLAN_DEF_TYPE_BRIDGE:
+            return "Bridge";
+        default:
+            return "Interface";
+    }
+}
+
+static void
+write_ovs_additional_data(GHashTable *data, const NetplanDefType type, const gchar* id_escaped, GString* cmds, const char* setting)
+{
+    GHashTableIter iter;
+    gchar* key;
+    gchar* value;
+
+    g_hash_table_iter_init(&iter, data);
+    while (g_hash_table_iter_next(&iter, (gpointer) &key, (gpointer) &value)) {
+        append_systemd_cmd(cmds, OPENVSWITCH_OVS_VSCTL " set %s %s %s:%s=%s",
+                           netplan_type_to_table_name(type), id_escaped, setting, key, value);
+    }
+}
+
+/**
+ * Generate the OpenVSwitch systemd units for configuration of the selected netdef
+ * @rootdir: If not %NULL, generate configuration in this root directory
+ *           (useful for testing).
+ */
+void
+write_ovs_conf(const NetplanNetDefinition* def, const char* rootdir)
+{
+    GString* cmds = g_string_new(NULL);
+    g_autofree gchar* id_escaped = NULL; // TODO: Check if this works
+
+    id_escaped = systemd_escape(def->id);
+
+    /* TODO: error out on non-existing ovs-vsctl tool */
+    /* TODO: maybe dynamically query the ovs-vsctl tool path? */
+
+    /* Common OVS settings can be specified even for non-OVS interfaces */
+    if (def->ovs_settings.external_ids && g_hash_table_size(def->ovs_settings.external_ids) > 0) {
+        write_ovs_additional_data(def->ovs_settings.external_ids, def->type,
+                                          id_escaped, cmds, "external-ids");
+    }
+
+    if (def->ovs_settings.other_config && g_hash_table_size(def->ovs_settings.other_config) > 0) {
+        write_ovs_additional_data(def->ovs_settings.other_config, def->type,
+                                          id_escaped, cmds, "other-config");
+    }
+
+    /* For other, more OVS specific settings, we expect the backend to be set to OVS */
+    if (def->backend == NETPLAN_BACKEND_OVS) {
+        /* TODO */
+    } else {
+        g_debug("openvswitch: definition %s is not for us (backend %i)", def->id, def->backend);
+    }
+
+    /* If we need to configure anything for this netdef, write the required systemd unit */
+    if (cmds->len > 0)
+        write_ovs_systemd_unit(id_escaped, cmds, rootdir);
+    g_string_free(cmds, TRUE);
+}
+
+/**
+ * Finalize the OpenVSwitch configuration (global config)
+ */
+void
+write_ovs_conf_finish(const char* rootdir)
+{
+    /* TODO: Write the global config here */
+}
+
+/**
+ * Clean up all generated configurations in @rootdir from previous runs.
+ */
+void
+cleanup_ovs_conf(const char* rootdir)
+{
+    //unlink_glob(rootdir, "/run/systemd/system/systemd-networkd.service.wants/netplan-ovs-*.service");
+    //unlink_glob(rootdir, "/run/systemd/system/netplan-ovs-*.service");
+}

--- a/src/openvswitch.h
+++ b/src/openvswitch.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2016 Canonical, Ltd.
- * Author: Martin Pitt <martin.pitt@ubuntu.com>
+ * Copyright (C) 2020 Canonical, Ltd.
+ * Author: Łukasz 'sil2100' Zemczak <lukasz.zemczak@ubuntu.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,14 +17,8 @@
 
 #pragma once
 
-GHashTable* wifi_frequency_24;
-GHashTable* wifi_frequency_5;
+#include "parse.h"
 
-void safe_mkdir_p_dir(const char* file_path);
-void g_string_free_to_file(GString* s, const char* rootdir, const char* path, const char* suffix);
-void unlink_glob(const char* rootdir, const char* _glob);
-
-int wifi_get_freq24(int channel);
-int wifi_get_freq5(int channel);
-
-gchar* systemd_escape(char* string);
+void write_ovs_conf(const NetplanNetDefinition* def, const char* rootdir);
+void write_ovs_conf_finish(const char* rootdir);
+void cleanup_ovs_conf(const char* rootdir);

--- a/src/parse.c
+++ b/src/parse.c
@@ -350,15 +350,13 @@ handle_generic_bool(yaml_document_t* doc, yaml_node_t* node, void* entryptr, con
 }
 
 /*
- * Handler for TODO
+ * Handler for setting a HashTable field from a mapping node, inside a given struct
  * @entryptr: pointer to the beginning of the to-be-modified data structure
  * @data: offset into entryptr struct where the boolean field to write is located
 */
 static gboolean
 handle_generic_map(yaml_document_t* doc, yaml_node_t* node, void* entryptr, const void* data, GError** error)
 {
-    g_assert(cur_netdef);
-
     guint offset = GPOINTER_TO_UINT(data);
     GHashTable** map = (GHashTable**) ((void*) entryptr + offset);
     if (!*map)
@@ -375,7 +373,7 @@ handle_generic_map(yaml_document_t* doc, yaml_node_t* node, void* entryptr, cons
 
         /* TODO: make sure we free all the memory here */
         if (!g_hash_table_insert(*map, g_strdup(scalar(key)), g_strdup(scalar(value))))
-            return yaml_error(key, error, "%s: Duplicate map entry '%s'", cur_netdef->id, scalar(key));
+            return yaml_error(node, error, "duplicate map entry '%s'", scalar(key));
     }
 
     return TRUE;
@@ -535,6 +533,7 @@ handle_netdef_addrgen(yaml_document_t* doc, yaml_node_t* node, const void* _, GE
 static gboolean
 handle_netdef_map(yaml_document_t* doc, yaml_node_t* node, const void* data, GError** error)
 {
+    g_assert(cur_netdef);
     return handle_generic_map(doc, node, cur_netdef, data, error);
 }
 
@@ -1866,7 +1865,7 @@ handle_network_renderer(yaml_document_t* doc, yaml_node_t* node, const void* _, 
 }
 
 static gboolean
-handle_network_ovs_settings(yaml_document_t* doc, yaml_node_t* node, const void* data, GError** error)
+handle_network_ovs_settings_global(yaml_document_t* doc, yaml_node_t* node, const void* data, GError** error)
 {
     return handle_generic_map(doc, node, &ovs_settings_global, data, error);
 }
@@ -1981,8 +1980,8 @@ handle_network_type(yaml_document_t* doc, yaml_node_t* node, const void* data, G
 }
 
 static const mapping_entry_handler ovs_network_settings_handlers[] = {
-    {"external-ids", YAML_MAPPING_NODE, handle_network_ovs_settings, NULL, ovs_settings_offset(external_ids)},
-    {"other-config", YAML_MAPPING_NODE, handle_network_ovs_settings, NULL, ovs_settings_offset(other_config)},
+    {"external-ids", YAML_MAPPING_NODE, handle_network_ovs_settings_global, NULL, ovs_settings_offset(external_ids)},
+    {"other-config", YAML_MAPPING_NODE, handle_network_ovs_settings_global, NULL, ovs_settings_offset(other_config)},
     {NULL}
 };
 

--- a/src/parse.c
+++ b/src/parse.c
@@ -36,6 +36,7 @@
 #define ip_rule_offset(field) GUINT_TO_POINTER(offsetof(NetplanIPRule, field))
 #define auth_offset(field) GUINT_TO_POINTER(offsetof(NetplanAuthenticationSettings, field))
 #define access_point_offset(field) GUINT_TO_POINTER(offsetof(NetplanWifiAccessPoint, field))
+#define ovs_settings_offset(field) GUINT_TO_POINTER(offsetof(NetplanOVSSettings, field))
 
 /* NetplanNetDefinition that is currently being processed */
 static NetplanNetDefinition* cur_netdef;
@@ -50,6 +51,9 @@ static NetplanIPRoute* cur_route;
 static NetplanIPRule* cur_ip_rule;
 
 static NetplanBackend backend_global, backend_cur_type;
+
+/* global OpenVSwitch settings */
+NetplanOVSSettings ovs_settings_global;
 
 /* Global ID → NetplanNetDefinition* map for all parsed config files */
 GHashTable* netdefs;
@@ -345,6 +349,39 @@ handle_generic_bool(yaml_document_t* doc, yaml_node_t* node, void* entryptr, con
     return TRUE;
 }
 
+/*
+ * Handler for TODO
+ * @entryptr: pointer to the beginning of the to-be-modified data structure
+ * @data: offset into entryptr struct where the boolean field to write is located
+*/
+static gboolean
+handle_generic_map(yaml_document_t* doc, yaml_node_t* node, void* entryptr, const void* data, GError** error)
+{
+    g_assert(cur_netdef);
+
+    guint offset = GPOINTER_TO_UINT(data);
+    GHashTable** map = (GHashTable**) ((void*) entryptr + offset);
+    if (!*map)
+        *map = g_hash_table_new(g_str_hash, g_str_equal);
+
+    for (yaml_node_pair_t* entry = node->data.mapping.pairs.start; entry < node->data.mapping.pairs.top; entry++) {
+        yaml_node_t* key, *value;
+
+        key = yaml_document_get_node(doc, entry->key);
+        value = yaml_document_get_node(doc, entry->value);
+
+        assert_type(key, YAML_SCALAR_NODE);
+        assert_type(value, YAML_SCALAR_NODE);
+
+        /* TODO: make sure we free all the memory here */
+        if (!g_hash_table_insert(*map, g_strdup(scalar(key)), g_strdup(scalar(value))))
+            return yaml_error(key, error, "%s: Duplicate map entry '%s'", cur_netdef->id, scalar(key));
+    }
+
+    return TRUE;
+}
+
+
 /**
  * Generic handler for setting a cur_netdef string field from a scalar node
  * @data: offset into NetplanNetDefinition where the const char* field to write is
@@ -493,6 +530,12 @@ handle_netdef_addrgen(yaml_document_t* doc, yaml_node_t* node, const void* _, GE
     else
         return yaml_error(node, error, "unknown ipv6-address-generation '%s'", scalar(node));
     return TRUE;
+}
+
+static gboolean
+handle_netdef_map(yaml_document_t* doc, yaml_node_t* node, const void* data, GError** error)
+{
+    return handle_generic_map(doc, node, cur_netdef, data, error);
 }
 
 
@@ -1657,6 +1700,12 @@ static const mapping_entry_handler nm_backend_settings_handlers[] = {
     {NULL}
 };
 
+static const mapping_entry_handler ovs_backend_settings_handlers[] = {
+    {"external-ids", YAML_MAPPING_NODE, handle_netdef_map, NULL, netdef_offset(ovs_settings.external_ids)},
+    {"other-config", YAML_MAPPING_NODE, handle_netdef_map, NULL, netdef_offset(ovs_settings.other_config)},
+    {NULL}
+};
+
 static const mapping_entry_handler nameservers_handlers[] = {
     {"search", YAML_SEQUENCE_NODE, handle_nameservers_search},
     {"addresses", YAML_SEQUENCE_NODE, handle_nameservers_addresses},
@@ -1710,8 +1759,9 @@ static const mapping_entry_handler dhcp6_overrides_handlers[] = {
     {"routes", YAML_SEQUENCE_NODE, handle_routes},                                            \
     {"routing-policy", YAML_SEQUENCE_NODE, handle_ip_rules}
 
-#define COMMON_BACKEND_HANDLERS							\
-    {"networkmanager", YAML_MAPPING_NODE, NULL, nm_backend_settings_handlers}
+#define COMMON_BACKEND_HANDLERS                                                \
+    {"networkmanager", YAML_MAPPING_NODE, NULL, nm_backend_settings_handlers}, \
+    {"openvswitch", YAML_MAPPING_NODE, NULL, ovs_backend_settings_handlers}
 
 /* Handlers for physical links */
 #define PHYSICAL_LINK_HANDLERS                                                           \
@@ -1813,6 +1863,12 @@ static gboolean
 handle_network_renderer(yaml_document_t* doc, yaml_node_t* node, const void* _, GError** error)
 {
     return parse_renderer(node, &backend_global, error);
+}
+
+static gboolean
+handle_network_ovs_settings(yaml_document_t* doc, yaml_node_t* node, const void* data, GError** error)
+{
+    return handle_generic_map(doc, node, &ovs_settings_global, data, error);
 }
 
 static void
@@ -1924,6 +1980,12 @@ handle_network_type(yaml_document_t* doc, yaml_node_t* node, const void* data, G
     return TRUE;
 }
 
+static const mapping_entry_handler ovs_network_settings_handlers[] = {
+    {"external-ids", YAML_MAPPING_NODE, handle_network_ovs_settings, NULL, ovs_settings_offset(external_ids)},
+    {"other-config", YAML_MAPPING_NODE, handle_network_ovs_settings, NULL, ovs_settings_offset(other_config)},
+    {NULL}
+};
+
 static const mapping_entry_handler network_handlers[] = {
     {"bonds", YAML_MAPPING_NODE, handle_network_type, NULL, GUINT_TO_POINTER(NETPLAN_DEF_TYPE_BOND)},
     {"bridges", YAML_MAPPING_NODE, handle_network_type, NULL, GUINT_TO_POINTER(NETPLAN_DEF_TYPE_BRIDGE)},
@@ -1934,6 +1996,7 @@ static const mapping_entry_handler network_handlers[] = {
     {"vlans", YAML_MAPPING_NODE, handle_network_type, NULL, GUINT_TO_POINTER(NETPLAN_DEF_TYPE_VLAN)},
     {"wifis", YAML_MAPPING_NODE, handle_network_type, NULL, GUINT_TO_POINTER(NETPLAN_DEF_TYPE_WIFI)},
     {"modems", YAML_MAPPING_NODE, handle_network_type, NULL, GUINT_TO_POINTER(NETPLAN_DEF_TYPE_MODEM)},
+    {"openvswitch", YAML_MAPPING_NODE, NULL, ovs_network_settings_handlers},
     {NULL}
 };
 

--- a/src/parse.h
+++ b/src/parse.h
@@ -56,6 +56,7 @@ typedef enum {
     NETPLAN_BACKEND_NONE,
     NETPLAN_BACKEND_NETWORKD,
     NETPLAN_BACKEND_NM,
+    NETPLAN_BACKEND_OVS,
     NETPLAN_BACKEND_MAX_,
 } NetplanBackend;
 
@@ -63,6 +64,7 @@ static const char* const netplan_backend_to_name[NETPLAN_BACKEND_MAX_] = {
         [NETPLAN_BACKEND_NONE] = "none",
         [NETPLAN_BACKEND_NETWORKD] = "networkd",
         [NETPLAN_BACKEND_NM] = "NetworkManager",
+        [NETPLAN_BACKEND_OVS] = "OpenVSwitch",
 };
 
 typedef enum {
@@ -195,6 +197,11 @@ typedef struct dhcp_overrides {
     char* hostname;
     guint metric;
 } NetplanDHCPOverrides;
+
+typedef struct ovs_settings {
+    GHashTable* external_ids;
+    GHashTable* other_config;
+} NetplanOVSSettings;
 
 /**
  * Represent a configuration stanza
@@ -340,6 +347,10 @@ struct net_definition {
     gboolean sriov_vlan_filter;
     guint sriov_explicit_vf_count;
 
+    /* these properties are only valid for OpenVSwitch */
+    /* netplan-feature: openvswitch */
+    NetplanOVSSettings ovs_settings;
+
     union {
         struct NetplanNMSettings {
             char *name;
@@ -418,6 +429,7 @@ typedef struct {
 /* Written/updated by parse_yaml(): char* id →  net_definition */
 extern GHashTable* netdefs;
 extern GList* netdefs_ordered;
+extern NetplanOVSSettings ovs_settings_global;
 
 /****************************************************
  * Functions

--- a/src/util.c
+++ b/src/util.c
@@ -148,3 +148,29 @@ wifi_get_freq5(int channel)
     return GPOINTER_TO_INT(g_hash_table_lookup(wifi_frequency_5,
                            GINT_TO_POINTER(channel)));
 }
+
+/**
+ * Systemd-escape the given string. The caller is responsible for freeing
+ * the allocated escaped string.
+ */
+gchar*
+systemd_escape(char* string)
+{
+    g_autoptr(GError) err = NULL;
+    g_autofree gchar* stderrh = NULL;
+    gint exit_status = 0;
+    gchar *escaped;
+
+    gchar *argv[] = {"bin" "/" "systemd-escape", string, NULL};
+    g_spawn_sync("/", argv, NULL, 0, NULL, NULL, &escaped, &stderrh, &exit_status, &err);
+    g_spawn_check_exit_status(exit_status, &err);
+    if (err != NULL) {
+        // LCOV_EXCL_START
+        g_fprintf(stderr, "failed to ask systemd to escape %s; exit %d\nstdout: '%s'\nstderr: '%s'", string, exit_status, escaped, stderrh);
+        exit(1);
+        // LCOV_EXCL_STOP
+    }
+    g_strstrip(escaped);
+
+    return escaped;
+}

--- a/tests/generator/base.py
+++ b/tests/generator/base.py
@@ -20,6 +20,7 @@
 
 import os
 import random
+import glob
 import stat
 import string
 import tempfile
@@ -175,7 +176,8 @@ class TestBase(unittest.TestCase):
     def assert_ovs(self, file_contents_map):
         systemd_dir = os.path.join(self.workdir.name, 'run', 'systemd', 'system')
         if not file_contents_map:
-            self.assertFalse(os.path.exists(systemd_dir))
+            # in this case we assume no OVS configuration should be present
+            self.assertFalse(glob.glob(os.path.join(systemd_dir, '*netplan-ovs-*.service')))
             return
 
         self.assertEqual(set(os.listdir(self.workdir.name)) - {'lib'}, {'etc', 'run'})

--- a/tests/generator/test_ovs.py
+++ b/tests/generator/test_ovs.py
@@ -1,0 +1,69 @@
+#
+# Common tests for netplan OpenVSwitch support
+#
+# Copyright (C) 2020 Canonical, Ltd.
+# Author: Łukasz 'sil2100' Zemczak <lukasz.zemczak@ubuntu.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from .base import TestBase, ND_DHCP4, ND_DHCP6
+
+
+class TestOpenVSwitch(TestBase):
+    '''OVS output'''
+
+    def test_interface_external_ids_other_config(self):
+        self.generate('''network:
+  version: 2
+  ethernets:
+    eth0:
+      openvswitch:
+        external-ids:
+          iface-id: myhostname
+        other-config:
+          disable-in-band: true
+      dhcp6: true
+    eth1:
+      dhcp4: true
+      openvswitch:
+        other-config:
+          disable-in-band: false
+          ''')
+        self.assert_ovs({'eth0.service': '''[Unit]
+Description=OpenVSwitch configuration for eth0
+DefaultDependencies=no
+Requires=sys-subsystem-net-devices-eth0.device
+After=sys-subsystem-net-devices-eth0.device
+Before=network.target
+Wants=network.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/ovs-vsctl set Interface eth0 external-ids:iface-id=myhostname
+ExecStart=/usr/bin/ovs-vsctl set Interface eth0 other-config:disable-in-band=true
+''',
+                         'eth1.service': '''[Unit]
+Description=OpenVSwitch configuration for eth1
+DefaultDependencies=no
+Requires=sys-subsystem-net-devices-eth1.device
+After=sys-subsystem-net-devices-eth1.device
+Before=network.target
+Wants=network.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/ovs-vsctl set Interface eth1 other-config:disable-in-band=false
+'''})
+        # Confirm that the networkd config is still sane
+        self.assert_networkd({'eth0.network': ND_DHCP6 % 'eth0',
+                              'eth1.network': ND_DHCP4 % 'eth1'})


### PR DESCRIPTION
This basically adds support for generating systemd unit files that would then later configure the OVS bits for devices that require it. The only schema piece supported right now is 'other-config' and 'external-ids', which were quite easy to do as they directly pass-through to OVS. Global setting not yet supported.

There is a basic OVS test to confirm that the parser and generator changes work.


## Description


## Checklist

- [ ] Runs `make check` successfully.
- [ ] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Closes an open bug in Launchpad.

