### PR TITLE
Add itegration tests for interface globbing and NM routing

### DIFF
--- a/tests/integration/ethernets.py
+++ b/tests/integration/ethernets.py
@@ -77,6 +77,9 @@ class _CommonTests():
                                'address', self.dev_e2_client_mac])
 
     def test_eth_glob(self):
+        '''Supposed to fail if tested against NetworkManager < 1.14
+
+        Interface globbing was introduced as of NM 1.14+'''
         self.setup_eth(None)
         self.start_dnsmasq(None, self.dev_e2_ap)
         with open(self.config, 'w') as f:

--- a/tests/integration/ethernets.py
+++ b/tests/integration/ethernets.py
@@ -89,6 +89,10 @@ class _CommonTests():
 ''' % {'r': self.backend}) # globbing match on "eth42", i.e. self.dev_e_client
         self.generate_and_settle()
         self.assert_iface_up(self.dev_e_client, ['inet 172.16.42.99/18', 'inet6 1234:ffff::42/64'])
+        out = subprocess.check_output(['ip', 'a', 'show', 'dev', self.dev_e_client],
+                                      universal_newlines=True)
+        self.assertIn('inet 172.16.42.99/18', out)
+        self.assertIn('inet6 1234:ffff::42/64', out)
 
     def test_manual_addresses(self):
         self.setup_eth(None)

--- a/tests/integration/ethernets.py
+++ b/tests/integration/ethernets.py
@@ -76,6 +76,20 @@ class _CommonTests():
         subprocess.check_call(['ip', 'link', 'set', self.dev_e2_client,
                                'address', self.dev_e2_client_mac])
 
+    def test_eth_glob(self):
+        self.setup_eth(None)
+        self.start_dnsmasq(None, self.dev_e2_ap)
+        with open(self.config, 'w') as f:
+            f.write('''network:
+  renderer: %(r)s
+  ethernets:
+    englob:
+      match: {name: "eth?2"}
+      addresses: ["172.16.42.99/18", "1234:FFFF::42/64"]
+''' % {'r': self.backend}) # globbing match on "eth42", i.e. self.dev_e_client
+        self.generate_and_settle()
+        self.assert_iface_up(self.dev_e_client, ['inet 172.16.42.99/18', 'inet6 1234:ffff::42/64'])
+
     def test_manual_addresses(self):
         self.setup_eth(None)
         with open(self.config, 'w') as f:

--- a/tests/integration/routing.py
+++ b/tests/integration/routing.py
@@ -38,18 +38,17 @@ class _CommonTests():
   ethernets:
     ethbn:
       match: {name: %(ec)s}
-      dhcp4: no
-      addresses: [ "10.20.10.1/24" ]
+      addresses: ["9876:BBBB::11/70"]
       routes:
-        - to: 20.0.0.0/24
-          via: 10.10.10.10
+        - to: 2001:f00f:f00f::1/64
+          via: 9876:BBBB::5
           on-link: true''' % {'r': self.backend, 'ec': self.dev_e_client})
         self.generate_and_settle()
         self.assert_iface_up(self.dev_e_client, ['inet 10.20.10.1'])
