### PR TITLE
OpenVSwitch Bonds

### DIFF
--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -824,6 +824,8 @@ wpasupplicant installed if you let the ``networkd`` renderer handle wifi.
           ``balance-rr`` (round robin). Possible values are ``balance-rr``,
           ``active-backup``, ``balance-xor``, ``broadcast``, ``802.3ad``,
           ``balance-tlb``, and ``balance-alb``.
+          For OpenVSwitch the additional modes ``balance-tcp`` and
+          ``balance-slb`` are supported.
 
      ``lacp-rate`` (scalar)
      :    Set the rate at which LACPDUs are transmitted. This is only useful

--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -148,6 +148,8 @@ Virtual devices
      ``other-config`` (mapping)
      :   Passed-through directly to OpenVSwitch
 
+     ``lacp`` (scalar)
+     :   Valid for bond interfaces. Accepts ``active``, ``passive` or ``off`` (the default).
 
 ## Common properties for all device types
 

--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -824,8 +824,8 @@ wpasupplicant installed if you let the ``networkd`` renderer handle wifi.
           ``balance-rr`` (round robin). Possible values are ``balance-rr``,
           ``active-backup``, ``balance-xor``, ``broadcast``, ``802.3ad``,
           ``balance-tlb``, and ``balance-alb``.
-          For OpenVSwitch the additional modes ``balance-tcp`` and
-          ``balance-slb`` are supported.
+          For OpenVSwitch ``active-backup`` and the additional modes
+          ``balance-tcp`` and ``balance-slb`` are supported.
 
      ``lacp-rate`` (scalar)
      :    Set the rate at which LACPDUs are transmitted. This is only useful

--- a/src/openvswitch.c
+++ b/src/openvswitch.c
@@ -153,7 +153,8 @@ write_ovs_conf(const NetplanNetDefinition* def, const char* rootdir)
                                   id_escaped, cmds, "other-config");
     }
 
-    /* For other, more OVS specific settings, we expect the backend to be set to OVS */
+    /* For other, more OVS specific settings, we expect the backend to be set to OVS.
+     * The OVS backend is implicitly set, if an interface contains the "openvswitch:" key. */
     if (def->backend == NETPLAN_BACKEND_OVS) {
         /* TODO */
     } else {

--- a/src/openvswitch.c
+++ b/src/openvswitch.c
@@ -185,7 +185,8 @@ write_ovs_conf(const NetplanNetDefinition* def, const char* rootdir)
     }
 
     /* For other, more OVS specific settings, we expect the backend to be set to OVS.
-     * The OVS backend is implicitly set, if an interface contains the "openvswitch:" key. */
+     * The OVS backend is implicitly set, if an interface contains an empty "openvswitch: {}"
+     * key, or an "openvswitch:" key containing only "external-ids" or "other-config". */
     if (def->backend == NETPLAN_BACKEND_OVS) {
         switch (def->type) {
             case NETPLAN_DEF_TYPE_BOND:

--- a/src/openvswitch.c
+++ b/src/openvswitch.c
@@ -182,6 +182,10 @@ write_ovs_conf(const NetplanNetDefinition* def, const char* rootdir)
         switch (def->type) {
             case NETPLAN_DEF_TYPE_BOND:
                 dependency = write_ovs_bond_interfaces(def, cmds);
+                /* Mark this bond as created by netplan */
+                append_systemd_cmd(cmds, OPENVSWITCH_OVS_VSCTL " set port %s external-ids:netplan=true",
+                                   id_escaped);
+                /* Set LACP mode, default to "off" */
                 append_systemd_cmd(cmds, OPENVSWITCH_OVS_VSCTL " set port %s lacp=%s",
                                    def->id, def->ovs_settings.lacp? def->ovs_settings.lacp : "off");
                 if (def->bond_params.mode) {

--- a/src/openvswitch.c
+++ b/src/openvswitch.c
@@ -155,6 +155,31 @@ write_ovs_bond_interfaces(const NetplanNetDefinition* def, const gchar* id_escap
     return def->bridge;
 }
 
+static void
+write_ovs_tag_netplan(const gchar* id_escaped, GString* cmds)
+{
+    /* Mark this port as created by netplan */
+    append_systemd_cmd(cmds, OPENVSWITCH_OVS_VSCTL " set port %s external-ids:netplan=true",
+                       id_escaped);
+}
+
+static void
+write_ovs_bond_mode(const NetplanNetDefinition* def, const gchar* id_escaped, GString* cmds)
+{
+    /* OVS supports only "active-backup", "balance-tcp" and "balance-slb":
+     * http://www.openvswitch.org/support/dist-docs/ovs-vswitchd.conf.db.5.txt */
+    if (!strcmp(def->bond_params.mode, "active-backup") ||
+        !strcmp(def->bond_params.mode, "balance-tcp") ||
+        !strcmp(def->bond_params.mode, "balance-slb")) {
+        append_systemd_cmd(cmds, OPENVSWITCH_OVS_VSCTL " set port %s bond_mode=%s",
+                            id_escaped, def->bond_params.mode);
+    } else {
+        g_fprintf(stderr, "%s: bond mode '%s' not supported by openvswitch\n",
+                    def->id, def->bond_params.mode);
+        exit(1);
+    }
+}
+
 /**
  * Generate the OpenVSwitch systemd units for configuration of the selected netdef
  * @rootdir: If not %NULL, generate configuration in this root directory
@@ -191,25 +216,12 @@ write_ovs_conf(const NetplanNetDefinition* def, const char* rootdir)
         switch (def->type) {
             case NETPLAN_DEF_TYPE_BOND:
                 dependency = write_ovs_bond_interfaces(def, id_escaped, cmds);
-                /* Mark this bond as created by netplan */
-                append_systemd_cmd(cmds, OPENVSWITCH_OVS_VSCTL " set port %s external-ids:netplan=true",
-                                   id_escaped);
+                write_ovs_tag_netplan(id_escaped, cmds);
                 /* Set LACP mode, default to "off" */
                 append_systemd_cmd(cmds, OPENVSWITCH_OVS_VSCTL " set port %s lacp=%s",
                                    id_escaped, def->ovs_settings.lacp? def->ovs_settings.lacp : "off");
                 if (def->bond_params.mode) {
-                    /* OVS supports only "active-backup", "balance-tcp" and "balance-slb":
-                     * http://www.openvswitch.org/support/dist-docs/ovs-vswitchd.conf.db.5.txt */
-                    if (!strcmp(def->bond_params.mode, "active-backup") ||
-                        !strcmp(def->bond_params.mode, "balance-tcp") ||
-                        !strcmp(def->bond_params.mode, "balance-slb")) {
-                        append_systemd_cmd(cmds, OPENVSWITCH_OVS_VSCTL " set port %s bond_mode=%s",
-                                           id_escaped, def->bond_params.mode);
-                    } else {
-                        g_fprintf(stderr, "%s: bond mode '%s' not supported by openvswitch\n",
-                                  def->id, def->bond_params.mode);
-                        exit(1);
-                    }
+                    write_ovs_bond_mode(def, id_escaped, cmds);
                 }
                 break;
 

--- a/src/openvswitch.c
+++ b/src/openvswitch.c
@@ -46,6 +46,7 @@ write_ovs_systemd_unit(const char* id, const GString* cmds, const char* rootdir,
     }
 
     g_string_append(s, "\n[Service]\nType=oneshot\n");
+    g_string_append(s, "RemainAfterExit=yes\n");
     g_string_append(s, cmds->str);
 
     g_string_free_to_file(s, rootdir, path, NULL);
@@ -63,6 +64,12 @@ write_ovs_systemd_unit(const char* id, const GString* cmds, const char* rootdir,
 #define append_systemd_cmd(s, command, ...) \
 { \
     g_string_append(s, "ExecStart="); \
+    g_string_append_printf(s, command, __VA_ARGS__); \
+    g_string_append(s, "\n"); \
+}
+#define append_systemd_stop(s, command, ...) \
+{ \
+    g_string_append(s, "ExecStop="); \
     g_string_append_printf(s, command, __VA_ARGS__); \
     g_string_append(s, "\n"); \
 }
@@ -143,6 +150,7 @@ write_ovs_bond_interfaces(const NetplanNetDefinition* def, const gchar* id_escap
     }
 
     append_systemd_cmd(cmds, s->str, systemd_escape(def->bridge), id_escaped);
+    append_systemd_stop(cmds, OPENVSWITCH_OVS_VSCTL " del-port %s", id_escaped);
     g_string_free(s, TRUE);
     return def->bridge;
 }

--- a/src/openvswitch.c
+++ b/src/openvswitch.c
@@ -182,6 +182,8 @@ write_ovs_conf(const NetplanNetDefinition* def, const char* rootdir)
         switch (def->type) {
             case NETPLAN_DEF_TYPE_BOND:
                 dependency = write_ovs_bond_interfaces(def, cmds);
+                append_systemd_cmd(cmds, OPENVSWITCH_OVS_VSCTL " set port %s lacp=%s",
+                                   def->id, def->ovs_settings.lacp? def->ovs_settings.lacp : "off");
                 break;
 
             default:

--- a/src/openvswitch.c
+++ b/src/openvswitch.c
@@ -184,6 +184,10 @@ write_ovs_conf(const NetplanNetDefinition* def, const char* rootdir)
                 dependency = write_ovs_bond_interfaces(def, cmds);
                 append_systemd_cmd(cmds, OPENVSWITCH_OVS_VSCTL " set port %s lacp=%s",
                                    def->id, def->ovs_settings.lacp? def->ovs_settings.lacp : "off");
+                /* XXX: Does OVS support all the other bond modes? */
+                if (def->bond_params.mode)
+                    append_systemd_cmd(cmds, OPENVSWITCH_OVS_VSCTL " set port %s bond_mode=%s",
+                                       def->id, def->bond_params.mode);
                 break;
 
             default:

--- a/src/openvswitch.c
+++ b/src/openvswitch.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2020 Canonical, Ltd.
  * Author: Łukasz 'sil2100' Zemczak <lukasz.zemczak@ubuntu.com>
+ *         Lukas 'slyon' Märdian <lukas.maerdian@canonical.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/openvswitch.c
+++ b/src/openvswitch.c
@@ -138,6 +138,8 @@ write_ovs_conf(const NetplanNetDefinition* def, const char* rootdir)
         /* TODO: make sure this systemd unit isrun after the OVS bond (port) was created */
         append_systemd_cmd(cmds, OPENVSWITCH_OVS_VSCTL " add-bond-iface %s %s",
                            def->bond, def->id);
+        append_systemd_cmd(cmds, OPENVSWITCH_OVS_VSCTL " --if-exists del-bond-iface %s %s",
+                           def->bond, def->bond)
     }
 
     /* Common OVS settings can be specified even for non-OVS interfaces */

--- a/src/parse.c
+++ b/src/parse.c
@@ -962,8 +962,18 @@ handle_bond_mode(yaml_document_t* doc, yaml_node_t* node, const void* data, GErr
         strcmp(scalar(node), "broadcast") == 0 ||
         strcmp(scalar(node), "802.3ad") == 0 ||
         strcmp(scalar(node), "balance-tlb") == 0 ||
-        strcmp(scalar(node), "balance-alb") == 0))
+        strcmp(scalar(node), "balance-alb") == 0 ||
+        strcmp(scalar(node), "balance-tcp") == 0 || // only supported for OVS
+        strcmp(scalar(node), "balance-slb") == 0))  // only supported for OVS
         return yaml_error(node, error, "unknown bond mode '%s'", scalar(node));
+
+    /* Implicitly set NETPLAN_BACKEND_OVS if ovs-only mode selected */
+    if (!strcmp(scalar(node), "balance-tcp") ||
+        !strcmp(scalar(node), "balance-slb")) {
+        g_debug("%s: mode '%s' only supported with openvswitch, choosing this backend",
+                cur_netdef->id, scalar(node));
+        cur_netdef->backend = NETPLAN_BACKEND_OVS;
+    }
 
     return handle_netdef_str(doc, node, data, error);
 }

--- a/src/parse.c
+++ b/src/parse.c
@@ -1702,9 +1702,22 @@ static const mapping_entry_handler nm_backend_settings_handlers[] = {
     {NULL}
 };
 
+static gboolean
+handle_ovs_bond_lacp(yaml_document_t* doc, yaml_node_t* node, const void* data, GError** error)
+{
+    if (cur_netdef->type != NETPLAN_DEF_TYPE_BOND)
+        return yaml_error(node, error, "Key 'lacp' is only valid for iterface type 'openvswitch bond'");
+
+    if (g_strcmp0(scalar(node), "active") && g_strcmp0(scalar(node), "passive") && g_strcmp0(scalar(node), "off"))
+        return yaml_error(node, error, "Value of 'lacp' needs to be 'active', 'passive' or 'off");
+
+    return handle_netdef_str(doc, node, data, error);
+}
+
 static const mapping_entry_handler ovs_backend_settings_handlers[] = {
     {"external-ids", YAML_MAPPING_NODE, handle_netdef_map, NULL, netdef_offset(ovs_settings.external_ids)},
     {"other-config", YAML_MAPPING_NODE, handle_netdef_map, NULL, netdef_offset(ovs_settings.other_config)},
+    {"lacp", YAML_SCALAR_NODE, handle_ovs_bond_lacp, NULL, netdef_offset(ovs_settings.lacp)},
     {NULL}
 };
 

--- a/src/parse.c
+++ b/src/parse.c
@@ -1708,6 +1708,14 @@ static const mapping_entry_handler ovs_backend_settings_handlers[] = {
     {NULL}
 };
 
+static gboolean
+handle_ovs_backend(yaml_document_t* doc, yaml_node_t* node, const void* _, GError** error)
+{
+    /* Set the renderer for this device to NETPLAN_BACKEND_OVS, implicitly. */
+    cur_netdef->backend = NETPLAN_BACKEND_OVS;
+    return process_mapping(doc, node, ovs_backend_settings_handlers, error);
+}
+
 static const mapping_entry_handler nameservers_handlers[] = {
     {"search", YAML_SEQUENCE_NODE, handle_nameservers_search},
     {"addresses", YAML_SEQUENCE_NODE, handle_nameservers_addresses},
@@ -1763,7 +1771,7 @@ static const mapping_entry_handler dhcp6_overrides_handlers[] = {
 
 #define COMMON_BACKEND_HANDLERS                                                \
     {"networkmanager", YAML_MAPPING_NODE, NULL, nm_backend_settings_handlers}, \
-    {"openvswitch", YAML_MAPPING_NODE, NULL, ovs_backend_settings_handlers}
+    {"openvswitch", YAML_MAPPING_NODE, handle_ovs_backend}
 
 /* Handlers for physical links */
 #define PHYSICAL_LINK_HANDLERS                                                           \

--- a/src/parse.c
+++ b/src/parse.c
@@ -1740,12 +1740,15 @@ handle_ovs_backend(yaml_document_t* doc, yaml_node_t* node, const void* _, GErro
     gboolean ret = process_mapping(doc, node, ovs_backend_settings_handlers, &values, error);
     guint len = g_list_length(values);
 
-    if (len == 1 && (g_list_find_custom(values, "other-config", (GCompareFunc) strcmp) ||
-        g_list_find_custom(values, "external-ids", (GCompareFunc) strcmp)))
-        return ret;
-    else if (len == 2 && g_list_find_custom(values, "other-config", (GCompareFunc) strcmp) &&
-             g_list_find_custom(values, "external-ids", (GCompareFunc) strcmp))
-        return ret;
+    if (cur_netdef->type != NETPLAN_DEF_TYPE_BOND) {
+        /* Non-bond interfaces might still be handled by the networkd backend */
+        if (len == 1 && (g_list_find_custom(values, "other-config", (GCompareFunc) strcmp) ||
+            g_list_find_custom(values, "external-ids", (GCompareFunc) strcmp)))
+            return ret;
+        else if (len == 2 && g_list_find_custom(values, "other-config", (GCompareFunc) strcmp) &&
+                g_list_find_custom(values, "external-ids", (GCompareFunc) strcmp))
+            return ret;
+    }
 
     /* Set the renderer for this device to NETPLAN_BACKEND_OVS, implicitly.
      * But only if empty "openvswitch: {}" or "openvswitch:" with more than

--- a/src/parse.c
+++ b/src/parse.c
@@ -1742,12 +1742,12 @@ handle_ovs_backend(yaml_document_t* doc, yaml_node_t* node, const void* _, GErro
     guint len = g_list_length(values);
 
     if (cur_netdef->type != NETPLAN_DEF_TYPE_BOND) {
+        GList *other_config = g_list_find_custom(values, "other-config", (GCompareFunc) strcmp);
+        GList *external_ids = g_list_find_custom(values, "external-ids", (GCompareFunc) strcmp);
         /* Non-bond interfaces might still be handled by the networkd backend */
-        if (len == 1 && (g_list_find_custom(values, "other-config", (GCompareFunc) strcmp) ||
-            g_list_find_custom(values, "external-ids", (GCompareFunc) strcmp)))
+        if (len == 1 && (other_config || external_ids))
             return ret;
-        else if (len == 2 && g_list_find_custom(values, "other-config", (GCompareFunc) strcmp) &&
-                g_list_find_custom(values, "external-ids", (GCompareFunc) strcmp))
+        else if (len == 2 && other_config && external_ids)
             return ret;
     }
     g_list_free_full(values, g_free);

--- a/src/parse.c
+++ b/src/parse.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2016 Canonical, Ltd.
  * Author: Martin Pitt <martin.pitt@ubuntu.com>
+ *         Lukas Märdian <lukas.maerdian@canonical.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -1749,6 +1750,7 @@ handle_ovs_backend(yaml_document_t* doc, yaml_node_t* node, const void* _, GErro
                 g_list_find_custom(values, "external-ids", (GCompareFunc) strcmp))
             return ret;
     }
+    g_list_free_full(values, g_free);
 
     /* Set the renderer for this device to NETPLAN_BACKEND_OVS, implicitly.
      * But only if empty "openvswitch: {}" or "openvswitch:" with more than

--- a/src/parse.h
+++ b/src/parse.h
@@ -201,6 +201,7 @@ typedef struct dhcp_overrides {
 typedef struct ovs_settings {
     GHashTable* external_ids;
     GHashTable* other_config;
+    char* lacp;
 } NetplanOVSSettings;
 
 /**

--- a/tests/generator/base.py
+++ b/tests/generator/base.py
@@ -44,6 +44,8 @@ ND_DHCP6 = '[Match]\nName=%s\n\n[Network]\nDHCP=ipv6\nLinkLocalAddressing=ipv6\n
 ND_DHCP6_NOMTU = '[Match]\nName=%s\n\n[Network]\nDHCP=ipv6\nLinkLocalAddressing=ipv6\n\n[DHCP]\nRouteMetric=100\nUseMTU=false\n'
 ND_DHCPYES = '[Match]\nName=%s\n\n[Network]\nDHCP=yes\nLinkLocalAddressing=ipv6\n\n[DHCP]\nRouteMetric=100\nUseMTU=true\n'
 ND_DHCPYES_NOMTU = '[Match]\nName=%s\n\n[Network]\nDHCP=yes\nLinkLocalAddressing=ipv6\n\n[DHCP]\nRouteMetric=100\nUseMTU=false\n'
+OVS_PHYSICAL = '[Unit]\nDescription=OpenVSwitch configuration for %(iface)s\nDefaultDependencies=no\nRequires=sys-subsystem-net-devices-%(iface)s.device\nAfter=sys-subsystem-net-devices-%(iface)s.device\nBefore=network.target\nWants=network.target\n\n%(service)s'
+OVS_VIRTUAL = '[Unit]\nDescription=OpenVSwitch configuration for %(iface)s\nDefaultDependencies=no\nBefore=network.target\nWants=network.target\n\n%(service)s'
 UDEV_MAC_RULE = 'SUBSYSTEM=="net", ACTION=="add", DRIVERS=="%s", ATTR{address}=="%s", NAME="%s"\n'
 UDEV_NO_MAC_RULE = 'SUBSYSTEM=="net", ACTION=="add", DRIVERS=="%s", NAME="%s"\n'
 

--- a/tests/generator/base.py
+++ b/tests/generator/base.py
@@ -44,8 +44,11 @@ ND_DHCP6 = '[Match]\nName=%s\n\n[Network]\nDHCP=ipv6\nLinkLocalAddressing=ipv6\n
 ND_DHCP6_NOMTU = '[Match]\nName=%s\n\n[Network]\nDHCP=ipv6\nLinkLocalAddressing=ipv6\n\n[DHCP]\nRouteMetric=100\nUseMTU=false\n'
 ND_DHCPYES = '[Match]\nName=%s\n\n[Network]\nDHCP=yes\nLinkLocalAddressing=ipv6\n\n[DHCP]\nRouteMetric=100\nUseMTU=true\n'
 ND_DHCPYES_NOMTU = '[Match]\nName=%s\n\n[Network]\nDHCP=yes\nLinkLocalAddressing=ipv6\n\n[DHCP]\nRouteMetric=100\nUseMTU=false\n'
-OVS_PHYSICAL = '[Unit]\nDescription=OpenVSwitch configuration for %(iface)s\nDefaultDependencies=no\nRequires=sys-subsystem-net-devices-%(iface)s.device\nAfter=sys-subsystem-net-devices-%(iface)s.device\nBefore=network.target\nWants=network.target\n\n%(service)s'
-OVS_VIRTUAL = '[Unit]\nDescription=OpenVSwitch configuration for %(iface)s\nDefaultDependencies=no\nBefore=network.target\nWants=network.target\n\n%(service)s'
+OVS_PHYSICAL = '[Unit]\nDescription=OpenVSwitch configuration for %(iface)s\nDefaultDependencies=no\n\
+Requires=sys-subsystem-net-devices-%(iface)s.device\nAfter=sys-subsystem-net-devices-%(iface)s.device\nBefore=network.target\n\
+Wants=network.target\n\n%(service)s'
+OVS_VIRTUAL = '[Unit]\nDescription=OpenVSwitch configuration for %(iface)s\nDefaultDependencies=no\nBefore=network.target\n\
+Wants=network.target\n\n%(service)s'
 UDEV_MAC_RULE = 'SUBSYSTEM=="net", ACTION=="add", DRIVERS=="%s", ATTR{address}=="%s", NAME="%s"\n'
 UDEV_NO_MAC_RULE = 'SUBSYSTEM=="net", ACTION=="add", DRIVERS=="%s", NAME="%s"\n'
 

--- a/tests/generator/base.py
+++ b/tests/generator/base.py
@@ -46,9 +46,9 @@ ND_DHCPYES = '[Match]\nName=%s\n\n[Network]\nDHCP=yes\nLinkLocalAddressing=ipv6\
 ND_DHCPYES_NOMTU = '[Match]\nName=%s\n\n[Network]\nDHCP=yes\nLinkLocalAddressing=ipv6\n\n[DHCP]\nRouteMetric=100\nUseMTU=false\n'
 OVS_PHYSICAL = '[Unit]\nDescription=OpenVSwitch configuration for %(iface)s\nDefaultDependencies=no\n\
 Requires=sys-subsystem-net-devices-%(iface)s.device\nAfter=sys-subsystem-net-devices-%(iface)s.device\nBefore=network.target\n\
-Wants=network.target\n\n%(service)s'
+Wants=network.target\n%(extra)s'
 OVS_VIRTUAL = '[Unit]\nDescription=OpenVSwitch configuration for %(iface)s\nDefaultDependencies=no\nBefore=network.target\n\
-Wants=network.target\n\n%(service)s'
+Wants=network.target\n%(extra)s'
 UDEV_MAC_RULE = 'SUBSYSTEM=="net", ACTION=="add", DRIVERS=="%s", ATTR{address}=="%s", NAME="%s"\n'
 UDEV_NO_MAC_RULE = 'SUBSYSTEM=="net", ACTION=="add", DRIVERS=="%s", NAME="%s"\n'
 

--- a/tests/generator/test_ovs.py
+++ b/tests/generator/test_ovs.py
@@ -145,7 +145,9 @@ ExecStart=/usr/bin/ovs-vsctl set open_vswitch . other-config:disable-in-band=tru
   bonds:
     bond0:
       interfaces: [eth1, eth2]
-      openvswitch: {}
+      openvswitch:
+        external-ids:
+          iface-id: myhostname
   bridges:
     br0:
       addresses: [192.170.1.1/24]
@@ -161,8 +163,9 @@ Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl add-bond br0 bond0 eth1 eth2
 ExecStop=/usr/bin/ovs-vsctl del-port bond0
-ExecStart=/usr/bin/ovs-vsctl set port bond0 external-ids:netplan=true
-ExecStart=/usr/bin/ovs-vsctl set port bond0 lacp=off
+ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=off
+ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:iface-id=myhostname
 '''}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({'eth1.network': '[Match]\nName=eth1\n\n[Network]\nLinkLocalAddressing=no\nBond=bond0\n',
@@ -241,8 +244,8 @@ Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl add-bond br0 bond0 eth1 eth2
 ExecStop=/usr/bin/ovs-vsctl del-port bond0
-ExecStart=/usr/bin/ovs-vsctl set port bond0 external-ids:netplan=true
-ExecStart=/usr/bin/ovs-vsctl set port bond0 lacp=active
+ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=active
 '''}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({'eth1.network': '[Match]\nName=eth1\n\n[Network]\nLinkLocalAddressing=no\nBond=bond0\n',
@@ -303,9 +306,9 @@ Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl add-bond br0 bond0 eth1 eth2
 ExecStop=/usr/bin/ovs-vsctl del-port bond0
-ExecStart=/usr/bin/ovs-vsctl set port bond0 external-ids:netplan=true
-ExecStart=/usr/bin/ovs-vsctl set port bond0 lacp=off
-ExecStart=/usr/bin/ovs-vsctl set port bond0 bond_mode=balance-tcp
+ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=off
+ExecStart=/usr/bin/ovs-vsctl set Port bond0 bond_mode=balance-tcp
 '''}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({'eth1.network': '[Match]\nName=eth1\n\n[Network]\nLinkLocalAddressing=no\nBond=bond0\n',
@@ -338,9 +341,9 @@ Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl add-bond br0 bond0 eth1 eth2
 ExecStop=/usr/bin/ovs-vsctl del-port bond0
-ExecStart=/usr/bin/ovs-vsctl set port bond0 external-ids:netplan=true
-ExecStart=/usr/bin/ovs-vsctl set port bond0 lacp=off
-ExecStart=/usr/bin/ovs-vsctl set port bond0 bond_mode=active-backup
+ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=off
+ExecStart=/usr/bin/ovs-vsctl set Port bond0 bond_mode=active-backup
 '''}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({'eth1.network': '[Match]\nName=eth1\n\n[Network]\nLinkLocalAddressing=no\nBond=bond0\n',

--- a/tests/generator/test_ovs.py
+++ b/tests/generator/test_ovs.py
@@ -136,34 +136,8 @@ ExecStart=/usr/bin/ovs-vsctl set open_vswitch . other-config:disable-in-band=tru
 ''')
         self.assert_ovs({'bond0.service': OVS_VIRTUAL % {'iface': 'bond0', 'service': '''[Service]
 Type=oneshot
-ExecStart=/usr/bin/ovs-vsctl add-port br0 bond0
-'''},
-                         'eth1.service': OVS_PHYSICAL % {'iface': 'eth1', 'service': '''[Service]
-Type=oneshot
-ExecStart=/usr/bin/ovs-vsctl add-bond-iface bond0 eth1
-ExecStart=/usr/bin/ovs-vsctl --if-exists del-bond-iface bond0 bond0
-'''},
-                         'eth2.service': OVS_PHYSICAL % {'iface': 'eth2', 'service': '''[Service]
-Type=oneshot
-ExecStart=/usr/bin/ovs-vsctl add-bond-iface bond0 eth2
-ExecStart=/usr/bin/ovs-vsctl --if-exists del-bond-iface bond0 bond0
+ExecStart=/usr/bin/ovs-vsctl add-bond br0 bond0 eth1 eth2
 '''}})
         # Confirm that the networkd config is still sane
-        self.assert_networkd({'br0.netdev': '[NetDev]\nName=br0\nKind=bridge\n',
-                              'br0.network': '''[Match]
-Name=br0
-
-[Network]
-LinkLocalAddressing=ipv6
-Address=192.170.1.1/24
-ConfigureWithoutCarrier=yes
-''',
-                              'bond0.netdev': '[NetDev]\nName=bond0\nKind=bond\n',
-                              'bond0.network': '''[Match]\nName=bond0\n
-[Network]
-LinkLocalAddressing=no
-ConfigureWithoutCarrier=yes
-Bridge=br0
-''',
-                              'eth1.network': '[Match]\nName=eth1\n\n[Network]\nLinkLocalAddressing=no\nBond=bond0\n',
+        self.assert_networkd({'eth1.network': '[Match]\nName=eth1\n\n[Network]\nLinkLocalAddressing=no\nBond=bond0\n',
                               'eth2.network': '[Match]\nName=eth2\n\n[Network]\nLinkLocalAddressing=no\nBond=bond0\n'})

--- a/tests/generator/test_ovs.py
+++ b/tests/generator/test_ovs.py
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from .base import TestBase, ND_DHCP4, ND_DHCP6, OVS_PHYSICAL, OVS_VIRTUAL
+from .base import TestBase, ND_DHCP4, OVS_PHYSICAL, OVS_VIRTUAL
 
 
 class TestOpenVSwitch(TestBase):
@@ -49,9 +49,8 @@ ExecStart=/usr/bin/ovs-vsctl set Interface eth0 other-config:disable-in-band=tru
 Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl set Interface eth1 other-config:disable-in-band=false
 '''}})
-        # Confirm that the networkd config is still sane
-        self.assert_networkd({'eth0.network': ND_DHCP6 % 'eth0',
-                              'eth1.network': ND_DHCP4 % 'eth1'})
+        # Confirm that networkd does not touch the OVS interfaces
+        self.assert_networkd({})
 
     def test_bridge_external_ids_other_config(self):
         self.generate('''network:
@@ -70,20 +69,8 @@ Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:iface-id=myhostname
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 other-config:disable-in-band=true
 '''}})
-        # Confirm that the networkd config is still sane
-        self.assert_networkd({'br0.netdev': '[NetDev]\nName=br0\nKind=bridge\n',
-                              'br0.network': '''[Match]
-Name=br0
-
-[Network]
-DHCP=ipv4
-LinkLocalAddressing=ipv6
-ConfigureWithoutCarrier=yes
-
-[DHCP]
-RouteMetric=100
-UseMTU=true
-'''})
+        # Confirm that networkd does not touch the OVS interfaces
+        self.assert_networkd({})
 
     def test_global_external_ids_other_config(self):
         self.generate('''network:

--- a/tests/generator/test_ovs.py
+++ b/tests/generator/test_ovs.py
@@ -318,3 +318,23 @@ ExecStart=/usr/bin/ovs-vsctl set port bond0 bond_mode=active-backup
         # Confirm that the networkd config is still sane
         self.assert_networkd({'eth1.network': '[Match]\nName=eth1\n\n[Network]\nLinkLocalAddressing=no\nBond=bond0\n',
                               'eth2.network': '[Match]\nName=eth2\n\n[Network]\nLinkLocalAddressing=no\nBond=bond0\n'})
+
+    def test_bond_mode_ovs_invalid(self):
+        err = self.generate('''network:
+  version: 2
+  ethernets:
+    eth1: {}
+    eth2: {}
+  bonds:
+    bond0:
+      interfaces: [eth1, eth2]
+      parameters:
+        mode: balance-rr
+      openvswitch: {}
+  bridges:
+    br0:
+      addresses: [192.170.1.1/24]
+      interfaces: [bond0]
+      openvswitch: {}
+''', expect_fail=True)
+        self.assertIn("bond0: bond mode 'balance-rr' not supported by openvswitch", err)

--- a/tests/generator/test_ovs.py
+++ b/tests/generator/test_ovs.py
@@ -43,12 +43,14 @@ class TestOpenVSwitch(TestBase):
         self.assert_ovs({'eth0.service': OVS_PHYSICAL % {'iface': 'eth0', 'extra': '''
 [Service]
 Type=oneshot
+RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl set Interface eth0 external-ids:iface-id=myhostname
 ExecStart=/usr/bin/ovs-vsctl set Interface eth0 other-config:disable-in-band=true
 '''},
                          'eth1.service': OVS_PHYSICAL % {'iface': 'eth1', 'extra': '''
 [Service]
 Type=oneshot
+RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl set Interface eth1 other-config:disable-in-band=false
 '''}})
         # Confirm that networkd does not touch the OVS interfaces
@@ -69,6 +71,7 @@ ExecStart=/usr/bin/ovs-vsctl set Interface eth1 other-config:disable-in-band=fal
         self.assert_ovs({'br0.service': OVS_VIRTUAL % {'iface': 'br0', 'extra': '''
 [Service]
 Type=oneshot
+RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:iface-id=myhostname
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 other-config:disable-in-band=true
 '''}})
@@ -90,6 +93,7 @@ ExecStart=/usr/bin/ovs-vsctl set Bridge br0 other-config:disable-in-band=true
         self.assert_ovs({'global.service': OVS_VIRTUAL % {'iface': 'global', 'extra': '''
 [Service]
 Type=oneshot
+RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:iface-id=myhostname
 ExecStart=/usr/bin/ovs-vsctl set open_vswitch . other-config:disable-in-band=true
 '''}})
@@ -128,8 +132,6 @@ ExecStart=/usr/bin/ovs-vsctl set open_vswitch . other-config:disable-in-band=tru
   bonds:
     bond0:
       interfaces: [eth1, eth2]
-      #parameters:
-      #  mode: balance-tcp # this is a bond mode only supported on openvswitch
       openvswitch: {}
   bridges:
     br0:
@@ -143,7 +145,9 @@ After=netplan-ovs-br0.service
 
 [Service]
 Type=oneshot
+RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl add-bond br0 bond0 eth1 eth2
+ExecStop=/usr/bin/ovs-vsctl del-port bond0
 ExecStart=/usr/bin/ovs-vsctl set port bond0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set port bond0 lacp=off
 '''}})
@@ -221,7 +225,9 @@ After=netplan-ovs-br0.service
 
 [Service]
 Type=oneshot
+RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl add-bond br0 bond0 eth1 eth2
+ExecStop=/usr/bin/ovs-vsctl del-port bond0
 ExecStart=/usr/bin/ovs-vsctl set port bond0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set port bond0 lacp=active
 '''}})
@@ -281,7 +287,9 @@ After=netplan-ovs-br0.service
 
 [Service]
 Type=oneshot
+RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl add-bond br0 bond0 eth1 eth2
+ExecStop=/usr/bin/ovs-vsctl del-port bond0
 ExecStart=/usr/bin/ovs-vsctl set port bond0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set port bond0 lacp=off
 ExecStart=/usr/bin/ovs-vsctl set port bond0 bond_mode=balance-tcp
@@ -314,7 +322,9 @@ After=netplan-ovs-br0.service
 
 [Service]
 Type=oneshot
+RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl add-bond br0 bond0 eth1 eth2
+ExecStop=/usr/bin/ovs-vsctl del-port bond0
 ExecStart=/usr/bin/ovs-vsctl set port bond0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set port bond0 lacp=off
 ExecStart=/usr/bin/ovs-vsctl set port bond0 bond_mode=active-backup

--- a/tests/generator/test_ovs.py
+++ b/tests/generator/test_ovs.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from .base import TestBase, ND_DHCP4, ND_DHCP6
+from .base import TestBase, ND_DHCP4, ND_DHCP6, OVS_PHYSICAL, OVS_VIRTUAL
 
 
 class TestOpenVSwitch(TestBase):
@@ -39,31 +39,15 @@ class TestOpenVSwitch(TestBase):
         other-config:
           disable-in-band: false
 ''')
-        self.assert_ovs({'eth0.service': '''[Unit]
-Description=OpenVSwitch configuration for eth0
-DefaultDependencies=no
-Requires=sys-subsystem-net-devices-eth0.device
-After=sys-subsystem-net-devices-eth0.device
-Before=network.target
-Wants=network.target
-
-[Service]
+        self.assert_ovs({'eth0.service': OVS_PHYSICAL % { 'iface': 'eth0', 'service': '''[Service]
 Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl set Interface eth0 external-ids:iface-id=myhostname
 ExecStart=/usr/bin/ovs-vsctl set Interface eth0 other-config:disable-in-band=true
-''',
-                         'eth1.service': '''[Unit]
-Description=OpenVSwitch configuration for eth1
-DefaultDependencies=no
-Requires=sys-subsystem-net-devices-eth1.device
-After=sys-subsystem-net-devices-eth1.device
-Before=network.target
-Wants=network.target
-
-[Service]
+'''},
+                         'eth1.service': OVS_PHYSICAL % { 'iface': 'eth1', 'service': '''[Service]
 Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl set Interface eth1 other-config:disable-in-band=false
-'''})
+'''}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({'eth0.network': ND_DHCP6 % 'eth0',
                               'eth1.network': ND_DHCP4 % 'eth1'})
@@ -80,17 +64,11 @@ ExecStart=/usr/bin/ovs-vsctl set Interface eth1 other-config:disable-in-band=fal
           disable-in-band: true
       dhcp4: yes
 ''')
-        self.assert_ovs({'br0.service': '''[Unit]
-Description=OpenVSwitch configuration for br0
-DefaultDependencies=no
-Before=network.target
-Wants=network.target
-
-[Service]
+        self.assert_ovs({'br0.service': OVS_VIRTUAL % { 'iface': 'br0', 'service': '''[Service]
 Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:iface-id=myhostname
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 other-config:disable-in-band=true
-'''})
+'''}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({'br0.netdev': '[NetDev]\nName=br0\nKind=bridge\n',
                               'br0.network': '''[Match]
@@ -118,17 +96,11 @@ UseMTU=true
     eth0:
       dhcp4: yes
 ''')
-        self.assert_ovs({'global.service': '''[Unit]
-Description=OpenVSwitch configuration for global
-DefaultDependencies=no
-Before=network.target
-Wants=network.target
-
-[Service]
+        self.assert_ovs({'global.service': OVS_VIRTUAL % { 'iface': 'global', 'service': '''[Service]
 Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:iface-id=myhostname
 ExecStart=/usr/bin/ovs-vsctl set open_vswitch . other-config:disable-in-band=true
-'''})
+'''}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({'eth0.network': ND_DHCP4 % 'eth0'})
 
@@ -154,3 +126,54 @@ ExecStart=/usr/bin/ovs-vsctl set open_vswitch . other-config:disable-in-band=tru
 ''')
         self.assert_ovs(None)
         self.assert_networkd({'eth0.network': ND_DHCP4 % 'eth0'})
+
+    def test_bond_setup(self):
+        self.generate('''network:
+  version: 2
+  ethernets:
+    eth2: {}
+    eth3: {}
+  bonds:
+    bond0:
+      interfaces: [eth2, eth3]
+      #parameters:
+      #  mode: balance-tcp # this is a bond mode only supported on openvswitch
+      openvswitch: {}
+      #  lacp: active
+  bridges:
+    br0:
+      addresses: [192.170.1.1/24]
+      interfaces: [bond0]
+      openvswitch: {}
+''')
+        self.assert_ovs({'bond0.service': OVS_VIRTUAL % { 'iface': 'bond0', 'service': '''[Service]
+Type=oneshot
+ExecStart=/usr/bin/ovs-vsctl add-port br0 bond0
+'''},
+                         'eth2.service': OVS_PHYSICAL % { 'iface': 'eth1', 'service': '''[Service]
+Type=oneshot
+ExecStart=/usr/bin/ovs-vsctl add-bond-iface bond0 eth1
+'''},
+                         'eth2.service': OVS_PHYSICAL % { 'iface': 'eth2', 'service': '''[Service]
+Type=oneshot
+ExecStart=/usr/bin/ovs-vsctl add-bond-iface bond0 eth2
+'''}})
+        # Confirm that the networkd config is still sane
+        self.assert_networkd({'br0.netdev': '[NetDev]\nName=br0\nKind=bridge\n',
+                              'br0.network': '''[Match]
+Name=br0
+
+[Network]
+LinkLocalAddressing=ipv6
+Address=192.170.1.1/24
+ConfigureWithoutCarrier=yes
+''',
+                              'bond0.netdev': '[NetDev]\nName=bond0\nKind=bond\n',
+                              'bond0.network': '''[Match]\nName=bond0\n
+[Network]
+LinkLocalAddressing=no
+ConfigureWithoutCarrier=yes
+Bridge=br0
+''',
+                              'eth2.network': '[Match]\nName=eth2\n\n[Network]\nLinkLocalAddressing=no\nBond=bond0\n',
+                              'eth3.network': '[Match]\nName=eth3\n\n[Network]\nLinkLocalAddressing=no\nBond=bond0\n'})

--- a/tests/generator/test_ovs.py
+++ b/tests/generator/test_ovs.py
@@ -40,12 +40,14 @@ class TestOpenVSwitch(TestBase):
         other-config:
           disable-in-band: false
 ''')
-        self.assert_ovs({'eth0.service': OVS_PHYSICAL % {'iface': 'eth0', 'service': '''[Service]
+        self.assert_ovs({'eth0.service': OVS_PHYSICAL % {'iface': 'eth0', 'extra': '''
+[Service]
 Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl set Interface eth0 external-ids:iface-id=myhostname
 ExecStart=/usr/bin/ovs-vsctl set Interface eth0 other-config:disable-in-band=true
 '''},
-                         'eth1.service': OVS_PHYSICAL % {'iface': 'eth1', 'service': '''[Service]
+                         'eth1.service': OVS_PHYSICAL % {'iface': 'eth1', 'extra': '''
+[Service]
 Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl set Interface eth1 other-config:disable-in-band=false
 '''}})
@@ -64,7 +66,8 @@ ExecStart=/usr/bin/ovs-vsctl set Interface eth1 other-config:disable-in-band=fal
           disable-in-band: true
       dhcp4: yes
 ''')
-        self.assert_ovs({'br0.service': OVS_VIRTUAL % {'iface': 'br0', 'service': '''[Service]
+        self.assert_ovs({'br0.service': OVS_VIRTUAL % {'iface': 'br0', 'extra': '''
+[Service]
 Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:iface-id=myhostname
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 other-config:disable-in-band=true
@@ -84,7 +87,8 @@ ExecStart=/usr/bin/ovs-vsctl set Bridge br0 other-config:disable-in-band=true
     eth0:
       dhcp4: yes
 ''')
-        self.assert_ovs({'global.service': OVS_VIRTUAL % {'iface': 'global', 'service': '''[Service]
+        self.assert_ovs({'global.service': OVS_VIRTUAL % {'iface': 'global', 'extra': '''
+[Service]
 Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:iface-id=myhostname
 ExecStart=/usr/bin/ovs-vsctl set open_vswitch . other-config:disable-in-band=true
@@ -134,7 +138,11 @@ ExecStart=/usr/bin/ovs-vsctl set open_vswitch . other-config:disable-in-band=tru
       interfaces: [bond0]
       openvswitch: {}
 ''')
-        self.assert_ovs({'bond0.service': OVS_VIRTUAL % {'iface': 'bond0', 'service': '''[Service]
+        self.assert_ovs({'bond0.service': OVS_VIRTUAL % {'iface': 'bond0', 'extra':
+                        '''Requires=netplan-ovs-br0.service
+After=netplan-ovs-br0.service
+
+[Service]
 Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl add-bond br0 bond0 eth1 eth2
 '''}})

--- a/tests/generator/test_ovs.py
+++ b/tests/generator/test_ovs.py
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from .base import TestBase, ND_DHCP4, OVS_PHYSICAL, OVS_VIRTUAL
+from .base import TestBase, ND_DHCP4, ND_DHCP6, OVS_PHYSICAL, OVS_VIRTUAL
 
 
 class TestOpenVSwitch(TestBase):
@@ -53,8 +53,9 @@ Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl set Interface eth1 other-config:disable-in-band=false
 '''}})
-        # Confirm that networkd does not touch the OVS interfaces
-        self.assert_networkd({})
+        # Confirm that the networkd config is still sane
+        self.assert_networkd({'eth0.network': ND_DHCP6 % 'eth0',
+                              'eth1.network': ND_DHCP4 % 'eth1'})
 
     def test_bridge_external_ids_other_config(self):
         self.generate('''network:
@@ -75,8 +76,20 @@ RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:iface-id=myhostname
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 other-config:disable-in-band=true
 '''}})
-        # Confirm that networkd does not touch the OVS interfaces
-        self.assert_networkd({})
+        # Confirm that the networkd config is still sane
+        self.assert_networkd({'br0.netdev': '[NetDev]\nName=br0\nKind=bridge\n',
+                              'br0.network': '''[Match]
+Name=br0
+
+[Network]
+DHCP=ipv4
+LinkLocalAddressing=ipv6
+ConfigureWithoutCarrier=yes
+
+[DHCP]
+RouteMetric=100
+UseMTU=true
+'''})
 
     def test_global_external_ids_other_config(self):
         self.generate('''network:

--- a/tests/generator/test_ovs.py
+++ b/tests/generator/test_ovs.py
@@ -144,6 +144,7 @@ After=netplan-ovs-br0.service
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl add-bond br0 bond0 eth1 eth2
+ExecStart=/usr/bin/ovs-vsctl set port bond0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set port bond0 lacp=off
 '''}})
         # Confirm that the networkd config is still sane
@@ -221,6 +222,7 @@ After=netplan-ovs-br0.service
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl add-bond br0 bond0 eth1 eth2
+ExecStart=/usr/bin/ovs-vsctl set port bond0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set port bond0 lacp=active
 '''}})
         # Confirm that the networkd config is still sane
@@ -280,6 +282,7 @@ After=netplan-ovs-br0.service
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl add-bond br0 bond0 eth1 eth2
+ExecStart=/usr/bin/ovs-vsctl set port bond0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set port bond0 lacp=off
 ExecStart=/usr/bin/ovs-vsctl set port bond0 bond_mode=balance-tcp
 '''}})
@@ -312,6 +315,7 @@ After=netplan-ovs-br0.service
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl add-bond br0 bond0 eth1 eth2
+ExecStart=/usr/bin/ovs-vsctl set port bond0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set port bond0 lacp=off
 ExecStart=/usr/bin/ovs-vsctl set port bond0 bond_mode=active-backup
 '''}})

--- a/tests/integration/ovs.py
+++ b/tests/integration/ovs.py
@@ -1,0 +1,80 @@
+#!/usr/bin/python3
+#
+# Integration tests for bonds
+#
+# These need to be run in a VM and do change the system
+# configuration.
+#
+# Copyright (C) 2020 Canonical, Ltd.
+# Author: Lukas Märdian <lukas.maerdian@canonical.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import sys
+import subprocess
+import unittest
+
+from base import IntegrationTestsBase, test_backends
+
+
+class _CommonTests():
+
+    def test_bond_base(self):
+        self.setup_eth(None, False)
+        self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-br', 'ovsbr'])
+        self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-port', 'mybond'])
+        # XXX: Temporary bridge setup, until netplan-ovs can do it itself
+        subprocess.call(['ovs-vsctl', 'add-br', 'ovsbr'])
+        with open(self.config, 'w') as f:
+            f.write('''network:
+  ethernets:
+    %(ec)s: {}
+    %(e2c)s: {}
+  bonds:
+    mybond:
+      interfaces: [%(ec)s, %(e2c)s]
+      parameters:
+        mode: balance-slb
+      openvswitch:
+        lacp: off
+  bridges:
+    ovsbr:
+      addresses: [192.170.1.1/24]
+      interfaces: [mybond]
+      openvswitch: {}''' % {'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
+        self.generate_and_settle()
+        # Basic verification that the interfaces/ports are in OVS
+        out = subprocess.check_output(['ovs-vsctl', 'show'])
+        self.assertIn(b'    Bridge ovsbr', out)
+        self.assertIn(b'        Port mybond', out)
+        self.assertIn(b'            Interface eth42', out)
+        self.assertIn(b'            Interface eth43', out)
+        # Verify the bridge was tagged 'netplan:true' correctly
+        out = subprocess.check_output(['ovs-vsctl', '--columns=name,external-ids', 'list', 'Port'])
+        self.assertIn(b'mybond\nexternal_ids        : {netplan="true"}', out)
+        # Verify bond params
+        out = subprocess.check_output(['ovs-appctl', 'bond/show', 'mybond'])
+        self.assertIn(b'---- mybond ----', out)
+        self.assertIn(b'bond_mode: balance-slb', out)
+        self.assertIn(b'lacp_status: off', out)
+        self.assertIn(b'slave eth42: enabled', out)
+        self.assertIn(b'slave eth43: enabled', out)
+
+
+@unittest.skipIf("networkd" not in test_backends,
+                     "skipping as networkd backend tests are disabled")
+class TestOVS(IntegrationTestsBase, _CommonTests):
+    backend = 'networkd'
+
+
+unittest.main(testRunner=unittest.TextTestRunner(stream=sys.stdout, verbosity=2))


### PR DESCRIPTION
## Description
This adds support for OpenVSwitch bonds, with the additional `parameters->mode` (`balance-tcp` & `balance-slb`) and `openvswitch->lacp` fields.

It implements `netplan apply` for OVS devices, defines systemd unit-file dependecies for OVS devices and adds a new, basic integration test for OVS.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [x] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Closes an open bug in Launchpad.

