### PR TITLE
OVS: Add support for bridge controller configuration

### DIFF
--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -177,6 +177,19 @@ Virtual devices
           :   Set the connection mode for the controller. Supported options are
               ``in-band`` and ``out-of-band``. The default is ``in-band``.
 
+     ``ssl`` (mapping)
+     :   Valid for global ``openvswitch`` settings. Options for configuring SSL
+         server endpoint for the switch.
+
+          ``ca-cert`` (scalar)
+          :   Path to a file containing the CA certificate to be used.
+
+          ``certificate`` (scalar)
+          :   Path to a file containing the server certificate.
+
+          ``private-key`` (scalar)
+          :   Path to a file containing the private key for the server.
+
 ## Common properties for all device types
 
 ``renderer`` (scalar)

--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -165,6 +165,19 @@ Virtual devices
      ``rstp`` (bool)
      :   Valid for bridge interfaces. False by default.
 
+     ``controller`` (mapping)
+     :   Valid for bridge interfaces.
+
+          ``addresses`` (sequence of scalars)
+          :   Sets the configured controller targets. Each  target may use any
+              of the following forms: ``ssl:host[:port]``, ``tcp:host[:port]``,
+              ``unix:file``, ``pssl:[port][:host]``, ``ptcp:[port][:host]`` or
+              ``punix:file``
+
+          ``connection-mode`` (scalar)
+          :   Mode to be used to connect to the OpenFlow controller. Accepts
+              ``out-of-band`` and ``in-band`` (the default).
+
 ## Common properties for all device types
 
 ``renderer`` (scalar)

--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -166,17 +166,16 @@ Virtual devices
      :   Valid for bridge interfaces. False by default.
 
      ``controller`` (mapping)
-     :   Valid for bridge interfaces.
+     :   Valid for bridge interfaces. Specify an external OpenFlow controller.
 
           ``addresses`` (sequence of scalars)
-          :   Sets the configured controller targets. Each  target may use any
-              of the following forms: ``ssl:host[:port]``, ``tcp:host[:port]``,
-              ``unix:file``, ``pssl:[port][:host]``, ``ptcp:[port][:host]`` or
-              ``punix:file``
+          :   Set the list of addresses to use for the controller targets. The
+              syntax of these addresses is as defined in ovs-vsctl(8). Example:
+              addresses: ``[tcp:127.0.0.1:6653, "ssl:[fe80::1234%eth0]:6653"]``
 
           ``connection-mode`` (scalar)
-          :   Mode to be used to connect to the OpenFlow controller. Accepts
-              ``out-of-band`` and ``in-band`` (the default).
+          :   Set the connection mode for the controller. Supported options are
+              ``in-band`` and ``out-of-band``. The default is ``in-band``.
 
 ## Common properties for all device types
 

--- a/src/openvswitch.c
+++ b/src/openvswitch.c
@@ -275,10 +275,17 @@ write_ovs_conf(const NetplanNetDefinition* def, const char* rootdir)
                 if (def->ovs_settings.protocols && def->ovs_settings.protocols->len > 0) {
                     write_ovs_protocols(&(def->ovs_settings), def->id, cmds);
                 }
+                /* Set controller connection mode */
+                if (def->ovs_settings.controller.connection_mode) {
+                    append_systemd_cmd(cmds, OPENVSWITCH_OVS_VSCTL " set controller %s connection-mode=%s", def->id, def->ovs_settings.controller.connection_mode);
+                }
                 break;
 
+            // LCOV_EXCL_START
             default:
-                break;
+                g_assert_not_reached();
+                //break;
+            // LCOV_EXCL_STOP
         }
 
         /* Try writing out a base config */

