### PR TITLE
Base support for OVS fake VLAN bridges.

### DIFF
--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -143,6 +143,12 @@ Virtual devices
      If openvswitch is not available on the system, netplan treats the presence of
      openvswitch configuration as an error.
 
+     Any supported network device that is declared with the ``openvswitch`` mapping
+     (or any bond/bridge that includes an interface with an openvswitch configuration)
+     will be created in openvswitch instead of the defined renderer.
+     In the case of a ``vlan`` definition declared the same way, netplan will create
+     a fake VLAN bridge in openvswitch with the requested vlan properties.
+
      ``external-ids`` (mapping) – since **0.100**
      :   Passed-through directly to OpenVSwitch
 

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -583,7 +583,7 @@ write_network_file(const NetplanNetDefinition* def, const char* rootdir, const c
             g_string_append_printf(network, "PrimarySlave=true\n");
     }
 
-    if (def->has_vlans) {
+    if (def->has_vlans && def->backend != NETPLAN_BACKEND_OVS) {
         /* iterate over all netdefs to find VLANs attached to us */
         GList *l = netdefs_ordered;
         const NetplanNetDefinition* nd;

--- a/src/openvswitch.c
+++ b/src/openvswitch.c
@@ -326,6 +326,15 @@ write_ovs_conf(const NetplanNetDefinition* def, const char* rootdir)
                 append_systemd_stop(cmds, OPENVSWITCH_OVS_VSCTL " --if-exists del-port %s", def->id);
                 break;
 
+            case NETPLAN_DEF_TYPE_VLAN:
+                g_assert(def->vlan_link);
+                dependency = def->vlan_link->id;
+                /* Create a fake VLAN bridge */
+                append_systemd_cmd(cmds, OPENVSWITCH_OVS_VSCTL " --may-exist add-br %s %s %i", def->id, def->vlan_link->id, def->vlan_id)
+                append_systemd_stop(cmds, OPENVSWITCH_OVS_VSCTL " del-br %s", def->id);
+                write_ovs_tag_netplan(def->id, cmds);
+                break;
+
             default: g_assert_not_reached(); // LCOV_EXCL_LINE
         }
 

--- a/tests/generator/test_ovs.py
+++ b/tests/generator/test_ovs.py
@@ -946,8 +946,7 @@ ExecStop=/usr/bin/ovs-vsctl --if-exists del-port patch1-0
       link: br0
       openvswitch: {}
 ''')
-        self.assert_ovs({'br0.service': OVS_VIRTUAL % {'iface': 'br0', 'extra':
-                        '''
+        self.assert_ovs({'br0.service': OVS_VIRTUAL % {'iface': 'br0', 'extra': '''
 [Service]
 Type=oneshot
 RemainAfterExit=yes
@@ -959,7 +958,7 @@ ExecStart=/usr/bin/ovs-vsctl set Bridge br0 mcast_snooping_enable=false
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 rstp_enable=false
 '''},
                          'br0.100.service': OVS_VIRTUAL % {'iface': 'br0.100', 'extra':
-                        '''Requires=netplan-ovs-br0.service
+                                                           '''Requires=netplan-ovs-br0.service
 After=netplan-ovs-br0.service
 
 [Service]
@@ -971,4 +970,4 @@ ExecStart=/usr/bin/ovs-vsctl set Port br0.100 external-ids:netplan=true
 '''}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({'br0.network': ND_WITHIP % ('br0', '192.168.1.1/24'),
-                              'br0.100.network': ND_EMPTY % ('br0.100', 'ipv6'),})
+                              'br0.100.network': ND_EMPTY % ('br0.100', 'ipv6')})

--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -94,7 +94,7 @@ class IntegrationTestsBase(unittest.TestCase):
 
     def tearDown(self):
         subprocess.call(['systemctl', 'stop', 'NetworkManager', 'systemd-networkd', 'netplan-wpa-*',
-                                              'systemd-networkd.socket'])
+                         'netplan-ovs-*', 'systemd-networkd.socket'])
         # NM has KillMode=process and leaks dhclient processes
         subprocess.call(['systemctl', 'kill', 'NetworkManager'])
         subprocess.call(['systemctl', 'reset-failed', 'NetworkManager', 'systemd-networkd'],

--- a/tests/integration/ovs.py
+++ b/tests/integration/ovs.py
@@ -29,6 +29,55 @@ from base import IntegrationTestsBase, test_backends
 
 class _CommonTests():
 
+    # FIXME: Why does this test need to run first in order to pass?
+    #   We must leave some dirty state somewhere in the other tests
+    def test_1_bridge_vlan(self):
+        self.setup_eth(None, True)
+        self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-br', 'br-%s' % self.dev_e_client])
+        self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-br', 'br-data'])
+        self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-br', 'br-%s.100' % self.dev_e_client])
+        with open(self.config, 'w') as f:
+            f.write('''network:
+    version: 2
+    ethernets:
+        %(ec)s:
+            mtu: 9000
+    bridges:
+        br-%(ec)s:
+            dhcp4: true
+            mtu: 9000
+            interfaces: [%(ec)s]
+            openvswitch: {}
+        br-data:
+            openvswitch: {}
+            addresses: [192.168.20.1/16]
+    vlans:
+        br-%(ec)s.100:
+            id: 100
+            link: br-%(ec)s
+            openvswitch: {}''' % {'ec': self.dev_e_client})
+        self.generate_and_settle()
+        # Basic verification that the interfaces/ports are set up in OVS
+        out = subprocess.check_output(['ovs-vsctl', 'show'])
+        self.assertIn(b'    Bridge br-%b' % self.dev_e_client.encode(), out)
+        self.assertIn(b'''        Port %(ec)b
+            Interface %(ec)b''' % {b'ec': self.dev_e_client.encode()}, out)
+        self.assertIn(b'''        Port br-%(ec)b.100
+            tag: 100
+            Interface br-%(ec)b.100
+                type: internal''' % {b'ec': self.dev_e_client.encode()}, out)
+        self.assertIn(b'    Bridge br-data', out)
+        self.assert_iface('br-%s' % self.dev_e_client,
+                          ['inet 192.168.5.[0-9]+/16', 'mtu 9000'])  # from DHCP
+        self.assert_iface('br-data', ['inet 192.168.20.1/16'])
+        self.assert_iface(self.dev_e_client, ['mtu 9000', 'master ovs-system'])
+        vid = subprocess.check_output(['ovs-vsctl', 'br-to-vlan',
+                                       'br-%s.100' % self.dev_e_client])
+        self.assertIn(b'100', vid)
+        parent = subprocess.check_output(['ovs-vsctl', 'br-to-parent',
+                                          'br-%s.100' % self.dev_e_client])
+        self.assertIn(b'br-%b' % self.dev_e_client.encode(), out)
+
     def test_bridge_base(self):
         self.setup_eth(None, False)
         self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-br', 'ovsbr'])
@@ -138,42 +187,6 @@ class _CommonTests():
                 options: {peer=patch0-1}''', out)
         self.assert_iface('br0', ['inet 192.168.1.1/24'])
         self.assert_iface('br1', ['inet 192.168.2.1/24'])
-
-    def test_bridge_vlan(self):
-        self.setup_eth(None, True)
-        self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-br', 'br-%s' % self.dev_e_client])
-        self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-br', 'br-data'])
-        with open(self.config, 'w') as f:
-            f.write('''network:
-    version: 2
-    ethernets:
-        %(ec)s:
-            mtu: 9000
-    bridges:
-        br-%(ec)s:
-            dhcp4: true
-            mtu: 9000
-            interfaces: [%(ec)s]
-            openvswitch: {}
-        br-data:
-            openvswitch: {}
-            addresses: [192.168.20.1/16]
-#    vlans:
-#        br-%(ec)s.100:
-#            id: 100
-#            link: br-%(ec)s
-#            openvswitch: {}''' % {'ec': self.dev_e_client})
-        self.generate_and_settle()
-        # Basic verification that the interfaces/ports are set up in OVS
-        out = subprocess.check_output(['ovs-vsctl', 'show'])
-        self.assertIn(b'    Bridge br-%b' % self.dev_e_client.encode(), out)
-        self.assertIn(b'''        Port %(ec)b
-            Interface %(ec)b''' % {b'ec': self.dev_e_client.encode()}, out)
-        self.assertIn(b'    Bridge br-data', out)
-        self.assert_iface('br-%s' % self.dev_e_client,
-                          ['inet 192.168.5.[0-9]+/16', 'mtu 9000'])  # from DHCP
-        self.assert_iface('br-data', ['inet 192.168.20.1/16'])
-        self.assert_iface(self.dev_e_client, ['mtu 9000', 'master ovs-system'])
 
 
 @unittest.skipIf("networkd" not in test_backends,


### PR DESCRIPTION
## Description

The spec defined fake VLAN bridge structures, but wasn't very clear about it being in scope. Let's add those now.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Closes an open bug in Launchpad.