-        out = subprocess.check_output(['ip', 'route', 'show', 'dev', self.dev_e_client],
+        out = subprocess.check_output(['ip', '-6', 'route', 'show', 'dev', self.dev_e_client],
                                       universal_newlines=True)
         # NM routes have a (default) 'metric' in between 'proto static' and 'onlink'
-        self.assertRegex(out, r'20\.0\.0\.0/24 via 10\.10\.10\.10 proto static.* onlink')
+        self.assertRegex(out, r'2001:f00f:f00f::/64 via 9876:bbbb::5 proto static[^\n]* onlink')
 
     def test_route_from(self):
         self.setup_eth(None)
@@ -94,7 +93,7 @@ class _CommonTests():
         out = subprocess.check_output(['ip', 'route', 'show', 'table', table_id, 'dev',
                                       self.dev_e_client], universal_newlines=True)
         # NM routes have a (default) 'metric' in between 'proto static' and 'onlink'
-        self.assertRegex(out, r'10\.0\.0\.0/8 via 11\.0\.0\.1 proto static.* onlink')
+        self.assertRegex(out, r'10\.0\.0\.0/8 via 11\.0\.0\.1 proto static[^\n]* onlink')
 
     @unittest.skip("fails due to networkd bug setting routes with dhcp")
     def test_routes_v4_with_dhcp(self):

--- a/tests/integration/routing.py
+++ b/tests/integration/routing.py
@@ -30,6 +30,10 @@ from base import IntegrationTestsBase, test_backends
 class _CommonTests():
 
     def test_route_on_link(self):
+        '''Supposed to fail if tested against NetworkManager < 1.12/1.18
+
+        The on-link option was introduced as of NM 1.12+ (for IPv4)
+        The on-link option was introduced as of NM 1.18+ (for IPv6)'''
         self.setup_eth(None)
         self.start_dnsmasq(None, self.dev_e2_ap)
         with open(self.config, 'w') as f:
@@ -51,6 +55,9 @@ class _CommonTests():
         self.assertRegex(out, r'2001:f00f:f00f::/64 via 9876:bbbb::5 proto static[^\n]* onlink')
 
     def test_route_from(self):
+        '''Supposed to fail if tested against NetworkManager < 1.8
+
+        The from option was introduced as of NM 1.8+'''
         self.setup_eth(None)
         self.start_dnsmasq(None, self.dev_e2_ap)
         with open(self.config, 'w') as f:
@@ -71,6 +78,9 @@ class _CommonTests():
         self.assertIn('10.10.10.0/24 via 192.168.14.20 proto static src 192.168.14.2', out)
 
     def test_route_table(self):
+        '''Supposed to fail if tested against NetworkManager < 1.10
+
+        The table option was introduced as of NM 1.10+'''
         self.setup_eth(None)
         self.start_dnsmasq(None, self.dev_e2_ap)
         table_id = '255' # This is the 'local' FIB of /etc/iproute2/rt_tables

--- a/tests/integration/routing.py
+++ b/tests/integration/routing.py
@@ -29,6 +29,78 @@ from base import IntegrationTestsBase, test_backends
 
 class _CommonTests():
 
+    def test_route_on_link(self):
+        self.setup_eth(None)
+        self.start_dnsmasq(None, self.dev_e2_ap)
+        with open(self.config, 'w') as f:
+            f.write('''network:
+  renderer: %(r)s
+  ethernets:
+    ethbn:
+      match: {name: %(ec)s}
+      dhcp4: no
+      addresses: [ "10.20.10.1/24" ]
+      routes:
+        - to: 20.0.0.0/24
+          via: 10.10.10.10
+          on-link: true''' % {'r': self.backend, 'ec': self.dev_e_client})
+        self.generate_and_settle()
+        self.assert_iface_up(self.dev_e_client, ['inet 10.20.10.1'])
+        out = subprocess.check_output(['ip', 'route', 'show', 'dev', self.dev_e_client],
+                                      universal_newlines=True)
+        # NM routes have a (default) 'metric' in between 'proto static' and 'onlink'
+        self.assertRegex(out, r'20\.0\.0\.0/24 via 10\.10\.10\.10 proto static.* onlink')
+
+    def test_route_from(self):
+        self.setup_eth(None)
+        self.start_dnsmasq(None, self.dev_e2_ap)
+        with open(self.config, 'w') as f:
+            f.write('''network:
+  renderer: %(r)s
+  ethernets:
+    ethbn:
+      match: {name: %(ec)s}
+      addresses: ["192.168.14.2/24"]
+      routes:
+        - to: 10.10.10.0/24
+          via: 192.168.14.20
+          from: 192.168.14.2''' % {'r': self.backend, 'ec': self.dev_e_client})
+        self.generate_and_settle()
+        self.assert_iface_up(self.dev_e_client, ['inet 192.168.14.2'])
+        out = subprocess.check_output(['ip', 'route', 'show', 'dev', self.dev_e_client],
+                                      universal_newlines=True)
+        self.assertIn('10.10.10.0/24 via 192.168.14.20 proto static src 192.168.14.2', out)
+
+    def test_route_table(self):
+        self.setup_eth(None)
+        self.start_dnsmasq(None, self.dev_e2_ap)
+        table_id = '255' # This is the 'local' FIB of /etc/iproute2/rt_tables
+        with open(self.config, 'w') as f:
+            f.write('''network:
+  renderer: %(r)s
+  ethernets:
+    ethbn:
+      match: {name: %(ec)s}
+      dhcp4: no
+      addresses: [ "10.20.10.2/24" ]
+      gateway4: 10.20.10.1
+      routes:
+        - to: 0.0.0.0/0
+          via: 11.0.0.1
+          table: %(tid)s
+          on-link: true
+      routing-policy:
+        - to: 10.0.0.0/8
+          from: 10.20.10.2/24
+          table: %(tid)s''' % {'r': self.backend, 'ec': self.dev_e_client, 'tid': table_id})
+        self.generate_and_settle()
+        self.assert_iface_up(self.dev_e_client,
+                             ['inet '])
+        out = subprocess.check_output(['ip', 'route', 'show', 'table', table_id, 'dev',
+                                      self.dev_e_client], universal_newlines=True)
+        # NM routes have a (default) 'metric' in between 'proto static' and 'onlink'
+        self.assertRegex(out, r'(default|0\.0\.0\.0/24) via 11\.0\.0\.1 proto static.* onlink')
+
     @unittest.skip("fails due to networkd bug setting routes with dhcp")
     def test_routes_v4_with_dhcp(self):
         self.setup_eth(None)
@@ -151,27 +223,6 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
         self.assert_iface_up(self.dev_e_client,
                              ['inet '])
         self.assertIn(b'blackhole 10.10.10.0/24',
-                      subprocess.check_output(['ip', 'route', 'show', 'dev', self.dev_e_client]))
-
-    def test_route_on_link(self):
-        self.setup_eth(None)
-        self.start_dnsmasq(None, self.dev_e2_ap)
-        with open(self.config, 'w') as f:
-            f.write('''network:
-  renderer: %(r)s
-  ethernets:
-    ethbn:
-      match: {name: %(ec)s}
-      dhcp4: no
-      addresses: [ "10.20.10.1/24" ]
-      routes:
-        - to: 20.0.0.0/24
-          via: 10.10.10.10
-          on-link: true''' % {'r': self.backend, 'ec': self.dev_e_client})
-        self.generate_and_settle()
-        self.assert_iface_up(self.dev_e_client,
-                             ['inet '])
-        self.assertIn(b'20.0.0.0/24 via 10.10.10.10 proto static onlink',
                       subprocess.check_output(['ip', 'route', 'show', 'dev', self.dev_e_client]))
 
     def test_route_with_policy(self):

--- a/tests/integration/routing.py
+++ b/tests/integration/routing.py
@@ -85,21 +85,16 @@ class _CommonTests():
       addresses: [ "10.20.10.2/24" ]
       gateway4: 10.20.10.1
       routes:
-        - to: 0.0.0.0/0
+        - to: 10.0.0.0/8
           via: 11.0.0.1
           table: %(tid)s
-          on-link: true
-      routing-policy:
-        - to: 10.0.0.0/8
-          from: 10.20.10.2/24
-          table: %(tid)s''' % {'r': self.backend, 'ec': self.dev_e_client, 'tid': table_id})
+          on-link: true''' % {'r': self.backend, 'ec': self.dev_e_client, 'tid': table_id})
         self.generate_and_settle()
-        self.assert_iface_up(self.dev_e_client,
-                             ['inet '])
+        self.assert_iface_up(self.dev_e_client, ['inet '])
         out = subprocess.check_output(['ip', 'route', 'show', 'table', table_id, 'dev',
                                       self.dev_e_client], universal_newlines=True)
         # NM routes have a (default) 'metric' in between 'proto static' and 'onlink'
-        self.assertRegex(out, r'(default|0\.0\.0\.0/24) via 11\.0\.0\.1 proto static.* onlink')
+        self.assertRegex(out, r'10\.0\.0\.0/8 via 11\.0\.0\.1 proto static.* onlink')
 
     @unittest.skip("fails due to networkd bug setting routes with dhcp")
     def test_routes_v4_with_dhcp(self):


### PR DESCRIPTION
## Description
This should actually fail if used with NetworkManager < 1.14, e.g. on Ubuntu Bionic.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Closes an open bug in Launchpad.

