### PR TITLE
OVS: Improve unit- & integration tests, throw error about unsupported OVS interfaces

### DIFF
--- a/src/networkd.c
+++ b/src/networkd.c
@@ -567,17 +567,14 @@ write_network_file(const NetplanNetDefinition* def, const char* rootdir, const c
         g_string_append(network, "ConfigureWithoutCarrier=yes\n");
 
     if (def->bridge && def->backend != NETPLAN_BACKEND_OVS) {
-        NetplanNetDefinition* bridge = g_hash_table_lookup(netdefs, def->bridge);
-        if (bridge && bridge->backend != NETPLAN_BACKEND_OVS) {
-            g_string_append_printf(network, "Bridge=%s\n", def->bridge);
+        g_string_append_printf(network, "Bridge=%s\n", def->bridge);
 
-            if (def->bridge_params.path_cost || def->bridge_params.port_priority)
-                g_string_append_printf(network, "\n[Bridge]\n");
-            if (def->bridge_params.path_cost)
-                g_string_append_printf(network, "Cost=%u\n", def->bridge_params.path_cost);
-            if (def->bridge_params.port_priority)
-                g_string_append_printf(network, "Priority=%u\n", def->bridge_params.port_priority);
-        }
+        if (def->bridge_params.path_cost || def->bridge_params.port_priority)
+            g_string_append_printf(network, "\n[Bridge]\n");
+        if (def->bridge_params.path_cost)
+            g_string_append_printf(network, "Cost=%u\n", def->bridge_params.path_cost);
+        if (def->bridge_params.port_priority)
+            g_string_append_printf(network, "Priority=%u\n", def->bridge_params.port_priority);
     }
     if (def->bond && def->backend != NETPLAN_BACKEND_OVS) {
         g_string_append_printf(network, "Bond=%s\n", def->bond);

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -567,14 +567,17 @@ write_network_file(const NetplanNetDefinition* def, const char* rootdir, const c
         g_string_append(network, "ConfigureWithoutCarrier=yes\n");
 
     if (def->bridge && def->backend != NETPLAN_BACKEND_OVS) {
-        g_string_append_printf(network, "Bridge=%s\n", def->bridge);
+        NetplanNetDefinition* bridge = g_hash_table_lookup(netdefs, def->bridge);
+        if (bridge && bridge->backend != NETPLAN_BACKEND_OVS) {
+            g_string_append_printf(network, "Bridge=%s\n", def->bridge);
 
-        if (def->bridge_params.path_cost || def->bridge_params.port_priority)
-            g_string_append_printf(network, "\n[Bridge]\n");
-        if (def->bridge_params.path_cost)
-            g_string_append_printf(network, "Cost=%u\n", def->bridge_params.path_cost);
-        if (def->bridge_params.port_priority)
-            g_string_append_printf(network, "Priority=%u\n", def->bridge_params.port_priority);
+            if (def->bridge_params.path_cost || def->bridge_params.port_priority)
+                g_string_append_printf(network, "\n[Bridge]\n");
+            if (def->bridge_params.path_cost)
+                g_string_append_printf(network, "Cost=%u\n", def->bridge_params.path_cost);
+            if (def->bridge_params.port_priority)
+                g_string_append_printf(network, "Priority=%u\n", def->bridge_params.port_priority);
+        }
     }
     if (def->bond && def->backend != NETPLAN_BACKEND_OVS) {
         g_string_append_printf(network, "Bond=%s\n", def->bond);

--- a/src/openvswitch.c
+++ b/src/openvswitch.c
@@ -326,7 +326,10 @@ write_ovs_conf(const NetplanNetDefinition* def, const char* rootdir)
                 append_systemd_stop(cmds, OPENVSWITCH_OVS_VSCTL " --if-exists del-port %s", def->id);
                 break;
 
-            default: g_assert_not_reached(); // LCOV_EXCL_LINE
+            default:
+                g_fprintf(stderr, "%s: This device type is not supported with the OpenVSwitch backend\n", def->id);
+                exit(1);
+                break;
         }
 
         /* Try writing out a base config */

--- a/tests/generator/test_ovs.py
+++ b/tests/generator/test_ovs.py
@@ -377,8 +377,8 @@ ExecStart=/usr/bin/ovs-vsctl set Bridge br0 mcast_snooping_enable=false
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 rstp_enable=false
 '''}})
         # Confirm that the networkd config is still sane
-        self.assert_networkd({'eth1.network': '[Match]\nName=eth1\n\n[Network]\nLinkLocalAddressing=no\n',
-                              'eth2.network': '[Match]\nName=eth2\n\n[Network]\nLinkLocalAddressing=no\n',
+        self.assert_networkd({'eth1.network': '[Match]\nName=eth1\n\n[Network]\nLinkLocalAddressing=no\nBridge=br0\n',
+                              'eth2.network': '[Match]\nName=eth2\n\n[Network]\nLinkLocalAddressing=no\nBridge=br0\n',
                               'br0.network': ND_WITHIP % ('br0', '192.170.1.1/24')})
 
     def test_bridge_external_ids_other_config(self):
@@ -440,8 +440,8 @@ ExecStart=/usr/bin/ovs-vsctl set Bridge br0 mcast_snooping_enable=true
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 rstp_enable=true
 '''}})
         # Confirm that the networkd config is still sane
