### PR TITLE
Inconsistent indentation

### DIFF
--- a/examples/static.yaml
+++ b/examples/static.yaml
@@ -7,5 +7,5 @@ network:
         - 10.10.10.2/24
       gateway4: 10.10.10.1
       nameservers:
-          search: [mydomain,otherdomain]
-          addresses: [10.10.10.1, 1.1.1.1]
+        search: [mydomain, otherdomain]
+        addresses: [10.10.10.1, 1.1.1.1]


### PR DESCRIPTION
Suddenly jumped from 2 spaces to 4 spaces for no apparent reason.


## Description


## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Closes an open bug in Launchpad.

- [X] None of the above really applies to this small change of an example config