### PR TITLE
Fix autopkgtest on arm64 with NM 1.24

### DIFF
--- a/netplan/cli/utils.py
+++ b/netplan/cli/utils.py
@@ -23,6 +23,8 @@ import fnmatch
 import argparse
 import subprocess
 import netifaces
+import re
+import glob
 
 NM_SERVICE_NAME = 'NetworkManager.service'
 NM_SNAP_SERVICE_NAME = 'snap.network-manager.networkmanager.service'
@@ -53,6 +55,19 @@ def nm_running():  # pragma: nocover (covered in autopkgtest)
         return True
     except (OSError, subprocess.SubprocessError):
         return False
+
+
+def nm_interfaces(paths=glob.glob('/run/NetworkManager/system-connections/netplan-*')):
+    pat = re.compile('^interface-name=(.*)$')
+    interfaces = []
+    for path in paths:
+        with open(path, 'r') as f:
+            for line in f:
+                m = pat.match(line)
+                if m:
+                    interfaces.append(m.group(1))
+                    break  # skip to next file
+    return interfaces
 
 
 def systemctl_network_manager(action, sync=False):  # pragma: nocover (covered in autopkgtest)

--- a/netplan/cli/utils.py
+++ b/netplan/cli/utils.py
@@ -24,7 +24,6 @@ import argparse
 import subprocess
 import netifaces
 import re
-import glob
 
 NM_SERVICE_NAME = 'NetworkManager.service'
 NM_SNAP_SERVICE_NAME = 'snap.network-manager.networkmanager.service'
@@ -57,7 +56,7 @@ def nm_running():  # pragma: nocover (covered in autopkgtest)
         return False
 
 
-def nm_interfaces(paths=glob.glob('/run/NetworkManager/system-connections/netplan-*')):
+def nm_interfaces(paths):
     pat = re.compile('^interface-name=(.*)$')
     interfaces = []
     for path in paths:

--- a/tests/integration/ethernets.py
+++ b/tests/integration/ethernets.py
@@ -156,12 +156,6 @@ class _CommonTests():
 ''' % {'r': self.backend, 'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
         self.start_dnsmasq(None, self.dev_e2_ap)
         self.generate_and_settle()
-        # generate_and_settle() ('netplan apply') can bring down the interfaces (incl. our 2nd DHCP server
-        # at veth43/dev_e_ap). Re-configure the AP's IP address to fix the DHCP server at dev_e2_ap.
-        out = subprocess.check_output(['ip', 'a', 'show', 'dev', self.dev_e2_ap])
-        if self.dev_e2_ap_ip4.encode('utf-8') not in out:
-            subprocess.check_call(['ip', 'a', 'add', self.dev_e2_ap_ip4, 'dev', self.dev_e2_ap])
-            subprocess.check_call(['ip', 'link', 'set', self.dev_e2_ap, 'up'])
         if self.backend == 'NetworkManager':
             self.nm_online_full(self.dev_e2_client)
         self.assert_iface_up(self.dev_e_client,

--- a/tests/integration/ethernets.py
+++ b/tests/integration/ethernets.py
@@ -156,6 +156,14 @@ class _CommonTests():
 ''' % {'r': self.backend, 'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
         self.start_dnsmasq(None, self.dev_e2_ap)
         self.generate_and_settle()
+        # generate_and_settle() ('netplan apply') can bring down the interfaces (incl. our 2nd DHCP server
+        # at veth43/dev_e_ap). Re-configure the AP's IP address to fix the DHCP server at dev_e2_ap.
+        out = subprocess.check_output(['ip', 'a', 'show', 'dev', self.dev_e2_ap])
+        if self.dev_e2_ap_ip4.encode('utf-8') not in out:
+            subprocess.check_call(['ip', 'a', 'add', self.dev_e2_ap_ip4, 'dev', self.dev_e2_ap])
+            subprocess.check_call(['ip', 'link', 'set', self.dev_e2_ap, 'up'])
+        if self.backend == 'NetworkManager':
+            self.nm_online_full(self.dev_e2_client)
         self.assert_iface_up(self.dev_e_client,
                              ['inet 172.16.5.3/20'],
                              ['inet 192.168.5',   # old DHCP

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,49 @@
+#!/usr/bin/python3
+#
+# Copyright (C) 2020 Canonical, Ltd.
+# Author: Lukas Märdian <lukas.maerdian@canonical.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import unittest
+import tempfile
+import glob
+
+import netplan.cli.utils as utils
+
+
+class TestUtils(unittest.TestCase):
+
+    def setUp(self):
+        self.workdir = tempfile.TemporaryDirectory()
+        os.makedirs(os.path.join(self.workdir.name, 'etc/netplan'))
+        os.makedirs(os.path.join(self.workdir.name,
+                    'run/NetworkManager/system-connections'))
+
+    def _create_nm_keyfile(self, filename, ifname):
+        with open(os.path.join(self.workdir.name,
+                  'run/NetworkManager/system-connections/', filename), 'w') as f:
+            f.write('[connection]\n')
+            f.write('key=value\n')
+            f.write('interface-name=%s\n' % ifname)
+            f.write('key2=value2\n')
+
+    def test_nm_interfaces(self):
+        self._create_nm_keyfile('netplan-test.nmconnection', 'eth0')
+        self._create_nm_keyfile('netplan-test2.nmconnection', 'eth1')
+        ifaces = utils.nm_interfaces(glob.glob(os.path.join(self.workdir.name,
+                                     'run/NetworkManager/system-connections/*.nmconnection')))
+        self.assertTrue('eth0' in ifaces)
+        self.assertTrue('eth1' in ifaces)
+        self.assertTrue(len(ifaces) == 2)


### PR DESCRIPTION
## Description
On `arm64` we had a test failure in `tests/integration/ethernets.py` -> `test_manual_addresses`, which was caused by the fact that `netplan apply` was disconnecting ALL available network interfaces via `nmcli`, in order to reload the new netplan config. This way the IP of the 2nd test DHCP server (dnsmasq on `veth43`) was lost and did not provide correct responses for the rest of the test.

It is not necessary to take all interfaces down, only the ones which are (or were) configured via netplan. This was fixed in the `netplan apply` command.

**Note:** This should make its way into the Groovy package as a distro-patch, to avoid future autopkgtest failures.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Closes an open bug in Launchpad.