-        self.assert_networkd({'eth1.network': '[Match]\nName=eth1\n\n[Network]\nLinkLocalAddressing=no\n',
-                              'eth2.network': '[Match]\nName=eth2\n\n[Network]\nLinkLocalAddressing=no\n',
+        self.assert_networkd({'eth1.network': '[Match]\nName=eth1\n\n[Network]\nLinkLocalAddressing=no\nBridge=br0\n',
+                              'eth2.network': '[Match]\nName=eth2\n\n[Network]\nLinkLocalAddressing=no\nBridge=br0\n',
                               'br0.network': ND_WITHIP % ('br0', '192.170.1.1/24')})
 
     def test_bridge_fail_mode_invalid(self):

--- a/tests/generator/test_ovs.py
+++ b/tests/generator/test_ovs.py
@@ -932,3 +932,14 @@ ExecStop=/usr/bin/ovs-vsctl --if-exists del-port patch1-0
                               'br1.network': ND_WITHIP % ('br1', '192.168.1.2/24'),
                               'patch0\\x2d1.network': ND_EMPTY % ('patch0-1', 'no'),
                               'patch1\\x2d0.network': ND_EMPTY % ('patch1-0', 'no')})
+
+    def test_invalid_device_type(self):
+        err = self.generate('''network:
+    version: 2
+    ethernets:
+        eth0:
+            openvswitch: {}
+''', expect_fail=True)
+        self.assertIn('eth0: This device type is not supported with the OpenVSwitch backend', err)
+        self.assert_ovs({})
+        self.assert_networkd({})

--- a/tests/generator/test_ovs.py
+++ b/tests/generator/test_ovs.py
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from .base import TestBase, ND_EMPTY, ND_WITHIP, ND_DHCP4, ND_DHCP6, OVS_PHYSICAL, OVS_VIRTUAL
+from .base import TestBase, ND_EMPTY, ND_WITHIP, ND_DHCP4, ND_DHCP6, OVS_PHYSICAL, OVS_VIRTUAL, OVS_BR_EMPTY
 
 
 class TestOpenVSwitch(TestBase):
