### PR TITLE
Fix process_link_changes handling 'up' interfaces

### DIFF
--- a/netplan/cli/commands/apply.py
+++ b/netplan/cli/commands/apply.py
@@ -248,6 +248,9 @@ class NetplanApply(utils.NetplanCommand):
                 continue
 
             driver_name = utils.get_interface_driver_name(interface, only_down=True)
+            if not driver_name:
+                # don't allow up interfaces to match by mac
+                continue
             macaddress = utils.get_interface_macaddress(interface)
             if driver_name in matches['by-driver']:
                 new_name = matches['by-driver'][driver_name]


### PR DESCRIPTION
## Description
b7f1d9b04212 refactored `process_link_changes` with helper methods to get
the interface driver name and MAC address. This new code introduced a
regression where it's possible for an interface in the up state to be
included in the changelist by its MAC address.

This patch restores the previous behaviour, skipping interfaces that
don't have driver_name set.

Fixes: https://bugs.launchpad.net/bugs/1875411



## Checklist

- [X] Runs `make check` successfully.
- [X] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [X] \(Optional\) Closes an open bug in Launchpad.

