### PR TITLE
Allow for fake VLAN bridges to be implicit for OVS

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -459,7 +459,9 @@ handle_netdef_id(yaml_document_t* doc, yaml_node_t* node, const void* data, GErr
 
 /**
  * Generic handler for setting a cur_netdef ID/iface name field referring to an
- * existing ID from a scalar node
+ * existing ID from a scalar node. This handler also includes a special case
+ * handler for OVS VLANs, switching the backend implicitly to OVS for such
+ * interfaces
  * @data: offset into NetplanNetDefinition where the NetplanNetDefinition* field to write is
  *        located
  */
@@ -474,6 +476,11 @@ handle_netdef_id_ref(yaml_document_t* doc, yaml_node_t* node, const void* data, 
         add_missing_node(node);
     } else {
         *((NetplanNetDefinition**) ((void*) cur_netdef + offset)) = ref;
+
+        if (cur_netdef->type == NETPLAN_DEF_TYPE_VLAN && ref->backend == NETPLAN_BACKEND_OVS) {
+            g_debug("%s: VLAN defined for openvswitch interface, choosing OVS backend", cur_netdef->id);
+            cur_netdef->backend = NETPLAN_BACKEND_OVS;
+        }
     }
     return TRUE;
 }

--- a/tests/generator/test_ovs.py
+++ b/tests/generator/test_ovs.py
@@ -976,6 +976,46 @@ ExecStart=/usr/bin/ovs-vsctl set Port br0.100 external-ids:netplan=true
         self.assert_networkd({'br0.network': ND_WITHIP % ('br0', '192.168.1.1/24'),
                               'br0.100.network': ND_EMPTY % ('br0.100', 'ipv6')})
 
+    def test_implicit_fake_vlan_bridge_setup(self):
+        # Test if, when a VLAN is added to an OVS bridge, netplan will
+        # implicitly assume the vlan should be done via OVS as well
+        self.generate('''network:
+  version: 2
+  bridges:
+    br0:
+      addresses: [192.168.1.1/24]
+      openvswitch: {}
+  vlans:
+    br0.100:
+      id: 100
+      link: br0
+''')
+        self.assert_ovs({'br0.service': OVS_VIRTUAL % {'iface': 'br0', 'extra': '''
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
+ExecStop=/usr/bin/ovs-vsctl del-br br0
+ExecStart=/usr/bin/ovs-vsctl set Port br0 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set-fail-mode br0 standalone
+ExecStart=/usr/bin/ovs-vsctl set Bridge br0 mcast_snooping_enable=false
+ExecStart=/usr/bin/ovs-vsctl set Bridge br0 rstp_enable=false
+'''},
+                         'br0.100.service': OVS_VIRTUAL % {'iface': 'br0.100', 'extra':
+                                                           '''Requires=netplan-ovs-br0.service
+After=netplan-ovs-br0.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0.100 br0 100
+ExecStop=/usr/bin/ovs-vsctl del-br br0.100
+ExecStart=/usr/bin/ovs-vsctl set Port br0.100 external-ids:netplan=true
+'''}})
+        # Confirm that the networkd config is still sane
+        self.assert_networkd({'br0.network': ND_WITHIP % ('br0', '192.168.1.1/24'),
+                              'br0.100.network': ND_EMPTY % ('br0.100', 'ipv6')})
+
     def test_invalid_device_type(self):
         err = self.generate('''network:
     version: 2


### PR DESCRIPTION
## Description

It was not mentioned explicitly by the spec, but there was actually not much about VLAN support at all. After some discussions with James, it seems like we would want to have the same logic for VLANs as we have for bridges and bonds: if a VLAN is defined for an OVS interface, switch the backend to OVS as well.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Closes an open bug in Launchpad.