--- a/src/openvswitch.c
+++ b/src/openvswitch.c
@@ -243,15 +243,15 @@ check_ovs_ssl(gchar* target)
 static void
 write_ovs_bridge_controller_targets(const NetplanOVSController* controller, const gchar* bridge, GString* cmds)
 {
-    gboolean needs_ssl = FALSE;
     g_autofree gchar* ssl = "";
     gchar* target = g_array_index(controller->addresses, char*, 0);
-    needs_ssl |= check_ovs_ssl(target);
+    gboolean needs_ssl = check_ovs_ssl(target);
     GString* s = g_string_new(target);
 
     for (unsigned i = 1; i < controller->addresses->len; ++i) {
         target = g_array_index(controller->addresses, char*, i);
-        needs_ssl |= check_ovs_ssl(target);
+        if (!needs_ssl)
+            needs_ssl = check_ovs_ssl(target);
         g_string_append_printf(s, " %s", target);
     }
 

--- a/src/parse.c
+++ b/src/parse.c
@@ -1787,6 +1787,152 @@ handle_ovs_bridge_protocol(yaml_document_t* doc, yaml_node_t* node, const void* 
     return handle_ovs_protocol(doc, node, cur_netdef, data, error);
 }
 
+static gboolean
+handle_ovs_bridge_controller_connection_mode(yaml_document_t* doc, yaml_node_t* node, const void* data, GError** error)
+{
+    if (cur_netdef->type != NETPLAN_DEF_TYPE_BRIDGE)
+        return yaml_error(node, error, "Key 'controller.connection-mode' is only valid for iterface type 'openvswitch bridge'");
+
+    if (g_strcmp0(scalar(node), "in-band") && g_strcmp0(scalar(node), "out-of-band"))
+        return yaml_error(node, error, "Value of 'connection-mode' needs to be 'in-band' or 'out-of-band'");
+
+    return handle_netdef_str(doc, node, data, error);
+}
+
+static gboolean
+verify_ovs_target(gboolean host_first, gchar* s) {
+    static guint dport = 6653; // the default port
+    g_autofree gchar* host = NULL;
+    g_autofree gchar* port = NULL;
+    gchar** vec = NULL;
+
+    /* Format tcp:host[:port] (or ssl:host[:port]) */
+    if (host_first) {
+        g_assert(s != NULL);
+        // IP6 host, indicated by bracketed notation ([..IPv6..])
+        if (s[0] == '[') {
+            gchar* tmp = NULL;
+            tmp = s+1; //get rid of '['
+            // append default port to unify parsing
+            if (!g_strrstr(tmp, "]:"))
+                vec = g_strsplit(g_strdup_printf("%s:%u", tmp, dport), "]:", 2);
+            else
+                vec = g_strsplit(tmp, "]:", 2);
+        // IP4 host
+        } else {
+            // append default port to unify parsing
+            if (!g_strrstr(s, ":"))
+                vec = g_strsplit(g_strdup_printf("%s:%u", s, dport), ":", 2);
+            else
+                vec = g_strsplit(s, ":", 2);
+        }
+        // host and port are always set
+        host = g_strdup(vec[0]); //set host alias
+        port = g_strdup(vec[1]); //set port alias
+        g_assert(vec[2] == NULL);
+        g_strfreev(vec);
+    /* Format ptcp:[port][:host] (or pssl:[port][:host]) */
+    } else {
+        // special case: "ptcp:" (no port, no host)
+        if (!g_strcmp0(s, ""))
+            port = g_strdup_printf("%u", dport);
+        else {
+            vec = g_strsplit(s, ":", 2);
+            port = g_strdup(vec[0]);
+            host = g_strdup(vec[1]);
+            // get rid of IPv6 brackets
+            if (host && host[0] == '[') {
+                char **split = g_strsplit_set(host, "[]", 3);
+                g_free(host);
+                host = g_strjoinv("", split);
+                g_strfreev(split);
+            }
+            g_assert(vec[2] == NULL);
+            g_strfreev(vec);
+        }
+    }
+
+    g_assert(port != NULL);
+    // special case where IPv6 notation contains '%iface' name
+    if (host && g_strrstr(host, "%")) {
+        gchar** split = g_strsplit (host, "%", 2);
+        g_free(host);
+        host = g_strdup(split[0]); // designated scope for IPv6 link-level addresses
+        g_assert(split[1] != NULL && split[2] == NULL);
+        //TODO: verify split[1] is an actual interface name
+        g_strfreev(split);
+    }
+
+    if (atoi(port) > 0 && atoi(port) <= 65535) {
+        if (!host)
+            return TRUE;
+        else if (host && (is_ip4_address(host) || is_ip6_address(host)))
+            return TRUE;
+    }
+    return FALSE;
+}
+
+static gboolean
+handle_ovs_bridge_controller_addresses(yaml_document_t* doc, yaml_node_t* node, const void* data, GError** error)
+{
+    if (cur_netdef->type != NETPLAN_DEF_TYPE_BRIDGE)
+        return yaml_error(node, error, "Key 'controller.addresses' is only valid for iterface type 'openvswitch bridge'");
+
+    for (yaml_node_item_t *i = node->data.sequence.items.start; i < node->data.sequence.items.top; i++) {
+        gchar** vec = NULL;
+        gboolean is_host = FALSE;
+        gboolean is_port = FALSE;
+        gboolean is_unix = FALSE;
+
+        yaml_node_t *entry = yaml_document_get_node(doc, *i);
+        assert_type(entry, YAML_SCALAR_NODE);
+        // we always need at least one colon
+        if (!strstr(scalar(entry), ":"))
+            return yaml_error(node, error, "Unsupported OVS controller target: %s", scalar(entry));
+
+        vec = g_strsplit (scalar(entry), ":", 2);
+
+        /* TODO: Add support for ssl/pssl, which needs private-key, certificate and ca-cert keys */
+        is_host = !g_strcmp0(vec[0], "tcp"); // or ssl
+        is_port = !g_strcmp0(vec[0], "ptcp"); // or pssl
+        is_unix = !g_strcmp0(vec[0], "unix") || !g_strcmp0(vec[0], "punix");
+
+        if (!cur_netdef->ovs_settings.controller.addresses)
+            cur_netdef->ovs_settings.controller.addresses = g_array_new(FALSE, FALSE, sizeof(char*));
+
+        /* Format: [p]unix:file */
+        if (is_unix && vec[1] != NULL && vec[2] == NULL) {
+            //TODO: verify vec[1] is a valid file/path (which does not exist, yet, at 'generate' stage)
+            char* s = g_strdup(scalar(entry));
+            g_array_append_val(cur_netdef->ovs_settings.controller.addresses, s);
+            g_strfreev(vec);
+            continue;
+        /* Format tcp:host[:port] (or ssl:host[:port]) */
+        } else if (is_host && verify_ovs_target(TRUE, vec[1])) {
+            char* s = g_strdup(scalar(entry));
+            g_array_append_val(cur_netdef->ovs_settings.controller.addresses, s);
+            g_strfreev(vec);
+            continue;
+        /* Format ptcp:[port][:host] (or pssl:[port][:host]) */
+        } else if (is_port && verify_ovs_target(FALSE, vec[1])) {
+            char* s = g_strdup(scalar(entry));
+            g_array_append_val(cur_netdef->ovs_settings.controller.addresses, s);
+            g_strfreev(vec);
+            continue;
+        }
+
+        g_strfreev(vec);
+        return yaml_error(node, error, "Unsupported OVS controller target: %s", scalar(entry));
+    }
+
+    return TRUE;
+}
+
+static const mapping_entry_handler ovs_controller_handlers[] = {
+    {"addresses", YAML_SEQUENCE_NODE, handle_ovs_bridge_controller_addresses, NULL, netdef_offset(ovs_settings.controller.addresses)},
+    {"connection-mode", YAML_SCALAR_NODE, handle_ovs_bridge_controller_connection_mode, NULL, netdef_offset(ovs_settings.controller.connection_mode)},
+    {NULL},
+};
 
 static const mapping_entry_handler ovs_backend_settings_handlers[] = {
     {"external-ids", YAML_MAPPING_NODE, handle_netdef_map, NULL, netdef_offset(ovs_settings.external_ids)},
@@ -1796,6 +1942,7 @@ static const mapping_entry_handler ovs_backend_settings_handlers[] = {
     {"mcast-snooping", YAML_SCALAR_NODE, handle_ovs_bridge_bool, NULL, netdef_offset(ovs_settings.mcast_snooping)},
     {"rstp", YAML_SCALAR_NODE, handle_ovs_bridge_bool, NULL, netdef_offset(ovs_settings.rstp)},
     {"protocols", YAML_SEQUENCE_NODE, handle_ovs_bridge_protocol, NULL, netdef_offset(ovs_settings.protocols)},
+    {"controller", YAML_MAPPING_NODE, NULL, ovs_controller_handlers},
     {NULL}
 };
 

--- a/src/parse.c
+++ b/src/parse.c
@@ -1819,7 +1819,6 @@ handle_ovs_bridge_controller_addresses(yaml_document_t* doc, yaml_node_t* node, 
 
         vec = g_strsplit (scalar(entry), ":", 2);
 
-        /* TODO: We probably need private-key, certificate and ca-cert keys, to fully support ssl: and pssl: */
         is_host = !g_strcmp0(vec[0], "tcp") || !g_strcmp0(vec[0], "ssl");
         is_port = !g_strcmp0(vec[0], "ptcp") || !g_strcmp0(vec[0], "pssl");
         is_unix = !g_strcmp0(vec[0], "unix") || !g_strcmp0(vec[0], "punix");
@@ -2187,10 +2186,30 @@ handle_network_type(yaml_document_t* doc, yaml_node_t* node, const void* data, G
     return TRUE;
 }
 
+static const mapping_entry_handler ovs_global_ssl_handlers[] = {
+    {"ca-cert", YAML_SCALAR_NODE, handle_auth_str, NULL, auth_offset(ca_certificate)},
+    {"certificate", YAML_SCALAR_NODE, handle_auth_str, NULL, auth_offset(client_certificate)},
+    {"private-key", YAML_SCALAR_NODE, handle_auth_str, NULL, auth_offset(client_key)},
+    {NULL}
+};
+
+static gboolean
+handle_ovs_global_ssl(yaml_document_t* doc, yaml_node_t* node, const void* _, GError** error)
+{
+    gboolean ret;
+
+    cur_auth = &(ovs_settings_global.ssl);
+    ret = process_mapping(doc, node, ovs_global_ssl_handlers, NULL, error);
+    cur_auth = NULL;
+
+    return ret;
+}
+
 static const mapping_entry_handler ovs_network_settings_handlers[] = {
     {"external-ids", YAML_MAPPING_NODE, handle_network_ovs_settings_global, NULL, ovs_settings_offset(external_ids)},
     {"other-config", YAML_MAPPING_NODE, handle_network_ovs_settings_global, NULL, ovs_settings_offset(other_config)},
     {"protocols", YAML_SEQUENCE_NODE, handle_network_ovs_settings_global_protocol, NULL, ovs_settings_offset(protocols)},
+    {"ssl", YAML_MAPPING_NODE, handle_ovs_global_ssl},
     {NULL}
 };
 

--- a/src/parse.h
+++ b/src/parse.h
@@ -198,6 +198,11 @@ typedef struct dhcp_overrides {
     guint metric;
 } NetplanDHCPOverrides;
 
+typedef struct ovs_controller {
+    char* connection_mode;
+    GArray* addresses;
+} NetplanOVSController;
+
 typedef struct ovs_settings {
     GHashTable* external_ids;
     GHashTable* other_config;
@@ -206,6 +211,7 @@ typedef struct ovs_settings {
     gboolean mcast_snooping;
     GArray* protocols;
     gboolean rstp;
+    NetplanOVSController controller;
 } NetplanOVSSettings;
 
 /**

--- a/src/parse.h
+++ b/src/parse.h
@@ -212,6 +212,7 @@ typedef struct ovs_settings {
     GArray* protocols;
     gboolean rstp;
     NetplanOVSController controller;
+    NetplanAuthenticationSettings ssl;
 } NetplanOVSSettings;
 
 /**

--- a/src/validation.c
+++ b/src/validation.c
@@ -57,6 +57,79 @@ is_ip6_address(const char* address)
     return FALSE;
 }
 
+/* Check sanity of OpenVSwitch controller targets */
+gboolean
+validate_ovs_target(gboolean host_first, gchar* s) {
+    static guint dport = 6653; // the default port
+    g_autofree gchar* host = NULL;
+    g_autofree gchar* port = NULL;
+    gchar** vec = NULL;
+
+    /* Format tcp:host[:port] or ssl:host[:port] */
+    if (host_first) {
+        g_assert(s != NULL);
+        // IP6 host, indicated by bracketed notation ([..IPv6..])
+        if (s[0] == '[') {
+            gchar* tmp = NULL;
+            tmp = s+1; //get rid of leading '['
+            // append default port to unify parsing
+            if (!g_strrstr(tmp, "]:"))
+                vec = g_strsplit(g_strdup_printf("%s:%u", tmp, dport), "]:", 2);
+            else
+                vec = g_strsplit(tmp, "]:", 2);
+        // IP4 host
+        } else {
+            // append default port to unify parsing
+            if (!g_strrstr(s, ":"))
+                vec = g_strsplit(g_strdup_printf("%s:%u", s, dport), ":", 2);
+            else
+                vec = g_strsplit(s, ":", 2);
+        }
+        // host and port are always set
+        host = g_strdup(vec[0]); //set host alias
+        port = g_strdup(vec[1]); //set port alias
+        g_assert(vec[2] == NULL);
+        g_strfreev(vec);
+    /* Format ptcp:[port][:host] or pssl:[port][:host] */
+    } else {
+        // special case: "ptcp:" (no port, no host)
+        if (!g_strcmp0(s, ""))
+            port = g_strdup_printf("%u", dport);
+        else {
+            vec = g_strsplit(s, ":", 2);
+            port = g_strdup(vec[0]);
+            host = g_strdup(vec[1]);
+            // get rid of leading & trailing IPv6 brackets
+            if (host && host[0] == '[') {
+                char **split = g_strsplit_set(host, "[]", 3);
+                g_free(host);
+                host = g_strjoinv("", split);
+                g_strfreev(split);
+            }
+            g_assert(vec[2] == NULL);
+            g_strfreev(vec);
+        }
+    }
+
+    g_assert(port != NULL);
+    // special case where IPv6 notation contains '%iface' name
+    if (host && g_strrstr(host, "%")) {
+        gchar** split = g_strsplit (host, "%", 2);
+        g_free(host);
+        host = g_strdup(split[0]); // designated scope for IPv6 link-level addresses
+        g_assert(split[1] != NULL && split[2] == NULL);
+        g_strfreev(split);
+    }
+
+    if (atoi(port) > 0 && atoi(port) <= 65535) {
+        if (!host)
+            return TRUE;
+        else if (host && (is_ip4_address(host) || is_ip6_address(host)))
+            return TRUE;
+    }
+    return FALSE;
+}
+
 /************************************************
  * Validation for grammar and backend rules.
  ************************************************/

--- a/src/validation.h
+++ b/src/validation.h
@@ -22,6 +22,7 @@
 
 gboolean is_ip4_address(const char* address);
 gboolean is_ip6_address(const char* address);
+gboolean validate_ovs_target(gboolean host_first, gchar* s);
 
 gboolean
 validate_netdef_grammar(NetplanNetDefinition* nd, yaml_node_t* node, GError** error);

--- a/tests/generator/test_ovs.py
+++ b/tests/generator/test_ovs.py
@@ -541,6 +541,11 @@ ExecStart=/usr/bin/ovs-vsctl set Bridge br0 protocols=OpenFlow10,OpenFlow11,Open
           addresses: ["ptcp:", "ptcp:1337", "ptcp:1337:[fe80::1234%eth0]", "pssl:1337:[fe80::1]", "ssl:10.10.10.1",\
                       tcp:127.0.0.1:1337, "tcp:[fe80::1234%eth0]", "tcp:[fe80::1]:1337", unix:/some/path, punix:other/path]
           connection-mode: out-of-band
+  openvswitch:
+    ssl:
+      ca-cert: /another/path
+      certificate: /some/path
+      private-key: /key/path
 ''')
         self.assert_ovs({'br0.service': OVS_VIRTUAL % {'iface': 'br0', 'extra':
                         '''
@@ -553,8 +558,9 @@ ExecStart=/usr/bin/ovs-vsctl set Port br0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set-fail-mode br0 standalone
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 mcast_snooping_enable=false
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 rstp_enable=false
-ExecStart=/usr/bin/ovs-vsctl set-controller br0 ptcp: ptcp:1337 ptcp:1337:[fe80::1234%eth0] pssl:1337:[fe80::1] ssl:10.10.10.1 \
-tcp:127.0.0.1:1337 tcp:[fe80::1234%eth0] tcp:[fe80::1]:1337 unix:/some/path punix:other/path
+ExecStart=/usr/bin/ovs-vsctl --private-key /key/path --certificate /some/path --ca-cert /another/path set-controller br0 ptcp: \
+ptcp:1337 ptcp:1337:[fe80::1234%eth0] pssl:1337:[fe80::1] ssl:10.10.10.1 tcp:127.0.0.1:1337 tcp:[fe80::1234%eth0] \
+tcp:[fe80::1]:1337 unix:/some/path punix:other/path
 ExecStart=/usr/bin/ovs-vsctl set controller br0 connection-mode=out-of-band
 '''}})
         # Confirm that the networkd config is still sane
@@ -593,9 +599,9 @@ ExecStart=/usr/bin/ovs-vsctl set controller br0 connection-mode=out-of-band
     br0:
       openvswitch:
         controller:
-          addresses: [pssl:65536]
+          addresses: [ptcp:65536]
 ''', expect_fail=True)
-        self.assertIn("Unsupported OVS controller target: pssl:65536", err)
+        self.assertIn("Unsupported OVS controller target: ptcp:65536", err)
         self.assert_ovs({})
         self.assert_networkd({})
 
@@ -635,5 +641,21 @@ ExecStart=/usr/bin/ovs-vsctl set controller br0 connection-mode=out-of-band
           addresses: [unix:/some/socket]
 ''', expect_fail=True)
         self.assertIn("Key 'controller.addresses' is only valid for iterface type 'openvswitch bridge'", err)
+        self.assert_ovs({})
+        self.assert_networkd({})
+
+    def test_missing_ssl(self):
+        err = self.generate('''network:
+  version: 2
+  bridges:
+    br0:
+      openvswitch:
+        controller:
+          addresses: [ssl:10.10.10.1]
+  openvswitch:
+    ssl: {}
+''', expect_fail=True)
+        self.assertIn("ERROR: openvswitch bridge controller target 'ssl:10.10.10.1' needs SSL configuration, but global \
+'openvswitch.ssl' settings are not set", err)
         self.assert_ovs({})
         self.assert_networkd({})

--- a/tests/generator/test_ovs.py
+++ b/tests/generator/test_ovs.py
@@ -531,14 +531,16 @@ ExecStart=/usr/bin/ovs-vsctl set Bridge br0 protocols=OpenFlow10,OpenFlow11,Open
 ''', expect_fail=True)
         self.assertIn("Key 'protocols' is only valid for iterface type 'openvswitch bridge'", err)
 
-    def test_bridge_controller_addresses(self):
+    def test_bridge_controller(self):
         self.generate('''network:
   version: 2
   bridges:
     br0:
       openvswitch:
         controller:
-          addresses: ["ptcp:", "ptcp:1337", "ptcp:1337:[fe80::1234%eth0]", "ptcp:1337:[fe80::1]", "tcp:10.10.10.1", tcp:127.0.0.1:1337, "tcp:[fe80::1234%eth0]", "tcp:[fe80::1]:1337", unix:/some/path, punix:/other/path]
+          addresses: ["ptcp:", "ptcp:1337", "ptcp:1337:[fe80::1234%eth0]", "pssl:1337:[fe80::1]", "ssl:10.10.10.1",\
+                      tcp:127.0.0.1:1337, "tcp:[fe80::1234%eth0]", "tcp:[fe80::1]:1337", unix:/some/path, punix:other/path]
+          connection-mode: out-of-band
 ''')
         self.assert_ovs({'br0.service': OVS_VIRTUAL % {'iface': 'br0', 'extra':
                         '''
@@ -551,6 +553,87 @@ ExecStart=/usr/bin/ovs-vsctl set Port br0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set-fail-mode br0 standalone
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 mcast_snooping_enable=false
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 rstp_enable=false
+ExecStart=/usr/bin/ovs-vsctl set-controller br0 ptcp: ptcp:1337 ptcp:1337:[fe80::1234%eth0] pssl:1337:[fe80::1] ssl:10.10.10.1 \
+tcp:127.0.0.1:1337 tcp:[fe80::1234%eth0] tcp:[fe80::1]:1337 unix:/some/path punix:other/path
+ExecStart=/usr/bin/ovs-vsctl set controller br0 connection-mode=out-of-band
 '''}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({'br0.network': ND_EMPTY % ('br0', 'ipv6')})
+
+    def test_bridge_controller_invalid_target(self):
+        err = self.generate('''network:
+  version: 2
+  bridges:
+    br0:
+      openvswitch:
+        controller:
+          addresses: [ptcp]
+''', expect_fail=True)
+        self.assertIn("Unsupported OVS controller target: ptcp", err)
+        self.assert_ovs({})
+        self.assert_networkd({})
+
+    def test_bridge_controller_invalid_target_ip(self):
+        err = self.generate('''network:
+  version: 2
+  bridges:
+    br0:
+      openvswitch:
+        controller:
+          addresses: ["tcp:[fe80:1234%eth0]"]
+''', expect_fail=True)
+        self.assertIn("Unsupported OVS controller target: tcp:[fe80:1234%eth0]", err)
+        self.assert_ovs({})
+        self.assert_networkd({})
+
+    def test_bridge_controller_invalid_target_port(self):
+        err = self.generate('''network:
+  version: 2
+  bridges:
+    br0:
+      openvswitch:
+        controller:
+          addresses: [pssl:65536]
+''', expect_fail=True)
+        self.assertIn("Unsupported OVS controller target: pssl:65536", err)
+        self.assert_ovs({})
+        self.assert_networkd({})
+
+    def test_bridge_controller_invalid_connection_mode(self):
+        err = self.generate('''network:
+  version: 2
+  bridges:
+    br0:
+      openvswitch:
+        controller:
+          connection-mode: INVALID
+''', expect_fail=True)
+        self.assertIn("Value of 'connection-mode' needs to be 'in-band' or 'out-of-band'", err)
+        self.assert_ovs({})
+        self.assert_networkd({})
+
+    def test_bridge_controller_connection_mode_invalid_interface_type(self):
+        err = self.generate('''network:
+  version: 2
+  bonds:
+    mybond:
+      openvswitch:
+        controller:
+          connection-mode: in-band
+''', expect_fail=True)
+        self.assertIn("Key 'controller.connection-mode' is only valid for iterface type 'openvswitch bridge'", err)
+        self.assert_ovs({})
+        self.assert_networkd({})
+
+    def test_bridge_controller_addresses_invalid_interface_type(self):
+        err = self.generate('''network:
+  version: 2
+  bonds:
+    mybond:
+      openvswitch:
+        controller:
+          addresses: [unix:/some/socket]
+''', expect_fail=True)
+        self.assertIn("Key 'controller.addresses' is only valid for iterface type 'openvswitch bridge'", err)
+        self.assert_ovs({})
+        self.assert_networkd({})

--- a/tests/integration/ovs.py
+++ b/tests/integration/ovs.py
@@ -29,12 +29,41 @@ from base import IntegrationTestsBase, test_backends
 
 class _CommonTests():
 
+    def test_bridge_base(self):
+        self.setup_eth(None, False)
+        self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-br', 'ovsbr'])
+        with open(self.config, 'w') as f:
+            f.write('''network:
+  ethernets:
+    %(ec)s: {}
+    %(e2c)s: {}
+  bridges:
+    ovsbr:
+      addresses: [192.170.1.1/24]
+      interfaces: [%(ec)s, %(e2c)s]
+      openvswitch:
+        fail-mode: secure
+        controller:
+          addresses: [tcp:127.0.0.1, "pssl:1337:[::1]", unix:/some/socket]
+''' % {'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
+        self.generate_and_settle()
+        # Basic verification that the interfaces/ports are in OVS
+        out = subprocess.check_output(['ovs-vsctl', 'show'])
+        self.assertIn(b'    Bridge ovsbr', out)
+        self.assertIn(b'        Controller "tcp:127.0.0.1"', out)
+        self.assertIn(b'        Controller "pssl:1337:[::1]"', out)
+        self.assertIn(b'        Controller "unix:/some/socket"', out)
+        self.assertIn(b'        fail_mode: secure', out)
+        self.assertIn(b'        Port eth42\n            Interface eth42', out)
+        self.assertIn(b'        Port eth43\n            Interface eth43', out)
+        # Verify the bridge was tagged 'netplan:true' correctly
+        out = subprocess.check_output(['ovs-vsctl', '--columns=name,external-ids', 'list', 'Port'])
+        self.assertIn(b'ovsbr\nexternal_ids        : {netplan="true"}', out)
+
     def test_bond_base(self):
         self.setup_eth(None, False)
         self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-br', 'ovsbr'])
         self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-port', 'mybond'])
-        # XXX: Temporary bridge setup, until netplan-ovs can do it itself
-        subprocess.call(['ovs-vsctl', 'add-br', 'ovsbr'])
         with open(self.config, 'w') as f:
             f.write('''network:
   ethernets:
@@ -59,7 +88,7 @@ class _CommonTests():
         self.assertIn(b'        Port mybond', out)
         self.assertIn(b'            Interface eth42', out)
         self.assertIn(b'            Interface eth43', out)
-        # Verify the bridge was tagged 'netplan:true' correctly
+        # Verify the bond was tagged 'netplan:true' correctly
         out = subprocess.check_output(['ovs-vsctl', '--columns=name,external-ids', 'list', 'Port'])
         self.assertIn(b'mybond\nexternal_ids        : {netplan="true"}', out)
         # Verify bond params

--- a/tests/integration/ovs.py
+++ b/tests/integration/ovs.py
@@ -37,6 +37,11 @@ class _CommonTests():
   ethernets:
     %(ec)s: {}
     %(e2c)s: {}
+  openvswitch:
+    ssl:
+      ca-cert: /some/ca-cert.pem
+      certificate: /another/certificate.pem
+      private-key: /private/key.pem
   bridges:
     ovsbr:
       addresses: [192.170.1.1/24]


### PR DESCRIPTION
## Description
Adds support for the OpenVSwitch Bridge `controller.addresses` config key to specify OpenFlow controller targets and `controller.connection-mode` config key, to define if the controller shall be used in a `in-band` or `out-of-band` configuration.

Additionally, it adds support for the following global `openvswitch.ssl` configs, which need to be used if a `ssl:` or `pssl:` OpenFlow controller target is to be used.
* ca-cert
* certificate
* private-key

It adds a new integration test in `tests/integration/ovs.py`, which we need to make sure to integrate into the debian package (via `debian/tests/control`), to have it run during `autopkgtest`.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [x] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Closes an open bug in Launchpad.