@@ -150,7 +150,8 @@ ExecStop=/usr/bin/ovs-vsctl del-port bond0
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=off
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:iface-id=myhostname
-'''}})
+'''},
+                         'br0.service': OVS_BR_EMPTY % {'iface': 'br0'}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({'eth1.network': '[Match]\nName=eth1\n\n[Network]\nLinkLocalAddressing=no\nBond=bond0\n',
                               'eth2.network': '[Match]\nName=eth2\n\n[Network]\nLinkLocalAddressing=no\nBond=bond0\n',
@@ -215,7 +216,8 @@ ExecStart=/usr/bin/ovs-vsctl --may-exist add-bond br0 bond0 eth1 eth2
 ExecStop=/usr/bin/ovs-vsctl del-port bond0
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=active
-'''}})
+'''},
+                         'br0.service': OVS_BR_EMPTY % {'iface': 'br0'}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({'eth1.network': '[Match]\nName=eth1\n\n[Network]\nLinkLocalAddressing=no\nBond=bond0\n',
                               'eth2.network': '[Match]\nName=eth2\n\n[Network]\nLinkLocalAddressing=no\nBond=bond0\n',
@@ -280,7 +282,8 @@ ExecStop=/usr/bin/ovs-vsctl del-port bond0
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=off
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 bond_mode=balance-tcp
-'''}})
+'''},
+                         'br0.service': OVS_BR_EMPTY % {'iface': 'br0'}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({'eth1.network': '[Match]\nName=eth1\n\n[Network]\nLinkLocalAddressing=no\nBond=bond0\n',
                               'eth2.network': '[Match]\nName=eth2\n\n[Network]\nLinkLocalAddressing=no\nBond=bond0\n',
@@ -317,7 +320,8 @@ ExecStop=/usr/bin/ovs-vsctl del-port bond0
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=off
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 bond_mode=active-backup
-'''}})
+'''},
+                         'br0.service': OVS_BR_EMPTY % {'iface': 'br0'}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({'eth1.network': '[Match]\nName=eth1\n\n[Network]\nLinkLocalAddressing=no\nBond=bond0\n',
                               'eth2.network': '[Match]\nName=eth2\n\n[Network]\nLinkLocalAddressing=no\nBond=bond0\n',
@@ -373,8 +377,8 @@ ExecStart=/usr/bin/ovs-vsctl set Bridge br0 mcast_snooping_enable=false
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 rstp_enable=false
 '''}})
         # Confirm that the networkd config is still sane
-        self.assert_networkd({'eth1.network': '[Match]\nName=eth1\n\n[Network]\nLinkLocalAddressing=no\nBridge=br0\n',
-                              'eth2.network': '[Match]\nName=eth2\n\n[Network]\nLinkLocalAddressing=no\nBridge=br0\n',
+        self.assert_networkd({'eth1.network': '[Match]\nName=eth1\n\n[Network]\nLinkLocalAddressing=no\n',
+                              'eth2.network': '[Match]\nName=eth2\n\n[Network]\nLinkLocalAddressing=no\n',
                               'br0.network': ND_WITHIP % ('br0', '192.170.1.1/24')})
 
     def test_bridge_external_ids_other_config(self):
@@ -436,8 +440,8 @@ ExecStart=/usr/bin/ovs-vsctl set Bridge br0 mcast_snooping_enable=true
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 rstp_enable=true
 '''}})
         # Confirm that the networkd config is still sane
-        self.assert_networkd({'eth1.network': '[Match]\nName=eth1\n\n[Network]\nLinkLocalAddressing=no\nBridge=br0\n',
-                              'eth2.network': '[Match]\nName=eth2\n\n[Network]\nLinkLocalAddressing=no\nBridge=br0\n',
+        self.assert_networkd({'eth1.network': '[Match]\nName=eth1\n\n[Network]\nLinkLocalAddressing=no\n',
+                              'eth2.network': '[Match]\nName=eth2\n\n[Network]\nLinkLocalAddressing=no\n',
                               'br0.network': ND_WITHIP % ('br0', '192.170.1.1/24')})
 
     def test_bridge_fail_mode_invalid(self):


### PR DESCRIPTION
## Description
* Throw error, if OVS backend is applied to an unsupported interface type.
* Check for existence of all OVS systemd unit files in unit-tests
* Add (preliminary) VLAN-Bridge integration test for OVS

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Closes an open bug in Launchpad.

