### PR TITLE
Cleanup OVS code and (old) OVS interfaces after 'netplan apply'

### DIFF
--- a/netplan/cli/commands/apply.py
+++ b/netplan/cli/commands/apply.py
@@ -193,7 +193,7 @@ class NetplanApply(utils.NetplanCommand):
         # (re)start backends
         if restart_networkd:
             netplan_wpa = [os.path.basename(f) for f in glob.glob('/run/systemd/system/*.wants/netplan-wpa-*.service')]
-            netplan_ovs = [os.path.basename(f) for f in glob.glob('/run/systemd/system/*.wants/netpalan-ovs-*.service')]
+            netplan_ovs = [os.path.basename(f) for f in glob.glob('/run/systemd/system/*.wants/netplan-ovs-*.service')]
             utils.systemctl_networkd('start', sync=sync, extra_services=netplan_wpa + netplan_ovs)
         if restart_nm:
             utils.systemctl_network_manager('start', sync=sync)

--- a/netplan/cli/commands/apply.py
+++ b/netplan/cli/commands/apply.py
@@ -137,7 +137,6 @@ class NetplanApply(utils.NetplanCommand):
             # service units have been deleted via 'netplan generate'. (Systemd
             # cannot read or execute the ExecStop= command anymore!)
             # XXX: only for old_files_ovs, which are not part of restart_ovs
-            # XXX: what about patch-ports (OVS "Interfaces")
             if old_files_ovs and os.path.isfile(OPENVSWITCH_OVS_VSCTL):
                 for t in [['Port', 'del-port'], ['Bridge', 'del-br']]:
                     out = subprocess.check_output([OPENVSWITCH_OVS_VSCTL, '--columns=name,external-ids',

--- a/netplan/cli/commands/apply.py
+++ b/netplan/cli/commands/apply.py
@@ -126,7 +126,7 @@ class NetplanApply(utils.NetplanCommand):
             if run_generate:
                 utils.systemctl_daemon_reload()
             # Stop OVS service units to clear 'RemainAfterExit=yes' state, so we can re-start the services
-            # This will also cleanly shutdown OVS interfaces, which were part of the old and new config. Thsoe
+            # This will also cleanly shutdown OVS interfaces, which were part of the old and new config. Those
             # will be re-started via systemmctl_networkd('start', ...) below.
             ovs_services = ['netplan-ovs-*.service']
             wpa_services = ['netplan-wpa-*.service']
@@ -136,7 +136,7 @@ class NetplanApply(utils.NetplanCommand):
                 wpa_services.insert(0, 'netplan-wpa@*.service')
             utils.systemctl_networkd('stop', sync=sync, extra_services=wpa_services + ovs_services)
 
-            # Tear down the (old) OVS interfaces, as they cannot be stopped by
+            # Tear down the old OVS interfaces, as they cannot be stopped by
             # 'systemctl stop netplan-ovs-*.service' after the corresponding
             # service units have been deleted via 'netplan generate'. (Systemd
             # cannot read or execute the ExecStop= command anymore!)

--- a/netplan/cli/commands/apply.py
+++ b/netplan/cli/commands/apply.py
@@ -43,7 +43,7 @@ class NetplanApply(utils.NetplanCommand):
         self.ovs_only = False
 
     def run(self):  # pragma: nocover (covered in autopkgtest)
-        self.parser.add_argument('--ovs-only', action='store_true',
+        self.parser.add_argument('--only-ovs-cleanup', action='store_true',
                                  help='Only clean up old OpenVSwitch interfaces and exit')
 
         self.func = self.command_apply

--- a/netplan/cli/commands/try_command.py
+++ b/netplan/cli/commands/try_command.py
@@ -80,7 +80,7 @@ class NetplanTry(utils.NetplanCommand):
             self.backup()
             self.setup()
 
-            NetplanApply.command_apply(run_generate=True, sync=True, exit_on_error=False)
+            NetplanApply().command_apply(run_generate=True, sync=True, exit_on_error=False)
 
             self.t.get_confirmation_input(timeout=self.timeout)
         except netplan.terminal.InputRejected:
@@ -114,7 +114,7 @@ class NetplanTry(utils.NetplanCommand):
 
     def revert(self):  # pragma: nocover (requires user input)
         self.config_manager.revert()
-        NetplanApply.command_apply(run_generate=False, sync=True, exit_on_error=False)
+        NetplanApply().command_apply(run_generate=False, sync=True, exit_on_error=False)
         for ifname in self.new_interfaces:
             if ifname not in self.config_manager.bonds and \
                ifname not in self.config_manager.bridges and \

--- a/netplan/cli/ovs.py
+++ b/netplan/cli/ovs.py
@@ -32,7 +32,7 @@ def apply_ovs_cleanup(config_manager, ovs_old, ovs_current):  # pragma: nocover 
 
     # Tear down old OVS interfacess, not defined in the current config
     if os.path.isfile(OPENVSWITCH_OVS_VSCTL):
-        for t in [['Port', 'del-port'], ['Bridge', 'del-br']]:
+        for t in (('Port', 'del-port'), ('Bridge', 'del-br')):
             out = subprocess.check_output([OPENVSWITCH_OVS_VSCTL, '--columns=name,external-ids',
                                            '-f', 'csv', '-d', 'bare', '--no-headings', 'list', t[0]],
                                           universal_newlines=True)

--- a/netplan/cli/ovs.py
+++ b/netplan/cli/ovs.py
@@ -1,0 +1,48 @@
+#!/usr/bin/python3
+#
+# Copyright (C) 2020 Canonical, Ltd.
+# Author: Łukas 'slyon' Märdian <lukas.maerdian@canonical.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+import os
+import subprocess
+
+OPENVSWITCH_OVS_VSCTL = '/usr/bin/ovs-vsctl'
+
+
+def apply_ovs_cleanup(config_manager, ovs_old, ovs_current, ovs_only):  # pragma: nocover (covered in autopkgtest)
+    """
+    Query OpenVSwitch state through 'ovs-vsctl' and filter for netplan=true
+    tagged ports/bonds and bridges. Delete interfaces which are not defined
+    in the current configuration.
+    """
+    config_manager.parse()
+
+    # Tear down old OVS interfacess, not defined in the current config
+    if os.path.isfile(OPENVSWITCH_OVS_VSCTL):
+        for t in [['Port', 'del-port'], ['Bridge', 'del-br']]:
+            out = subprocess.check_output([OPENVSWITCH_OVS_VSCTL, '--columns=name,external-ids',
+                                           '-f', 'csv', '-d', 'bare', '--no-headings', 'list', t[0]],
+                                          universal_newlines=True)
+            for line in out.split('\n'):
+                if 'netplan=true' in line:
+                    iface = line.split(',')[0]
+                    # Skip cleanup if this OVS interface is part of the current netplan OVS config
+                    if config_manager.interfaces.get(iface, {}).get('openvswitch') is not None:
+                        continue
+                    subprocess.check_call([OPENVSWITCH_OVS_VSCTL, '--if-exists', t[1], iface])
+    # Show the warning only if we are or have been working with OVS definitions
+    elif ovs_old or ovs_current or ovs_only:
+        logging.warning('ovs-vsctl is missing, cannot tear down old OpenVSwitch interfaces')

--- a/netplan/cli/ovs.py
+++ b/netplan/cli/ovs.py
@@ -36,7 +36,7 @@ def apply_ovs_cleanup(config_manager, ovs_old, ovs_current):  # pragma: nocover 
             out = subprocess.check_output([OPENVSWITCH_OVS_VSCTL, '--columns=name,external-ids',
                                            '-f', 'csv', '-d', 'bare', '--no-headings', 'list', t[0]],
                                           universal_newlines=True)
-            for line in out.split('\n'):
+            for line in out.splitlines():
                 if 'netplan=true' in line:
                     iface = line.split(',')[0]
                     # Skip cleanup if this OVS interface is part of the current netplan OVS config

--- a/netplan/cli/ovs.py
+++ b/netplan/cli/ovs.py
@@ -22,7 +22,7 @@ import subprocess
 OPENVSWITCH_OVS_VSCTL = '/usr/bin/ovs-vsctl'
 
 
-def apply_ovs_cleanup(config_manager, ovs_old, ovs_current, ovs_only):  # pragma: nocover (covered in autopkgtest)
+def apply_ovs_cleanup(config_manager, ovs_old, ovs_current):  # pragma: nocover (covered in autopkgtest)
     """
     Query OpenVSwitch state through 'ovs-vsctl' and filter for netplan=true
     tagged ports/bonds and bridges. Delete interfaces which are not defined
@@ -44,5 +44,5 @@ def apply_ovs_cleanup(config_manager, ovs_old, ovs_current, ovs_only):  # pragma
                         continue
                     subprocess.check_call([OPENVSWITCH_OVS_VSCTL, '--if-exists', t[1], iface])
     # Show the warning only if we are or have been working with OVS definitions
-    elif ovs_old or ovs_current or ovs_only:
+    elif ovs_old or ovs_current:
         logging.warning('ovs-vsctl is missing, cannot tear down old OpenVSwitch interfaces')

--- a/src/openvswitch.c
+++ b/src/openvswitch.c
@@ -88,6 +88,7 @@ netplan_type_to_table_name(const NetplanDefType type)
         case NETPLAN_DEF_TYPE_BRIDGE:
             return "Bridge";
         case NETPLAN_DEF_TYPE_BOND:
+        case NETPLAN_DEF_TYPE_PORT:
             return "Port";
         default: /* For regular interfaces and others */
             return "Interface";

--- a/src/openvswitch.c
+++ b/src/openvswitch.c
@@ -163,7 +163,7 @@ write_ovs_bond_interfaces(const NetplanNetDefinition* def, GString* cmds)
 static void
 write_ovs_tag_netplan(const gchar* id, const char* type, GString* cmds)
 {
-    /* Mark this port as created by netplan */
+    /* Mark this bridge/port/interface as created by netplan */
     append_systemd_cmd(cmds, OPENVSWITCH_OVS_VSCTL " set %s %s external-ids:netplan=true",
                        type, id);
 }
@@ -279,7 +279,7 @@ write_ovs_conf(const NetplanNetDefinition* def, const char* rootdir)
 
     /* For other, more OVS specific settings, we expect the backend to be set to OVS.
      * The OVS backend is implicitly set, if an interface contains an empty "openvswitch: {}"
-     * key, or an "openvswitch:" key containing only "external-ids" or "other-config". */
+     * key, or an "openvswitch:" key, containing more than "external-ids" and/or "other-config". */
     if (def->backend == NETPLAN_BACKEND_OVS) {
         switch (def->type) {
             case NETPLAN_DEF_TYPE_BOND:

--- a/src/openvswitch.c
+++ b/src/openvswitch.c
@@ -286,7 +286,7 @@ write_ovs_conf(const NetplanNetDefinition* def, const char* rootdir)
     }
     // LCOV_EXCL_STOP
 
-    /* For other, more OVS specific settings, we expect the backend to be set to OVS.
+    /* For OVS specific settings, we expect the backend to be set to OVS.
      * The OVS backend is implicitly set, if an interface contains an empty "openvswitch: {}"
      * key, or an "openvswitch:" key, containing more than "external-ids" and/or "other-config". */
     if (def->backend == NETPLAN_BACKEND_OVS) {

--- a/src/openvswitch.c
+++ b/src/openvswitch.c
@@ -27,33 +27,6 @@
 #include "parse.h"
 #include "util.h"
 
-/* Arrays to store the current netplan=true tagged OVS interfaces */
-static GArray* _ovs_bridges = NULL;
-static GArray* _ovs_ports = NULL;
-
-static gchar*
-_prepare_ovs_interface_filter(GArray* interfaces) {
-    GString* filter = g_string_new("");
-    gchar* res = NULL;
-
-    /* Cleanup all old, netplan=true tagged OVS interfaces, which are not in the current config.
-       This is done by piping all "netplan=true" tagged ports/bridges through an inverse egrep. */
-    if (interfaces && interfaces->len > 0) {
-        g_string_append(filter, " | egrep -v \"(");
-        for (unsigned i = 0; i < interfaces->len; ++i) {
-            if (i > 0)
-                g_string_append(filter, "|");
-            g_string_append_printf(filter, "%s", g_array_index(interfaces, char*, i));
-        }
-        g_string_append(filter, "),\"");
-    }
-    res = g_string_free(filter, FALSE);
-    /* Replace "." -> "\.", to avoid "." matching any char in the egrep RegEx.
-       Escaped to "\\.", to pass it through systemd "ExecStart=". */
-    res = g_strjoinv("\\\\.", g_strsplit(res, ".", -1));
-    return res;
-}
-
 static void
 write_ovs_systemd_unit(const char* id, const GString* cmds, const char* rootdir, gboolean physical, gboolean cleanup, const char* dependency)
 {
@@ -187,16 +160,6 @@ write_ovs_tag_netplan(const gchar* id, const char* type, GString* cmds)
     /* Mark this bridge/port/interface as created by netplan */
     append_systemd_cmd(cmds, OPENVSWITCH_OVS_VSCTL " set %s %s external-ids:netplan=true",
                        type, id);
-    /* Remember netplan=true tagged interfaces, which should be kept in OVS */
-    if (!g_strcmp0(type, "Bridge")) {
-        if (!_ovs_bridges)
-            _ovs_bridges = g_array_new(FALSE, FALSE, sizeof(char*));
-        g_array_append_val(_ovs_bridges, id);
-    } else if (!g_strcmp0(type, "Port")) {
-        if (!_ovs_ports)
-            _ovs_ports = g_array_new(FALSE, FALSE, sizeof(char*));
-        g_array_append_val(_ovs_ports, id);
-    }
 }
 
 static void
@@ -413,7 +376,6 @@ void
 write_ovs_conf_finish(const char* rootdir)
 {
     GString* cmds = g_string_new(NULL);
-    gchar* filter = NULL;
 
     /* Global external-ids and other-config settings */
     if (ovs_settings_global.external_ids && g_hash_table_size(ovs_settings_global.external_ids) > 0) {
@@ -442,19 +404,9 @@ write_ovs_conf_finish(const char* rootdir)
         write_ovs_systemd_unit("global", cmds, rootdir, FALSE, FALSE, NULL);
     g_string_free(cmds, TRUE);
 
-    /* Clear all netplan=true tagged ports and bridges */
+    /* Clear all netplan=true tagged ports/bonds and bridges, via 'netplan apply --ovs-only' */
     cmds = g_string_new(NULL);
-
-    filter = _prepare_ovs_interface_filter(_ovs_ports);
-    append_systemd_cmd(cmds, "/bin/sh -c '" OPENVSWITCH_OVS_VSCTL " --column=name,external-ids -f csv -d bare --no-headings list Port"
-                       " | grep netplan=true%s | cut -d, -f1 | xargs -I {} " OPENVSWITCH_OVS_VSCTL " --if-exists del-port {}'", filter);
-    g_free(filter);
-
-    filter = _prepare_ovs_interface_filter(_ovs_bridges);
-    append_systemd_cmd(cmds, "/bin/sh -c '" OPENVSWITCH_OVS_VSCTL " --column=name,external-ids -f csv -d bare --no-headings list Bridge"
-                       " | grep netplan=true%s | cut -d, -f1 | xargs -I {} " OPENVSWITCH_OVS_VSCTL " --if-exists del-br {}'", filter);
-    g_free(filter);
-
+    append_systemd_cmd(cmds, "/usr/sbin/netplan apply %s", "--ovs-only");
     write_ovs_systemd_unit("cleanup", cmds, rootdir, FALSE, TRUE, NULL);
     g_string_free(cmds, TRUE);
 }

--- a/src/openvswitch.c
+++ b/src/openvswitch.c
@@ -399,9 +399,9 @@ write_ovs_conf_finish(const char* rootdir)
         write_ovs_systemd_unit("global", cmds, rootdir, FALSE, FALSE, NULL);
     g_string_free(cmds, TRUE);
 
-    /* Clear all netplan=true tagged ports/bonds and bridges, via 'netplan apply --ovs-only' */
+    /* Clear all netplan=true tagged ports/bonds and bridges, via 'netplan apply --only-ovs-cleanup' */
     cmds = g_string_new(NULL);
-    append_systemd_cmd(cmds, "/usr/sbin/netplan apply %s", "--ovs-only");
+    append_systemd_cmd(cmds, "/usr/sbin/netplan apply %s", "--only-ovs-cleanup");
     write_ovs_systemd_unit("cleanup", cmds, rootdir, FALSE, TRUE, NULL);
     g_string_free(cmds, TRUE);
 }

--- a/src/openvswitch.c
+++ b/src/openvswitch.c
@@ -277,8 +277,14 @@ write_ovs_conf(const NetplanNetDefinition* def, const char* rootdir)
     const char* type = netplan_type_to_table_name(def->type);
     g_autofree char* base_config_path = NULL;
 
-    /* TODO: error out on non-existing ovs-vsctl tool */
     /* TODO: maybe dynamically query the ovs-vsctl tool path? */
+    // LCOV_EXCL_START
+    if (!g_file_test(OPENVSWITCH_OVS_VSCTL, G_FILE_TEST_EXISTS)) {
+        /* Tested via integration test */
+        g_fprintf(stderr, "%s: The 'ovs-vsctl' tool is required to setup OpenVSwitch interfaces.\n", def->id);
+        exit(1);
+    }
+    // LCOV_EXCL_STOP
 
     /* For other, more OVS specific settings, we expect the backend to be set to OVS.
      * The OVS backend is implicitly set, if an interface contains an empty "openvswitch: {}"

--- a/src/openvswitch.c
+++ b/src/openvswitch.c
@@ -52,6 +52,9 @@ write_ovs_systemd_unit(const char* id, const GString* cmds, const char* rootdir,
     }
 
     g_string_append(s, "\n[Service]\nType=oneshot\n");
+    /* RemainAfterExist=yes keeps the service units active after executing all ExecStart= commands.
+     * It will cleanly shutdown the service units and the interfaces/configs it created at shutdown
+     * or reboot via the ExecStop= commands specified. */
     g_string_append(s, "RemainAfterExit=yes\n");
     g_string_append(s, cmds->str);
 

--- a/src/openvswitch.c
+++ b/src/openvswitch.c
@@ -152,7 +152,7 @@ write_ovs_bond_interfaces(const NetplanNetDefinition* def, GString* cmds)
     }
 
     append_systemd_cmd(cmds, s->str, def->bridge, def->id);
-    append_systemd_stop(cmds, OPENVSWITCH_OVS_VSCTL " del-port %s", def->id);
+    append_systemd_stop(cmds, OPENVSWITCH_OVS_VSCTL " --if-exists del-port %s", def->id);
     g_string_free(s, TRUE);
     return def->bridge;
 }
@@ -197,11 +197,11 @@ write_ovs_bridge_interfaces(const NetplanNetDefinition* def, GString* cmds)
         if ((tmp_nd->type != NETPLAN_DEF_TYPE_BOND || tmp_nd->backend != NETPLAN_BACKEND_OVS)
             && !g_strcmp0(def->id, tmp_nd->bridge)) {
             append_systemd_cmd(cmds,  OPENVSWITCH_OVS_VSCTL " --may-exist add-port %s %s", def->id, tmp_nd->id);
-            append_systemd_stop(cmds, OPENVSWITCH_OVS_VSCTL " del-port %s %s", def->id, tmp_nd->id);
+            append_systemd_stop(cmds, OPENVSWITCH_OVS_VSCTL " --if-exists del-port %s %s", def->id, tmp_nd->id);
         }
     }
 
-    append_systemd_stop(cmds, OPENVSWITCH_OVS_VSCTL " del-br %s", def->id);
+    append_systemd_stop(cmds, OPENVSWITCH_OVS_VSCTL " --if-exists del-br %s", def->id);
 }
 
 static void
@@ -336,7 +336,7 @@ write_ovs_conf(const NetplanNetDefinition* def, const char* rootdir)
                 dependency = def->vlan_link->id;
                 /* Create a fake VLAN bridge */
                 append_systemd_cmd(cmds, OPENVSWITCH_OVS_VSCTL " --may-exist add-br %s %s %i", def->id, def->vlan_link->id, def->vlan_id)
-                append_systemd_stop(cmds, OPENVSWITCH_OVS_VSCTL " del-br %s", def->id);
+                append_systemd_stop(cmds, OPENVSWITCH_OVS_VSCTL " --if-exists del-br %s", def->id);
                 /* This is an OVS fake VLAN bridge, not a VLAN interface */
                 write_ovs_tag_netplan(def->id, "Bridge", cmds);
                 break;

--- a/src/openvswitch.c
+++ b/src/openvswitch.c
@@ -36,6 +36,9 @@ write_ovs_systemd_unit(const char* id, const GString* cmds, const char* rootdir,
     GString* s = g_string_new("[Unit]\n");
     g_string_append_printf(s, "Description=OpenVSwitch configuration for %s\n", id);
     g_string_append(s, "DefaultDependencies=no\n");
+    /* run any ovs-netplan unit only after openvswitch-switch.service is ready */
+    g_string_append_printf(s, "Requires=openvswitch-switch.service\n");
+    g_string_append_printf(s, "After=openvswitch-switch.service\n");
     if (physical) {
         g_string_append_printf(s, "Requires=sys-subsystem-net-devices-%s.device\n", id);
         g_string_append_printf(s, "After=sys-subsystem-net-devices-%s.device\n", id);

--- a/src/util.h
+++ b/src/util.h
@@ -28,3 +28,6 @@ int wifi_get_freq24(int channel);
 int wifi_get_freq5(int channel);
 
 gchar* systemd_escape(char* string);
+
+#define OPENVSWITCH_OVS_VSCTL "/usr/bin/ovs-vsctl"
+#define OPENVSWITCH_OVS_OFCTL "/usr/bin/ovs-ofctl"

--- a/src/validation.c
+++ b/src/validation.c
@@ -25,6 +25,7 @@
 
 #include "parse.h"
 #include "error.h"
+#include "util.h"
 
 
 /* Check sanity for address types */
@@ -265,6 +266,15 @@ validate_netdef_grammar(NetplanNetDefinition* nd, yaml_node_t* node, GError** er
         valid = validate_tunnel_grammar(nd, node, error);
         if (!valid)
             goto netdef_grammar_error;
+    }
+
+    if (nd->backend == NETPLAN_BACKEND_OVS) {
+        // LCOV_EXCL_START
+        if (!g_file_test(OPENVSWITCH_OVS_VSCTL, G_FILE_TEST_EXISTS)) {
+            /* Tested via integration test */
+            return yaml_error(node, error, "%s: The 'ovs-vsctl' tool is required to setup OpenVSwitch interfaces.", nd->id);
+        }
+        // LCOV_EXCL_STOP
     }
 
     valid = TRUE;

--- a/tests/generator/base.py
+++ b/tests/generator/base.py
@@ -46,17 +46,19 @@ ND_DHCP6 = '[Match]\nName=%s\n\n[Network]\nDHCP=ipv6\nLinkLocalAddressing=ipv6\n
 ND_DHCP6_NOMTU = '[Match]\nName=%s\n\n[Network]\nDHCP=ipv6\nLinkLocalAddressing=ipv6\n\n[DHCP]\nRouteMetric=100\nUseMTU=false\n'
 ND_DHCPYES = '[Match]\nName=%s\n\n[Network]\nDHCP=yes\nLinkLocalAddressing=ipv6\n\n[DHCP]\nRouteMetric=100\nUseMTU=true\n'
 ND_DHCPYES_NOMTU = '[Match]\nName=%s\n\n[Network]\nDHCP=yes\nLinkLocalAddressing=ipv6\n\n[DHCP]\nRouteMetric=100\nUseMTU=false\n'
-_OVS_BASE = '[Unit]\nDescription=OpenVSwitch configuration for %(iface)s\nDefaultDependencies=no\n\
-Requires=openvswitch-switch.service\nAfter=openvswitch-switch.service\n'
+_OVS_BASE = '[Unit]\nDescription=OpenVSwitch configuration for %(iface)s\nDefaultDependencies=no\n'
 OVS_PHYSICAL = _OVS_BASE + 'Requires=sys-subsystem-net-devices-%(iface)s.device\nAfter=sys-subsystem-net-devices-%(iface)s\
-.device\nAfter=netplan-ovs-cleanup.service\nBefore=network.target\nWants=network.target\n%(extra)s'
-OVS_VIRTUAL = _OVS_BASE + 'After=netplan-ovs-cleanup.service\nBefore=network.target\nWants=network.target\n%(extra)s'
-OVS_BR_EMPTY = _OVS_BASE + 'After=netplan-ovs-cleanup.service\nBefore=network.target\nWants=network.target\n\n[Service]\n\
+.device\nRequires=openvswitch-switch.service\nAfter=openvswitch-switch.service\nAfter=netplan-ovs-cleanup.service\n\
+Before=network.target\nWants=network.target\n%(extra)s'
+OVS_VIRTUAL = _OVS_BASE + 'Requires=openvswitch-switch.service\nAfter=openvswitch-switch.service\n\
+After=netplan-ovs-cleanup.service\nBefore=network.target\nWants=network.target\n%(extra)s'
+OVS_BR_EMPTY = _OVS_BASE + 'Requires=openvswitch-switch.service\nAfter=openvswitch-switch.service\n\
+After=netplan-ovs-cleanup.service\nBefore=network.target\nWants=network.target\n\n[Service]\n\
 Type=oneshot\nExecStart=/usr/bin/ovs-vsctl --may-exist add-br %(iface)s\nExecStart=/usr/bin/ovs-vsctl set Bridge %(iface)s \
 external-ids:netplan=true\nExecStart=/usr/bin/ovs-vsctl set-fail-mode %(iface)s standalone\nExecStart=/usr/bin/ovs-vsctl set \
 Bridge %(iface)s mcast_snooping_enable=false\nExecStart=/usr/bin/ovs-vsctl set Bridge %(iface)s rstp_enable=false\n'
-OVS_CLEANUP = _OVS_BASE + 'Before=network.target\nWants=network.target\n\n[Service]\nType=oneshot\nExecStart=/usr/sbin/netplan \
-apply --ovs-only\n'
+OVS_CLEANUP = _OVS_BASE + 'ConditionFileIsExecutable=/usr/bin/ovs-vsctl\nBefore=network.target\nWants=network.target\n\n\
+[Service]\nType=oneshot\nExecStart=/usr/sbin/netplan apply --ovs-only\n'
 UDEV_MAC_RULE = 'SUBSYSTEM=="net", ACTION=="add", DRIVERS=="%s", ATTR{address}=="%s", NAME="%s"\n'
 UDEV_NO_MAC_RULE = 'SUBSYSTEM=="net", ACTION=="add", DRIVERS=="%s", NAME="%s"\n'
 

--- a/tests/generator/base.py
+++ b/tests/generator/base.py
@@ -55,11 +55,8 @@ OVS_BR_EMPTY = _OVS_BASE + 'After=netplan-ovs-cleanup.service\nBefore=network.ta
 Type=oneshot\nExecStart=/usr/bin/ovs-vsctl --may-exist add-br %(iface)s\nExecStart=/usr/bin/ovs-vsctl set Bridge %(iface)s \
 external-ids:netplan=true\nExecStart=/usr/bin/ovs-vsctl set-fail-mode %(iface)s standalone\nExecStart=/usr/bin/ovs-vsctl set \
 Bridge %(iface)s mcast_snooping_enable=false\nExecStart=/usr/bin/ovs-vsctl set Bridge %(iface)s rstp_enable=false\n'
-OVS_CLEANUP = _OVS_BASE + 'Before=network.target\nWants=network.target\n\n[Service]\nType=oneshot\nExecStart=/bin/sh -c \
-\'/usr/bin/ovs-vsctl --column=name,external-ids -f csv -d bare --no-headings list Port | grep netplan=true%(pfilter)s | \
-cut -d, -f1 | xargs -I {} /usr/bin/ovs-vsctl --if-exists del-port {}\'\nExecStart=/bin/sh -c \'/usr/bin/ovs-vsctl \
---column=name,external-ids -f csv -d bare --no-headings list Bridge | grep netplan=true%(bfilter)s | cut -d, -f1 | \
-xargs -I {} /usr/bin/ovs-vsctl --if-exists del-br {}\'\n'
+OVS_CLEANUP = _OVS_BASE + 'Before=network.target\nWants=network.target\n\n[Service]\nType=oneshot\nExecStart=/usr/sbin/netplan \
+apply --ovs-only\n'
 UDEV_MAC_RULE = 'SUBSYSTEM=="net", ACTION=="add", DRIVERS=="%s", ATTR{address}=="%s", NAME="%s"\n'
 UDEV_NO_MAC_RULE = 'SUBSYSTEM=="net", ACTION=="add", DRIVERS=="%s", NAME="%s"\n'
 

--- a/tests/generator/base.py
+++ b/tests/generator/base.py
@@ -56,10 +56,10 @@ Type=oneshot\nExecStart=/usr/bin/ovs-vsctl --may-exist add-br %(iface)s\nExecSta
 external-ids:netplan=true\nExecStart=/usr/bin/ovs-vsctl set-fail-mode %(iface)s standalone\nExecStart=/usr/bin/ovs-vsctl set \
 Bridge %(iface)s mcast_snooping_enable=false\nExecStart=/usr/bin/ovs-vsctl set Bridge %(iface)s rstp_enable=false\n'
 OVS_CLEANUP = _OVS_BASE + 'Before=network.target\nWants=network.target\n\n[Service]\nType=oneshot\nExecStart=/bin/sh -c \
-\'/usr/bin/ovs-vsctl --column=name,external-ids -f csv -d bare --no-headings list Port | grep netplan=true | cut -d, -f1 \
-| xargs -I {} /usr/bin/ovs-vsctl --if-exists del-port {}\'\nExecStart=/bin/sh -c \'/usr/bin/ovs-vsctl --column=name,external-ids\
- -f csv -d bare --no-headings list Bridge | grep netplan=true | cut -d, -f1 | xargs -I {} /usr/bin/ovs-vsctl --if-exists del-br \
-{}\'\n'
+\'/usr/bin/ovs-vsctl --column=name,external-ids -f csv -d bare --no-headings list Port | grep netplan=true%(pfilter)s | \
+cut -d, -f1 | xargs -I {} /usr/bin/ovs-vsctl --if-exists del-port {}\'\nExecStart=/bin/sh -c \'/usr/bin/ovs-vsctl \
+--column=name,external-ids -f csv -d bare --no-headings list Bridge | grep netplan=true%(bfilter)s | cut -d, -f1 | \
+xargs -I {} /usr/bin/ovs-vsctl --if-exists del-br {}\'\n'
 UDEV_MAC_RULE = 'SUBSYSTEM=="net", ACTION=="add", DRIVERS=="%s", ATTR{address}=="%s", NAME="%s"\n'
 UDEV_NO_MAC_RULE = 'SUBSYSTEM=="net", ACTION=="add", DRIVERS=="%s", NAME="%s"\n'
 

--- a/tests/generator/base.py
+++ b/tests/generator/base.py
@@ -52,7 +52,7 @@ OVS_PHYSICAL = _OVS_BASE + 'Requires=sys-subsystem-net-devices-%(iface)s.device\
 After=sys-subsystem-net-devices-%(iface)s.device\nBefore=network.target\nWants=network.target\n%(extra)s'
 OVS_VIRTUAL = _OVS_BASE + 'Before=network.target\nWants=network.target\n%(extra)s'
 OVS_BR_EMPTY = _OVS_BASE + 'Before=network.target\nWants=network.target\n\n[Service]\nType=oneshot\nRemainAfterExit=yes\n\
-ExecStart=/usr/bin/ovs-vsctl --may-exist add-br %(iface)s\nExecStop=/usr/bin/ovs-vsctl del-br %(iface)s\n\
+ExecStart=/usr/bin/ovs-vsctl --may-exist add-br %(iface)s\nExecStop=/usr/bin/ovs-vsctl --if-exists del-br %(iface)s\n\
 ExecStart=/usr/bin/ovs-vsctl set Bridge %(iface)s external-ids:netplan=true\nExecStart=/usr/bin/ovs-vsctl set-fail-mode \
 %(iface)s standalone\nExecStart=/usr/bin/ovs-vsctl set Bridge %(iface)s mcast_snooping_enable=false\n\
 ExecStart=/usr/bin/ovs-vsctl set Bridge %(iface)s rstp_enable=false\n'

--- a/tests/generator/base.py
+++ b/tests/generator/base.py
@@ -53,9 +53,9 @@ After=sys-subsystem-net-devices-%(iface)s.device\nBefore=network.target\nWants=n
 OVS_VIRTUAL = _OVS_BASE + 'Before=network.target\nWants=network.target\n%(extra)s'
 OVS_BR_EMPTY = _OVS_BASE + 'Before=network.target\nWants=network.target\n\n[Service]\nType=oneshot\nRemainAfterExit=yes\n\
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br %(iface)s\nExecStop=/usr/bin/ovs-vsctl del-br %(iface)s\n\
-ExecStart=/usr/bin/ovs-vsctl set Port %(iface)s external-ids:netplan=true\nExecStart=/usr/bin/ovs-vsctl set-fail-mode %(iface)s \
-standalone\nExecStart=/usr/bin/ovs-vsctl set Bridge %(iface)s mcast_snooping_enable=false\nExecStart=/usr/bin/ovs-vsctl set \
-Bridge %(iface)s rstp_enable=false\n'
+ExecStart=/usr/bin/ovs-vsctl set Bridge %(iface)s external-ids:netplan=true\nExecStart=/usr/bin/ovs-vsctl set-fail-mode \
+%(iface)s standalone\nExecStart=/usr/bin/ovs-vsctl set Bridge %(iface)s mcast_snooping_enable=false\n\
+ExecStart=/usr/bin/ovs-vsctl set Bridge %(iface)s rstp_enable=false\n'
 UDEV_MAC_RULE = 'SUBSYSTEM=="net", ACTION=="add", DRIVERS=="%s", ATTR{address}=="%s", NAME="%s"\n'
 UDEV_NO_MAC_RULE = 'SUBSYSTEM=="net", ACTION=="add", DRIVERS=="%s", NAME="%s"\n'
 

--- a/tests/generator/base.py
+++ b/tests/generator/base.py
@@ -46,16 +46,16 @@ ND_DHCP6 = '[Match]\nName=%s\n\n[Network]\nDHCP=ipv6\nLinkLocalAddressing=ipv6\n
 ND_DHCP6_NOMTU = '[Match]\nName=%s\n\n[Network]\nDHCP=ipv6\nLinkLocalAddressing=ipv6\n\n[DHCP]\nRouteMetric=100\nUseMTU=false\n'
 ND_DHCPYES = '[Match]\nName=%s\n\n[Network]\nDHCP=yes\nLinkLocalAddressing=ipv6\n\n[DHCP]\nRouteMetric=100\nUseMTU=true\n'
 ND_DHCPYES_NOMTU = '[Match]\nName=%s\n\n[Network]\nDHCP=yes\nLinkLocalAddressing=ipv6\n\n[DHCP]\nRouteMetric=100\nUseMTU=false\n'
-OVS_PHYSICAL = '[Unit]\nDescription=OpenVSwitch configuration for %(iface)s\nDefaultDependencies=no\n\
-Requires=sys-subsystem-net-devices-%(iface)s.device\nAfter=sys-subsystem-net-devices-%(iface)s.device\nBefore=network.target\n\
-Wants=network.target\n%(extra)s'
-OVS_VIRTUAL = '[Unit]\nDescription=OpenVSwitch configuration for %(iface)s\nDefaultDependencies=no\nBefore=network.target\n\
-Wants=network.target\n%(extra)s'
-OVS_BR_EMPTY = '[Unit]\nDescription=OpenVSwitch configuration for %(iface)s\nDefaultDependencies=no\nBefore=network.target\n\
-Wants=network.target\n\n[Service]\nType=oneshot\nRemainAfterExit=yes\nExecStart=/usr/bin/ovs-vsctl --may-exist add-br %(iface)s\n\
-ExecStop=/usr/bin/ovs-vsctl del-br %(iface)s\nExecStart=/usr/bin/ovs-vsctl set Port %(iface)s external-ids:netplan=true\n\
-ExecStart=/usr/bin/ovs-vsctl set-fail-mode %(iface)s standalone\nExecStart=/usr/bin/ovs-vsctl set Bridge %(iface)s \
-mcast_snooping_enable=false\nExecStart=/usr/bin/ovs-vsctl set Bridge %(iface)s rstp_enable=false\n'
+_OVS_BASE = '[Unit]\nDescription=OpenVSwitch configuration for %(iface)s\nDefaultDependencies=no\n\
+Requires=openvswitch-switch.service\nAfter=openvswitch-switch.service\n'
+OVS_PHYSICAL = _OVS_BASE + 'Requires=sys-subsystem-net-devices-%(iface)s.device\n\
+After=sys-subsystem-net-devices-%(iface)s.device\nBefore=network.target\nWants=network.target\n%(extra)s'
+OVS_VIRTUAL = _OVS_BASE + 'Before=network.target\nWants=network.target\n%(extra)s'
+OVS_BR_EMPTY = _OVS_BASE + 'Before=network.target\nWants=network.target\n\n[Service]\nType=oneshot\nRemainAfterExit=yes\n\
+ExecStart=/usr/bin/ovs-vsctl --may-exist add-br %(iface)s\nExecStop=/usr/bin/ovs-vsctl del-br %(iface)s\n\
+ExecStart=/usr/bin/ovs-vsctl set Port %(iface)s external-ids:netplan=true\nExecStart=/usr/bin/ovs-vsctl set-fail-mode %(iface)s \
+standalone\nExecStart=/usr/bin/ovs-vsctl set Bridge %(iface)s mcast_snooping_enable=false\nExecStart=/usr/bin/ovs-vsctl set \
+Bridge %(iface)s rstp_enable=false\n'
 UDEV_MAC_RULE = 'SUBSYSTEM=="net", ACTION=="add", DRIVERS=="%s", ATTR{address}=="%s", NAME="%s"\n'
 UDEV_NO_MAC_RULE = 'SUBSYSTEM=="net", ACTION=="add", DRIVERS=="%s", NAME="%s"\n'
 

--- a/tests/generator/base.py
+++ b/tests/generator/base.py
@@ -58,7 +58,7 @@ Type=oneshot\nExecStart=/usr/bin/ovs-vsctl --may-exist add-br %(iface)s\nExecSta
 external-ids:netplan=true\nExecStart=/usr/bin/ovs-vsctl set-fail-mode %(iface)s standalone\nExecStart=/usr/bin/ovs-vsctl set \
 Bridge %(iface)s mcast_snooping_enable=false\nExecStart=/usr/bin/ovs-vsctl set Bridge %(iface)s rstp_enable=false\n'
 OVS_CLEANUP = _OVS_BASE + 'ConditionFileIsExecutable=/usr/bin/ovs-vsctl\nBefore=network.target\nWants=network.target\n\n\
-[Service]\nType=oneshot\nExecStart=/usr/sbin/netplan apply --ovs-only\n'
+[Service]\nType=oneshot\nExecStart=/usr/sbin/netplan apply --only-ovs-cleanup\n'
 UDEV_MAC_RULE = 'SUBSYSTEM=="net", ACTION=="add", DRIVERS=="%s", ATTR{address}=="%s", NAME="%s"\n'
 UDEV_NO_MAC_RULE = 'SUBSYSTEM=="net", ACTION=="add", DRIVERS=="%s", NAME="%s"\n'
 

--- a/tests/generator/test_args.py
+++ b/tests/generator/test_args.py
@@ -38,7 +38,7 @@ class TestConfigArgs(TestBase):
         self.assert_networkd_udev(None)
         self.assert_nm(None)
         self.assert_nm_udev(None)
-        self.assert_ovs({'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
+        self.assert_ovs({'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup', 'pfilter': '', 'bfilter': ''}})
 
     def test_empty_config(self):
         self.generate('')
@@ -48,7 +48,7 @@ class TestConfigArgs(TestBase):
         self.assert_networkd_udev(None)
         self.assert_nm(None)
         self.assert_nm_udev(None)
-        self.assert_ovs({'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
+        self.assert_ovs({'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup', 'pfilter': '', 'bfilter': ''}})
 
     def test_file_args(self):
         conf = os.path.join(self.workdir.name, 'config')

--- a/tests/generator/test_args.py
+++ b/tests/generator/test_args.py
@@ -38,7 +38,7 @@ class TestConfigArgs(TestBase):
         self.assert_networkd_udev(None)
         self.assert_nm(None)
         self.assert_nm_udev(None)
-        self.assert_ovs({'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup', 'pfilter': '', 'bfilter': ''}})
+        self.assert_ovs({'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
 
     def test_empty_config(self):
         self.generate('')
@@ -48,7 +48,7 @@ class TestConfigArgs(TestBase):
         self.assert_networkd_udev(None)
         self.assert_nm(None)
         self.assert_nm_udev(None)
-        self.assert_ovs({'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup', 'pfilter': '', 'bfilter': ''}})
+        self.assert_ovs({'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
 
     def test_file_args(self):
         conf = os.path.join(self.workdir.name, 'config')

--- a/tests/generator/test_args.py
+++ b/tests/generator/test_args.py
@@ -19,7 +19,7 @@
 import os
 import subprocess
 
-from .base import TestBase, exe_generate
+from .base import TestBase, exe_generate, OVS_CLEANUP
 
 
 class TestConfigArgs(TestBase):
@@ -33,14 +33,22 @@ class TestConfigArgs(TestBase):
     def test_no_configs(self):
         self.generate('network:\n  version: 2')
         # should not write any files
-        self.assertEqual(os.listdir(self.workdir.name), ['etc'])
+        self.assertEqual(os.listdir(self.workdir.name), ['etc', 'run'])
+        self.assert_networkd(None)
+        self.assert_networkd_udev(None)
+        self.assert_nm(None)
         self.assert_nm_udev(None)
+        self.assert_ovs({'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
 
     def test_empty_config(self):
         self.generate('')
         # should not write any files
-        self.assertEqual(os.listdir(self.workdir.name), ['etc'])
+        self.assertEqual(os.listdir(self.workdir.name), ['etc', 'run'])
+        self.assert_networkd(None)
+        self.assert_networkd_udev(None)
+        self.assert_nm(None)
         self.assert_nm_udev(None)
+        self.assert_ovs({'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
 
     def test_file_args(self):
         conf = os.path.join(self.workdir.name, 'config')
@@ -52,7 +60,13 @@ class TestConfigArgs(TestBase):
   ethernets:
     eth0:
       dhcp4: true''', extra_args=[conf])
-        self.assertEqual(set(os.listdir(self.workdir.name)), {'config', 'etc'})
+        # There is one systemd service unit 'netplan-ovs-cleanup.service' in /run,
+        # which will always be created
+        self.assertEqual(set(os.listdir(self.workdir.name)), {'config', 'etc', 'run'})
+        self.assert_networkd(None)
+        self.assert_networkd_udev(None)
+        self.assert_nm(None)
+        self.assert_nm_udev(None)
 
     def test_file_args_notfound(self):
         err = self.generate('''network:

--- a/tests/generator/test_ovs.py
+++ b/tests/generator/test_ovs.py
@@ -912,8 +912,8 @@ ExecStart=/usr/bin/ovs-vsctl set-fail-mode br1 standalone
 ExecStart=/usr/bin/ovs-vsctl set Bridge br1 mcast_snooping_enable=false
 ExecStart=/usr/bin/ovs-vsctl set Bridge br1 rstp_enable=false
 '''},
-                         'patch0\\x2d1.service': OVS_VIRTUAL % {'iface': 'patch0\\x2d1', 'extra':
-                                                                '''Requires=netplan-ovs-br0.service
+                         'patch0-1.service': OVS_VIRTUAL % {'iface': 'patch0-1', 'extra':
+                                                            '''Requires=netplan-ovs-br0.service
 After=netplan-ovs-br0.service
 
 [Service]
@@ -924,8 +924,8 @@ ExecStart=/usr/bin/ovs-vsctl set Interface patch0-1 options:peer=patch1-0
 ExecStop=/usr/bin/ovs-vsctl --if-exists del-port patch0-1
 ExecStart=/usr/bin/ovs-vsctl set Interface patch0-1 external-ids:netplan=true
 '''},
-                         'patch1\\x2d0.service': OVS_VIRTUAL % {'iface': 'patch1\\x2d0', 'extra':
-                                                                '''Requires=netplan-ovs-br1.service
+                         'patch1-0.service': OVS_VIRTUAL % {'iface': 'patch1-0', 'extra':
+                                                            '''Requires=netplan-ovs-br1.service
 After=netplan-ovs-br1.service
 
 [Service]
@@ -938,8 +938,8 @@ ExecStart=/usr/bin/ovs-vsctl set Interface patch1-0 external-ids:netplan=true
 '''}})
         self.assert_networkd({'br0.network': ND_WITHIP % ('br0', '192.168.1.1/24'),
                               'br1.network': ND_WITHIP % ('br1', '192.168.1.2/24'),
-                              'patch0\\x2d1.network': ND_EMPTY % ('patch0-1', 'no'),
-                              'patch1\\x2d0.network': ND_EMPTY % ('patch1-0', 'no')})
+                              'patch0-1.network': ND_EMPTY % ('patch0-1', 'no'),
+                              'patch1-0.network': ND_EMPTY % ('patch1-0', 'no')})
 
     def test_fake_vlan_bridge_setup(self):
         self.generate('''network:
@@ -1045,7 +1045,7 @@ ExecStart=/usr/bin/ovs-vsctl set Bridge br0.100 external-ids:netplan=true
             interfaces: [non-ovs-bond]
             openvswitch: {}
 ''')
-        self.assert_ovs({'ovs\\x2dbr.service': OVS_VIRTUAL % {'iface': 'ovs\\x2dbr', 'extra': '''
+        self.assert_ovs({'ovs-br.service': OVS_VIRTUAL % {'iface': 'ovs-br', 'extra': '''
 [Service]
 Type=oneshot
 RemainAfterExit=yes
@@ -1064,5 +1064,5 @@ ExecStart=/usr/bin/ovs-vsctl set Bridge ovs-br rstp_enable=false
                               'Bond=non-ovs-bond'),
                               'eth0.network': (ND_EMPTY % ('eth0', 'no')).replace('ConfigureWithoutCarrier=yes',
                               'Bond=non-ovs-bond'),
-                              'ovs\\x2dbr.network': ND_EMPTY % ('ovs-br', 'ipv6'),
+                              'ovs-br.network': ND_EMPTY % ('ovs-br', 'ipv6'),
                               'non-ovs-bond.netdev': '[NetDev]\nName=non-ovs-bond\nKind=bond\n'})

--- a/tests/generator/test_ovs.py
+++ b/tests/generator/test_ovs.py
@@ -51,7 +51,7 @@ ExecStart=/usr/bin/ovs-vsctl set Interface eth0 other-config:disable-in-band=tru
 Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl set Interface eth1 other-config:disable-in-band=false
 '''},
-                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
+                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup', 'pfilter': '', 'bfilter': ''}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({'eth0.network': ND_DHCP6 % 'eth0',
                               'eth1.network': ND_DHCP4 % 'eth1'})
@@ -74,7 +74,7 @@ Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:iface-id=myhostname
 ExecStart=/usr/bin/ovs-vsctl set open_vswitch . other-config:disable-in-band=true
 '''},
-                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
+                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup', 'pfilter': '', 'bfilter': ''}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({'eth0.network': ND_DHCP4 % 'eth0'})
 
@@ -92,7 +92,7 @@ ExecStart=/usr/bin/ovs-vsctl set open_vswitch . other-config:disable-in-band=tru
 Type=oneshot
 ExecStart=/usr/bin/ovs-ofctl -O OpenFlow10,OpenFlow11,OpenFlow12
 '''},
-                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
+                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup', 'pfilter': '', 'bfilter': ''}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({'eth0.network': ND_DHCP4 % 'eth0'})
 
@@ -116,7 +116,7 @@ ExecStart=/usr/bin/ovs-ofctl -O OpenFlow10,OpenFlow11,OpenFlow12
     eth0:
       dhcp4: yes
 ''')
-        self.assert_ovs({'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
+        self.assert_ovs({'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup', 'pfilter': '', 'bfilter': ''}})
         self.assert_networkd({'eth0.network': ND_DHCP4 % 'eth0'})
 
     def test_bond_setup(self):
@@ -149,7 +149,8 @@ ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=off
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:iface-id=myhostname
 '''},
                          'br0.service': OVS_BR_EMPTY % {'iface': 'br0'},
-                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
+                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup', 'pfilter': ' | egrep -v "(bond0),"',
+                                                           'bfilter': ' | egrep -v "(br0),"'}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({'eth1.network': '[Match]\nName=eth1\n\n[Network]\nLinkLocalAddressing=no\nBond=bond0\n',
                               'eth2.network': '[Match]\nName=eth2\n\n[Network]\nLinkLocalAddressing=no\nBond=bond0\n',
@@ -214,7 +215,8 @@ ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=active
 '''},
                          'br0.service': OVS_BR_EMPTY % {'iface': 'br0'},
-                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
+                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup', 'pfilter': ' | egrep -v "(bond0),"',
+                                                           'bfilter': ' | egrep -v "(br0),"'}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({'eth1.network': '[Match]\nName=eth1\n\n[Network]\nLinkLocalAddressing=no\nBond=bond0\n',
                               'eth2.network': '[Match]\nName=eth2\n\n[Network]\nLinkLocalAddressing=no\nBond=bond0\n',
@@ -279,7 +281,8 @@ ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=off
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 bond_mode=balance-tcp
 '''},
                          'br0.service': OVS_BR_EMPTY % {'iface': 'br0'},
-                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
+                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup', 'pfilter': ' | egrep -v "(bond0),"',
+                                                           'bfilter': ' | egrep -v "(br0),"'}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({'eth1.network': '[Match]\nName=eth1\n\n[Network]\nLinkLocalAddressing=no\nBond=bond0\n',
                               'eth2.network': '[Match]\nName=eth2\n\n[Network]\nLinkLocalAddressing=no\nBond=bond0\n',
@@ -316,7 +319,8 @@ ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=off
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 bond_mode=active-backup
 '''},
                          'br0.service': OVS_BR_EMPTY % {'iface': 'br0'},
-                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
+                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup', 'pfilter': ' | egrep -v "(bond0),"',
+                                                           'bfilter': ' | egrep -v "(br0),"'}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({'eth1.network': '[Match]\nName=eth1\n\n[Network]\nLinkLocalAddressing=no\nBond=bond0\n',
                               'eth2.network': '[Match]\nName=eth2\n\n[Network]\nLinkLocalAddressing=no\nBond=bond0\n',
@@ -367,7 +371,7 @@ ExecStart=/usr/bin/ovs-vsctl set-fail-mode br0 standalone
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 mcast_snooping_enable=false
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 rstp_enable=false
 '''},
-                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
+                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup', 'pfilter': '', 'bfilter': ' | egrep -v "(br0),"'}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({'eth1.network': '[Match]\nName=eth1\n\n[Network]\nLinkLocalAddressing=no\nBridge=br0\n',
                               'eth2.network': '[Match]\nName=eth2\n\n[Network]\nLinkLocalAddressing=no\nBridge=br0\n',
@@ -395,7 +399,7 @@ ExecStart=/usr/bin/ovs-vsctl set Bridge br0 rstp_enable=false
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:iface-id=myhostname
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 other-config:disable-in-band=true
 '''},
-                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
+                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup', 'pfilter': '', 'bfilter': ' | egrep -v "(br0),"'}})
         # Confirm that the bridge has been only configured for OVS
         self.assert_networkd({'br0.network': ND_EMPTY % ('br0', 'ipv6')})
 
@@ -426,7 +430,7 @@ ExecStart=/usr/bin/ovs-vsctl set-fail-mode br0 secure
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 mcast_snooping_enable=true
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 rstp_enable=true
 '''},
-                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
+                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup', 'pfilter': '', 'bfilter': ' | egrep -v "(br0),"'}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({'eth1.network': '[Match]\nName=eth1\n\n[Network]\nLinkLocalAddressing=no\nBridge=br0\n',
                               'eth2.network': '[Match]\nName=eth2\n\n[Network]\nLinkLocalAddressing=no\nBridge=br0\n',
@@ -481,7 +485,7 @@ ExecStart=/usr/bin/ovs-vsctl set Bridge br0 mcast_snooping_enable=false
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 rstp_enable=false
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 protocols=OpenFlow10,OpenFlow11,OpenFlow15
 '''},
-                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
+                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup', 'pfilter': '', 'bfilter': ' | egrep -v "(br0),"'}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({'br0.network': ND_EMPTY % ('br0', 'ipv6')})
 
@@ -539,7 +543,7 @@ ExecStart=/usr/bin/ovs-vsctl set controller br0 connection-mode=out-of-band
 Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl set-ssl /key/path /some/path /another/path
 '''},
-                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
+                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup', 'pfilter': '', 'bfilter': ' | egrep -v "(br0),"'}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({'br0.network': ND_EMPTY % ('br0', 'ipv6')})
 
@@ -635,7 +639,7 @@ ExecStart=/usr/bin/ovs-vsctl set-ssl /key/path /some/path /another/path
 Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl set-ssl /key/path /some/path /another/path
 '''},
-                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
+                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup', 'pfilter': '', 'bfilter': ''}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({})
 
@@ -748,7 +752,8 @@ ExecStart=/usr/bin/ovs-vsctl --may-exist add-bond br0 bond0 eth1 eth2
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=off
 '''},
-                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
+                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup', 'pfilter': ' | egrep -v "(bond0),"',
+                                                           'bfilter': ' | egrep -v "(br0),"'}})
         self.assert_networkd({'br0.network': ND_WITHIP % ('br0', '192.170.1.1/24'),
                               'bond0.network': ND_EMPTY % ('bond0', 'no'),
                               'eth1.network':
@@ -836,7 +841,8 @@ ExecStart=/usr/bin/ovs-vsctl set Interface patchy type=patch
 ExecStart=/usr/bin/ovs-vsctl set Interface patchy options:peer=patchx
 ExecStart=/usr/bin/ovs-vsctl set Port patchy external-ids:netplan=true
 '''},
-                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
+                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup', 'pfilter': ' | egrep -v "(bond0|patchx|patchy),"',
+                                                           'bfilter': ' | egrep -v "(br0|br1),"'}})
         self.assert_networkd({'br0.network': ND_WITHIP % ('br0', '192.170.1.1/24'),
                               'br1.network': ND_WITHIP % ('br1', '2001:FFfe::1/64'),
                               'bond0.network': ND_EMPTY % ('bond0', 'no'),
@@ -898,7 +904,8 @@ ExecStart=/usr/bin/ovs-vsctl set Interface patch1-0 type=patch
 ExecStart=/usr/bin/ovs-vsctl set Interface patch1-0 options:peer=patch0-1
 ExecStart=/usr/bin/ovs-vsctl set Port patch1-0 external-ids:netplan=true
 '''},
-                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
+                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup', 'pfilter': ' | egrep -v "(patch0-1|patch1-0),"',
+                                                           'bfilter': ' | egrep -v "(br0|br1),"'}})
         self.assert_networkd({'br0.network': ND_WITHIP % ('br0', '192.168.1.1/24'),
                               'br1.network': ND_WITHIP % ('br1', '192.168.1.2/24'),
                               'patch0-1.network': ND_EMPTY % ('patch0-1', 'no'),
@@ -935,7 +942,8 @@ Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0.100 br0 100
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0.100 external-ids:netplan=true
 '''},
-                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
+                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup', 'pfilter': '',
+                                                           'bfilter': r' | egrep -v "(br0|br0\\.100),"'}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({'br0.network': ND_WITHIP % ('br0', '192.168.1.1/24'),
                               'br0.100.network': ND_EMPTY % ('br0.100', 'ipv6')})
@@ -972,7 +980,8 @@ Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0.100 br0 100
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0.100 external-ids:netplan=true
 '''},
-                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
+                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup', 'pfilter': '',
+                                                           'bfilter': r' | egrep -v "(br0|br0\\.100),"'}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({'br0.network': ND_WITHIP % ('br0', '192.168.1.1/24'),
                               'br0.100.network': ND_EMPTY % ('br0.100', 'ipv6')})
@@ -1012,7 +1021,8 @@ ExecStart=/usr/bin/ovs-vsctl set-fail-mode ovs-br standalone
 ExecStart=/usr/bin/ovs-vsctl set Bridge ovs-br mcast_snooping_enable=false
 ExecStart=/usr/bin/ovs-vsctl set Bridge ovs-br rstp_enable=false
 '''},
-                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
+                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup', 'pfilter': '',
+                                                           'bfilter': ' | egrep -v "(ovs-br),"'}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({'non-ovs-bond.network': ND_EMPTY % ('non-ovs-bond', 'no') + 'Bridge=ovs-br\n',
                               'eth1.network': (ND_EMPTY % ('eth1', 'no')).replace('ConfigureWithoutCarrier=yes',

--- a/tests/generator/test_ovs.py
+++ b/tests/generator/test_ovs.py
@@ -51,7 +51,7 @@ ExecStart=/usr/bin/ovs-vsctl set Interface eth0 other-config:disable-in-band=tru
 Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl set Interface eth1 other-config:disable-in-band=false
 '''},
-                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup', 'pfilter': '', 'bfilter': ''}})
+                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({'eth0.network': ND_DHCP6 % 'eth0',
                               'eth1.network': ND_DHCP4 % 'eth1'})
@@ -74,7 +74,7 @@ Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:iface-id=myhostname
 ExecStart=/usr/bin/ovs-vsctl set open_vswitch . other-config:disable-in-band=true
 '''},
-                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup', 'pfilter': '', 'bfilter': ''}})
+                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({'eth0.network': ND_DHCP4 % 'eth0'})
 
@@ -92,7 +92,7 @@ ExecStart=/usr/bin/ovs-vsctl set open_vswitch . other-config:disable-in-band=tru
 Type=oneshot
 ExecStart=/usr/bin/ovs-ofctl -O OpenFlow10,OpenFlow11,OpenFlow12
 '''},
-                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup', 'pfilter': '', 'bfilter': ''}})
+                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({'eth0.network': ND_DHCP4 % 'eth0'})
 
@@ -116,7 +116,7 @@ ExecStart=/usr/bin/ovs-ofctl -O OpenFlow10,OpenFlow11,OpenFlow12
     eth0:
       dhcp4: yes
 ''')
-        self.assert_ovs({'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup', 'pfilter': '', 'bfilter': ''}})
+        self.assert_ovs({'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         self.assert_networkd({'eth0.network': ND_DHCP4 % 'eth0'})
 
     def test_bond_setup(self):
@@ -149,8 +149,7 @@ ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=off
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:iface-id=myhostname
 '''},
                          'br0.service': OVS_BR_EMPTY % {'iface': 'br0'},
-                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup', 'pfilter': ' | egrep -v "(bond0),"',
-                                                           'bfilter': ' | egrep -v "(br0),"'}})
+                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({'eth1.network': '[Match]\nName=eth1\n\n[Network]\nLinkLocalAddressing=no\nBond=bond0\n',
                               'eth2.network': '[Match]\nName=eth2\n\n[Network]\nLinkLocalAddressing=no\nBond=bond0\n',
@@ -215,8 +214,7 @@ ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=active
 '''},
                          'br0.service': OVS_BR_EMPTY % {'iface': 'br0'},
-                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup', 'pfilter': ' | egrep -v "(bond0),"',
-                                                           'bfilter': ' | egrep -v "(br0),"'}})
+                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({'eth1.network': '[Match]\nName=eth1\n\n[Network]\nLinkLocalAddressing=no\nBond=bond0\n',
                               'eth2.network': '[Match]\nName=eth2\n\n[Network]\nLinkLocalAddressing=no\nBond=bond0\n',
@@ -281,8 +279,7 @@ ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=off
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 bond_mode=balance-tcp
 '''},
                          'br0.service': OVS_BR_EMPTY % {'iface': 'br0'},
-                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup', 'pfilter': ' | egrep -v "(bond0),"',
-                                                           'bfilter': ' | egrep -v "(br0),"'}})
+                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({'eth1.network': '[Match]\nName=eth1\n\n[Network]\nLinkLocalAddressing=no\nBond=bond0\n',
                               'eth2.network': '[Match]\nName=eth2\n\n[Network]\nLinkLocalAddressing=no\nBond=bond0\n',
@@ -319,8 +316,7 @@ ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=off
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 bond_mode=active-backup
 '''},
                          'br0.service': OVS_BR_EMPTY % {'iface': 'br0'},
-                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup', 'pfilter': ' | egrep -v "(bond0),"',
-                                                           'bfilter': ' | egrep -v "(br0),"'}})
+                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({'eth1.network': '[Match]\nName=eth1\n\n[Network]\nLinkLocalAddressing=no\nBond=bond0\n',
                               'eth2.network': '[Match]\nName=eth2\n\n[Network]\nLinkLocalAddressing=no\nBond=bond0\n',
@@ -371,7 +367,7 @@ ExecStart=/usr/bin/ovs-vsctl set-fail-mode br0 standalone
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 mcast_snooping_enable=false
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 rstp_enable=false
 '''},
-                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup', 'pfilter': '', 'bfilter': ' | egrep -v "(br0),"'}})
+                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({'eth1.network': '[Match]\nName=eth1\n\n[Network]\nLinkLocalAddressing=no\nBridge=br0\n',
                               'eth2.network': '[Match]\nName=eth2\n\n[Network]\nLinkLocalAddressing=no\nBridge=br0\n',
@@ -399,7 +395,7 @@ ExecStart=/usr/bin/ovs-vsctl set Bridge br0 rstp_enable=false
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:iface-id=myhostname
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 other-config:disable-in-band=true
 '''},
-                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup', 'pfilter': '', 'bfilter': ' | egrep -v "(br0),"'}})
+                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the bridge has been only configured for OVS
         self.assert_networkd({'br0.network': ND_EMPTY % ('br0', 'ipv6')})
 
@@ -430,7 +426,7 @@ ExecStart=/usr/bin/ovs-vsctl set-fail-mode br0 secure
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 mcast_snooping_enable=true
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 rstp_enable=true
 '''},
-                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup', 'pfilter': '', 'bfilter': ' | egrep -v "(br0),"'}})
+                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({'eth1.network': '[Match]\nName=eth1\n\n[Network]\nLinkLocalAddressing=no\nBridge=br0\n',
                               'eth2.network': '[Match]\nName=eth2\n\n[Network]\nLinkLocalAddressing=no\nBridge=br0\n',
@@ -485,7 +481,7 @@ ExecStart=/usr/bin/ovs-vsctl set Bridge br0 mcast_snooping_enable=false
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 rstp_enable=false
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 protocols=OpenFlow10,OpenFlow11,OpenFlow15
 '''},
-                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup', 'pfilter': '', 'bfilter': ' | egrep -v "(br0),"'}})
+                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({'br0.network': ND_EMPTY % ('br0', 'ipv6')})
 
@@ -543,7 +539,7 @@ ExecStart=/usr/bin/ovs-vsctl set controller br0 connection-mode=out-of-band
 Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl set-ssl /key/path /some/path /another/path
 '''},
-                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup', 'pfilter': '', 'bfilter': ' | egrep -v "(br0),"'}})
+                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({'br0.network': ND_EMPTY % ('br0', 'ipv6')})
 
@@ -639,7 +635,7 @@ ExecStart=/usr/bin/ovs-vsctl set-ssl /key/path /some/path /another/path
 Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl set-ssl /key/path /some/path /another/path
 '''},
-                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup', 'pfilter': '', 'bfilter': ''}})
+                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({})
 
@@ -752,8 +748,7 @@ ExecStart=/usr/bin/ovs-vsctl --may-exist add-bond br0 bond0 eth1 eth2
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=off
 '''},
-                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup', 'pfilter': ' | egrep -v "(bond0),"',
-                                                           'bfilter': ' | egrep -v "(br0),"'}})
+                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         self.assert_networkd({'br0.network': ND_WITHIP % ('br0', '192.170.1.1/24'),
                               'bond0.network': ND_EMPTY % ('bond0', 'no'),
                               'eth1.network':
@@ -841,8 +836,7 @@ ExecStart=/usr/bin/ovs-vsctl set Interface patchy type=patch
 ExecStart=/usr/bin/ovs-vsctl set Interface patchy options:peer=patchx
 ExecStart=/usr/bin/ovs-vsctl set Port patchy external-ids:netplan=true
 '''},
-                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup', 'pfilter': ' | egrep -v "(bond0|patchx|patchy),"',
-                                                           'bfilter': ' | egrep -v "(br0|br1),"'}})
+                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         self.assert_networkd({'br0.network': ND_WITHIP % ('br0', '192.170.1.1/24'),
                               'br1.network': ND_WITHIP % ('br1', '2001:FFfe::1/64'),
                               'bond0.network': ND_EMPTY % ('bond0', 'no'),
@@ -904,8 +898,7 @@ ExecStart=/usr/bin/ovs-vsctl set Interface patch1-0 type=patch
 ExecStart=/usr/bin/ovs-vsctl set Interface patch1-0 options:peer=patch0-1
 ExecStart=/usr/bin/ovs-vsctl set Port patch1-0 external-ids:netplan=true
 '''},
-                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup', 'pfilter': ' | egrep -v "(patch0-1|patch1-0),"',
-                                                           'bfilter': ' | egrep -v "(br0|br1),"'}})
+                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         self.assert_networkd({'br0.network': ND_WITHIP % ('br0', '192.168.1.1/24'),
                               'br1.network': ND_WITHIP % ('br1', '192.168.1.2/24'),
                               'patch0-1.network': ND_EMPTY % ('patch0-1', 'no'),
@@ -942,8 +935,7 @@ Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0.100 br0 100
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0.100 external-ids:netplan=true
 '''},
-                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup', 'pfilter': '',
-                                                           'bfilter': r' | egrep -v "(br0|br0\\.100),"'}})
+                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({'br0.network': ND_WITHIP % ('br0', '192.168.1.1/24'),
                               'br0.100.network': ND_EMPTY % ('br0.100', 'ipv6')})
@@ -980,8 +972,7 @@ Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0.100 br0 100
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0.100 external-ids:netplan=true
 '''},
-                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup', 'pfilter': '',
-                                                           'bfilter': r' | egrep -v "(br0|br0\\.100),"'}})
+                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({'br0.network': ND_WITHIP % ('br0', '192.168.1.1/24'),
                               'br0.100.network': ND_EMPTY % ('br0.100', 'ipv6')})
@@ -1021,8 +1012,7 @@ ExecStart=/usr/bin/ovs-vsctl set-fail-mode ovs-br standalone
 ExecStart=/usr/bin/ovs-vsctl set Bridge ovs-br mcast_snooping_enable=false
 ExecStart=/usr/bin/ovs-vsctl set Bridge ovs-br rstp_enable=false
 '''},
-                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup', 'pfilter': '',
-                                                           'bfilter': ' | egrep -v "(ovs-br),"'}})
+                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({'non-ovs-bond.network': ND_EMPTY % ('non-ovs-bond', 'no') + 'Bridge=ovs-br\n',
                               'eth1.network': (ND_EMPTY % ('eth1', 'no')).replace('ConfigureWithoutCarrier=yes',

--- a/tests/generator/test_ovs.py
+++ b/tests/generator/test_ovs.py
@@ -371,7 +371,7 @@ ExecStop=/usr/bin/ovs-vsctl del-port br0 eth1
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-port br0 eth2
 ExecStop=/usr/bin/ovs-vsctl del-port br0 eth2
 ExecStop=/usr/bin/ovs-vsctl del-br br0
-ExecStart=/usr/bin/ovs-vsctl set Port br0 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set-fail-mode br0 standalone
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 mcast_snooping_enable=false
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 rstp_enable=false
@@ -398,7 +398,7 @@ Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
 ExecStop=/usr/bin/ovs-vsctl del-br br0
-ExecStart=/usr/bin/ovs-vsctl set Port br0 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set-fail-mode br0 standalone
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 mcast_snooping_enable=false
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 rstp_enable=false
@@ -434,7 +434,7 @@ ExecStop=/usr/bin/ovs-vsctl del-port br0 eth1
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-port br0 eth2
 ExecStop=/usr/bin/ovs-vsctl del-port br0 eth2
 ExecStop=/usr/bin/ovs-vsctl del-br br0
-ExecStart=/usr/bin/ovs-vsctl set Port br0 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set-fail-mode br0 secure
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 mcast_snooping_enable=true
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 rstp_enable=true
@@ -489,7 +489,7 @@ Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
 ExecStop=/usr/bin/ovs-vsctl del-br br0
-ExecStart=/usr/bin/ovs-vsctl set Port br0 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set-fail-mode br0 standalone
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 mcast_snooping_enable=false
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 rstp_enable=false
@@ -541,7 +541,7 @@ Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
 ExecStop=/usr/bin/ovs-vsctl del-br br0
-ExecStart=/usr/bin/ovs-vsctl set Port br0 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set-fail-mode br0 standalone
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 mcast_snooping_enable=false
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 rstp_enable=false
@@ -750,7 +750,7 @@ Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
 ExecStop=/usr/bin/ovs-vsctl del-br br0
-ExecStart=/usr/bin/ovs-vsctl set Port br0 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set-fail-mode br0 standalone
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 mcast_snooping_enable=false
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 rstp_enable=false
@@ -811,7 +811,7 @@ Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
 ExecStop=/usr/bin/ovs-vsctl del-br br0
-ExecStart=/usr/bin/ovs-vsctl set Port br0 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set-fail-mode br0 standalone
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 mcast_snooping_enable=false
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 rstp_enable=false
@@ -824,7 +824,7 @@ ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br1
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-port br1 patchx
 ExecStop=/usr/bin/ovs-vsctl del-port br1 patchx
 ExecStop=/usr/bin/ovs-vsctl del-br br1
-ExecStart=/usr/bin/ovs-vsctl set Port br1 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Bridge br1 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set-fail-mode br1 standalone
 ExecStart=/usr/bin/ovs-vsctl set Bridge br1 mcast_snooping_enable=false
 ExecStart=/usr/bin/ovs-vsctl set Bridge br1 rstp_enable=false
@@ -851,6 +851,7 @@ RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl set Interface patchx type=patch
 ExecStart=/usr/bin/ovs-vsctl set Interface patchx options:peer=patchy
 ExecStop=/usr/bin/ovs-vsctl --if-exists del-port patchx
+ExecStart=/usr/bin/ovs-vsctl set Interface patchx external-ids:netplan=true
 '''},
                          'patchy.service': OVS_VIRTUAL % {'iface': 'patchy', 'extra':
                                                           '''Requires=netplan-ovs-bond0.service
@@ -862,6 +863,7 @@ RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl set Interface patchy type=patch
 ExecStart=/usr/bin/ovs-vsctl set Interface patchy options:peer=patchx
 ExecStop=/usr/bin/ovs-vsctl --if-exists del-port patchy
+ExecStart=/usr/bin/ovs-vsctl set Interface patchy external-ids:netplan=true
 '''}})
         self.assert_networkd({'br0.network': ND_WITHIP % ('br0', '192.170.1.1/24'),
                               'br1.network': ND_WITHIP % ('br1', '2001:FFfe::1/64'),
@@ -892,7 +894,7 @@ ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-port br0 patch0-1
 ExecStop=/usr/bin/ovs-vsctl del-port br0 patch0-1
 ExecStop=/usr/bin/ovs-vsctl del-br br0
-ExecStart=/usr/bin/ovs-vsctl set Port br0 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set-fail-mode br0 standalone
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 mcast_snooping_enable=false
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 rstp_enable=false
@@ -905,7 +907,7 @@ ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br1
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-port br1 patch1-0
 ExecStop=/usr/bin/ovs-vsctl del-port br1 patch1-0
 ExecStop=/usr/bin/ovs-vsctl del-br br1
-ExecStart=/usr/bin/ovs-vsctl set Port br1 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Bridge br1 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set-fail-mode br1 standalone
 ExecStart=/usr/bin/ovs-vsctl set Bridge br1 mcast_snooping_enable=false
 ExecStart=/usr/bin/ovs-vsctl set Bridge br1 rstp_enable=false
@@ -920,6 +922,7 @@ RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl set Interface patch0-1 type=patch
 ExecStart=/usr/bin/ovs-vsctl set Interface patch0-1 options:peer=patch1-0
 ExecStop=/usr/bin/ovs-vsctl --if-exists del-port patch0-1
+ExecStart=/usr/bin/ovs-vsctl set Interface patch0-1 external-ids:netplan=true
 '''},
                          'patch1\\x2d0.service': OVS_VIRTUAL % {'iface': 'patch1\\x2d0', 'extra':
                                                                 '''Requires=netplan-ovs-br1.service
@@ -931,6 +934,7 @@ RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl set Interface patch1-0 type=patch
 ExecStart=/usr/bin/ovs-vsctl set Interface patch1-0 options:peer=patch0-1
 ExecStop=/usr/bin/ovs-vsctl --if-exists del-port patch1-0
+ExecStart=/usr/bin/ovs-vsctl set Interface patch1-0 external-ids:netplan=true
 '''}})
         self.assert_networkd({'br0.network': ND_WITHIP % ('br0', '192.168.1.1/24'),
                               'br1.network': ND_WITHIP % ('br1', '192.168.1.2/24'),
@@ -956,7 +960,7 @@ Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
 ExecStop=/usr/bin/ovs-vsctl del-br br0
-ExecStart=/usr/bin/ovs-vsctl set Port br0 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set-fail-mode br0 standalone
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 mcast_snooping_enable=false
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 rstp_enable=false
@@ -970,7 +974,7 @@ Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0.100 br0 100
 ExecStop=/usr/bin/ovs-vsctl del-br br0.100
-ExecStart=/usr/bin/ovs-vsctl set Port br0.100 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Bridge br0.100 external-ids:netplan=true
 '''}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({'br0.network': ND_WITHIP % ('br0', '192.168.1.1/24'),
@@ -996,7 +1000,7 @@ Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
 ExecStop=/usr/bin/ovs-vsctl del-br br0
-ExecStart=/usr/bin/ovs-vsctl set Port br0 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set-fail-mode br0 standalone
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 mcast_snooping_enable=false
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 rstp_enable=false
@@ -1010,7 +1014,7 @@ Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0.100 br0 100
 ExecStop=/usr/bin/ovs-vsctl del-br br0.100
-ExecStart=/usr/bin/ovs-vsctl set Port br0.100 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Bridge br0.100 external-ids:netplan=true
 '''}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({'br0.network': ND_WITHIP % ('br0', '192.168.1.1/24'),
@@ -1049,7 +1053,7 @@ ExecStart=/usr/bin/ovs-vsctl --may-exist add-br ovs-br
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-port ovs-br non-ovs-bond
 ExecStop=/usr/bin/ovs-vsctl del-port ovs-br non-ovs-bond
 ExecStop=/usr/bin/ovs-vsctl del-br ovs-br
-ExecStart=/usr/bin/ovs-vsctl set Port ovs-br external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Bridge ovs-br external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set-fail-mode ovs-br standalone
 ExecStart=/usr/bin/ovs-vsctl set Bridge ovs-br mcast_snooping_enable=false
 ExecStart=/usr/bin/ovs-vsctl set Bridge ovs-br rstp_enable=false

--- a/tests/generator/test_ovs.py
+++ b/tests/generator/test_ovs.py
@@ -851,7 +851,7 @@ RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl set Interface patchx type=patch
 ExecStart=/usr/bin/ovs-vsctl set Interface patchx options:peer=patchy
 ExecStop=/usr/bin/ovs-vsctl --if-exists del-port patchx
-ExecStart=/usr/bin/ovs-vsctl set Interface patchx external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Port patchx external-ids:netplan=true
 '''},
                          'patchy.service': OVS_VIRTUAL % {'iface': 'patchy', 'extra':
                                                           '''Requires=netplan-ovs-bond0.service
@@ -863,7 +863,7 @@ RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl set Interface patchy type=patch
 ExecStart=/usr/bin/ovs-vsctl set Interface patchy options:peer=patchx
 ExecStop=/usr/bin/ovs-vsctl --if-exists del-port patchy
-ExecStart=/usr/bin/ovs-vsctl set Interface patchy external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Port patchy external-ids:netplan=true
 '''}})
         self.assert_networkd({'br0.network': ND_WITHIP % ('br0', '192.170.1.1/24'),
                               'br1.network': ND_WITHIP % ('br1', '2001:FFfe::1/64'),
@@ -922,7 +922,7 @@ RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl set Interface patch0-1 type=patch
 ExecStart=/usr/bin/ovs-vsctl set Interface patch0-1 options:peer=patch1-0
 ExecStop=/usr/bin/ovs-vsctl --if-exists del-port patch0-1
-ExecStart=/usr/bin/ovs-vsctl set Interface patch0-1 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Port patch0-1 external-ids:netplan=true
 '''},
                          'patch1-0.service': OVS_VIRTUAL % {'iface': 'patch1-0', 'extra':
                                                             '''Requires=netplan-ovs-br1.service
@@ -934,7 +934,7 @@ RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl set Interface patch1-0 type=patch
 ExecStart=/usr/bin/ovs-vsctl set Interface patch1-0 options:peer=patch0-1
 ExecStop=/usr/bin/ovs-vsctl --if-exists del-port patch1-0
-ExecStart=/usr/bin/ovs-vsctl set Interface patch1-0 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Port patch1-0 external-ids:netplan=true
 '''}})
         self.assert_networkd({'br0.network': ND_WITHIP % ('br0', '192.168.1.1/24'),
                               'br1.network': ND_WITHIP % ('br1', '192.168.1.2/24'),

--- a/tests/generator/test_ovs.py
+++ b/tests/generator/test_ovs.py
@@ -146,7 +146,7 @@ After=netplan-ovs-br0.service
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-bond br0 bond0 eth1 eth2
-ExecStop=/usr/bin/ovs-vsctl del-port bond0
+ExecStop=/usr/bin/ovs-vsctl --if-exists del-port bond0
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=off
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:iface-id=myhostname
@@ -213,7 +213,7 @@ After=netplan-ovs-br0.service
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-bond br0 bond0 eth1 eth2
-ExecStop=/usr/bin/ovs-vsctl del-port bond0
+ExecStop=/usr/bin/ovs-vsctl --if-exists del-port bond0
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=active
 '''},
@@ -278,7 +278,7 @@ After=netplan-ovs-br0.service
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-bond br0 bond0 eth1 eth2
-ExecStop=/usr/bin/ovs-vsctl del-port bond0
+ExecStop=/usr/bin/ovs-vsctl --if-exists del-port bond0
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=off
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 bond_mode=balance-tcp
@@ -316,7 +316,7 @@ After=netplan-ovs-br0.service
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-bond br0 bond0 eth1 eth2
-ExecStop=/usr/bin/ovs-vsctl del-port bond0
+ExecStop=/usr/bin/ovs-vsctl --if-exists del-port bond0
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=off
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 bond_mode=active-backup
@@ -367,10 +367,10 @@ Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-port br0 eth1
-ExecStop=/usr/bin/ovs-vsctl del-port br0 eth1
+ExecStop=/usr/bin/ovs-vsctl --if-exists del-port br0 eth1
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-port br0 eth2
-ExecStop=/usr/bin/ovs-vsctl del-port br0 eth2
-ExecStop=/usr/bin/ovs-vsctl del-br br0
+ExecStop=/usr/bin/ovs-vsctl --if-exists del-port br0 eth2
+ExecStop=/usr/bin/ovs-vsctl --if-exists del-br br0
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set-fail-mode br0 standalone
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 mcast_snooping_enable=false
@@ -397,7 +397,7 @@ ExecStart=/usr/bin/ovs-vsctl set Bridge br0 rstp_enable=false
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
-ExecStop=/usr/bin/ovs-vsctl del-br br0
+ExecStop=/usr/bin/ovs-vsctl --if-exists del-br br0
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set-fail-mode br0 standalone
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 mcast_snooping_enable=false
@@ -430,10 +430,10 @@ Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-port br0 eth1
-ExecStop=/usr/bin/ovs-vsctl del-port br0 eth1
+ExecStop=/usr/bin/ovs-vsctl --if-exists del-port br0 eth1
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-port br0 eth2
-ExecStop=/usr/bin/ovs-vsctl del-port br0 eth2
-ExecStop=/usr/bin/ovs-vsctl del-br br0
+ExecStop=/usr/bin/ovs-vsctl --if-exists del-port br0 eth2
+ExecStop=/usr/bin/ovs-vsctl --if-exists del-br br0
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set-fail-mode br0 secure
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 mcast_snooping_enable=true
@@ -488,7 +488,7 @@ ExecStart=/usr/bin/ovs-vsctl set Bridge br0 rstp_enable=true
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
-ExecStop=/usr/bin/ovs-vsctl del-br br0
+ExecStop=/usr/bin/ovs-vsctl --if-exists del-br br0
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set-fail-mode br0 standalone
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 mcast_snooping_enable=false
@@ -540,7 +540,7 @@ ExecStart=/usr/bin/ovs-vsctl set Bridge br0 protocols=OpenFlow10,OpenFlow11,Open
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
-ExecStop=/usr/bin/ovs-vsctl del-br br0
+ExecStop=/usr/bin/ovs-vsctl --if-exists del-br br0
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set-fail-mode br0 standalone
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 mcast_snooping_enable=false
@@ -749,7 +749,7 @@ ExecStart=/usr/bin/ovs-vsctl set-ssl /key/path /some/path /another/path
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
-ExecStop=/usr/bin/ovs-vsctl del-br br0
+ExecStop=/usr/bin/ovs-vsctl --if-exists del-br br0
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set-fail-mode br0 standalone
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 mcast_snooping_enable=false
@@ -763,7 +763,7 @@ After=netplan-ovs-br0.service
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-bond br0 bond0 eth1 eth2
-ExecStop=/usr/bin/ovs-vsctl del-port bond0
+ExecStop=/usr/bin/ovs-vsctl --if-exists del-port bond0
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=off
 '''}})
@@ -810,7 +810,7 @@ Bond=bond0
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
-ExecStop=/usr/bin/ovs-vsctl del-br br0
+ExecStop=/usr/bin/ovs-vsctl --if-exists del-br br0
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set-fail-mode br0 standalone
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 mcast_snooping_enable=false
@@ -822,8 +822,8 @@ Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br1
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-port br1 patchx
-ExecStop=/usr/bin/ovs-vsctl del-port br1 patchx
-ExecStop=/usr/bin/ovs-vsctl del-br br1
+ExecStop=/usr/bin/ovs-vsctl --if-exists del-port br1 patchx
+ExecStop=/usr/bin/ovs-vsctl --if-exists del-br br1
 ExecStart=/usr/bin/ovs-vsctl set Bridge br1 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set-fail-mode br1 standalone
 ExecStart=/usr/bin/ovs-vsctl set Bridge br1 mcast_snooping_enable=false
@@ -837,7 +837,7 @@ After=netplan-ovs-br0.service
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-bond br0 bond0 patchy eth0
-ExecStop=/usr/bin/ovs-vsctl del-port bond0
+ExecStop=/usr/bin/ovs-vsctl --if-exists del-port bond0
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=off
 '''},
@@ -892,8 +892,8 @@ Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-port br0 patch0-1
-ExecStop=/usr/bin/ovs-vsctl del-port br0 patch0-1
-ExecStop=/usr/bin/ovs-vsctl del-br br0
+ExecStop=/usr/bin/ovs-vsctl --if-exists del-port br0 patch0-1
+ExecStop=/usr/bin/ovs-vsctl --if-exists del-br br0
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set-fail-mode br0 standalone
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 mcast_snooping_enable=false
@@ -905,8 +905,8 @@ Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br1
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-port br1 patch1-0
-ExecStop=/usr/bin/ovs-vsctl del-port br1 patch1-0
-ExecStop=/usr/bin/ovs-vsctl del-br br1
+ExecStop=/usr/bin/ovs-vsctl --if-exists del-port br1 patch1-0
+ExecStop=/usr/bin/ovs-vsctl --if-exists del-br br1
 ExecStart=/usr/bin/ovs-vsctl set Bridge br1 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set-fail-mode br1 standalone
 ExecStart=/usr/bin/ovs-vsctl set Bridge br1 mcast_snooping_enable=false
@@ -959,7 +959,7 @@ ExecStart=/usr/bin/ovs-vsctl set Interface patch1-0 external-ids:netplan=true
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
-ExecStop=/usr/bin/ovs-vsctl del-br br0
+ExecStop=/usr/bin/ovs-vsctl --if-exists del-br br0
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set-fail-mode br0 standalone
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 mcast_snooping_enable=false
@@ -973,7 +973,7 @@ After=netplan-ovs-br0.service
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0.100 br0 100
-ExecStop=/usr/bin/ovs-vsctl del-br br0.100
+ExecStop=/usr/bin/ovs-vsctl --if-exists del-br br0.100
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0.100 external-ids:netplan=true
 '''}})
         # Confirm that the networkd config is still sane
@@ -999,7 +999,7 @@ ExecStart=/usr/bin/ovs-vsctl set Bridge br0.100 external-ids:netplan=true
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
-ExecStop=/usr/bin/ovs-vsctl del-br br0
+ExecStop=/usr/bin/ovs-vsctl --if-exists del-br br0
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set-fail-mode br0 standalone
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 mcast_snooping_enable=false
@@ -1013,7 +1013,7 @@ After=netplan-ovs-br0.service
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0.100 br0 100
-ExecStop=/usr/bin/ovs-vsctl del-br br0.100
+ExecStop=/usr/bin/ovs-vsctl --if-exists del-br br0.100
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0.100 external-ids:netplan=true
 '''}})
         # Confirm that the networkd config is still sane
@@ -1051,8 +1051,8 @@ Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br ovs-br
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-port ovs-br non-ovs-bond
-ExecStop=/usr/bin/ovs-vsctl del-port ovs-br non-ovs-bond
-ExecStop=/usr/bin/ovs-vsctl del-br ovs-br
+ExecStop=/usr/bin/ovs-vsctl --if-exists del-port ovs-br non-ovs-bond
+ExecStop=/usr/bin/ovs-vsctl --if-exists del-br ovs-br
 ExecStart=/usr/bin/ovs-vsctl set Bridge ovs-br external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set-fail-mode ovs-br standalone
 ExecStart=/usr/bin/ovs-vsctl set Bridge ovs-br mcast_snooping_enable=false

--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -359,7 +359,7 @@ class IntegrationTestsBase(unittest.TestCase):
         subprocess.check_call(['systemctl', 'start', '--no-block', 'NetworkManager.service'])
         # wait until networkd is done
         if self.is_active('systemd-networkd.service'):
-            if subprocess.call(['/lib/systemd/systemd-networkd-wait-online', '--quiet', '--timeout=50']) != 0:
+            if subprocess.call(['/lib/systemd/systemd-networkd-wait-online', '--quiet', '--timeout=20']) != 0:
                 subprocess.call(['journalctl', '-b', '--no-pager', '-t', 'systemd-networkd'])
                 st = subprocess.check_output(['networkctl'], stderr=subprocess.PIPE, universal_newlines=True)
                 st_e = subprocess.check_output(['networkctl', 'status', self.dev_e_client],

--- a/tests/integration/ovs.py
+++ b/tests/integration/ovs.py
@@ -53,8 +53,7 @@ class _CommonTests():
         #implicitly handled by OVS because of its link
         br-%(ec)s.100:
             id: 100
-            link: br-%(ec)s
-''' % {'ec': self.dev_e_client})
+            link: br-%(ec)s''' % {'ec': self.dev_e_client})
         self.generate_and_settle()
         # Basic verification that the interfaces/ports are set up in OVS
         out = subprocess.check_output(['ovs-vsctl', 'show'])
@@ -280,8 +279,7 @@ class _CommonTests():
         interfaces: [%(ec)s]
         openvswitch: {}
     ethernets:
-      %(ec)s: {}
-''' % {'ec': self.dev_e_client})
+      %(ec)s: {}''' % {'ec': self.dev_e_client})
         p = subprocess.Popen(['netplan', 'apply'], stdout=subprocess.PIPE,
                              stderr=subprocess.PIPE, universal_newlines=True)
         (out, err) = p.communicate()

--- a/tests/integration/ovs.py
+++ b/tests/integration/ovs.py
@@ -29,6 +29,45 @@ from base import IntegrationTestsBase, test_backends
 
 class _CommonTests():
 
+    # FIXME: Why does this test need to run first, in order to pass?
+    def test_1_cleanup_interfaces(self):
+        self.setup_eth(None, False)
+        self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-br', 'ovs0'])
+        self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-br', 'ovs1'])
+        self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-port', 'patch0-1'])
+        self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-port', 'patch1-0'])
+        with open(self.config, 'w') as f:
+            f.write('''network:
+  openvswitch:
+    ports:
+      - [patch0-1, patch1-0]
+  bridges:
+    ovs0: {interfaces: [patch0-1]}
+    ovs1: {interfaces: [patch1-0]}''')
+        self.generate_and_settle()
+        # Basic verification that the bridges/ports/interfaces are there in OVS
+        out = subprocess.check_output(['ovs-vsctl', 'show'])
+        self.assertIn(b'    Bridge ovs0', out)
+        self.assertIn(b'        Port patch0-1', out)
+        self.assertIn(b'            Interface patch0-1', out)
+        self.assertIn(b'    Bridge ovs1', out)
+        self.assertIn(b'        Port patch1-0', out)
+        self.assertIn(b'            Interface patch1-0', out)
+        with open(self.config, 'w') as f:
+            f.write('''network:
+  ethernets:
+    %(ec)s: {addresses: ['1.2.3.4/24']}''' % {'ec': self.dev_e_client})
+        self.generate_and_settle()
+        # Verify that the netplan=true tagged bridges/ports have been cleaned up
+        out = subprocess.check_output(['ovs-vsctl', 'show'])
+        self.assertNotIn(b'Bridge ovs0', out)
+        self.assertNotIn(b'Port patch0-1', out)
+        self.assertNotIn(b'Interface patch0-1', out)
+        self.assertNotIn(b'Bridge ovs1', out)
+        self.assertNotIn(b'Port patch1-0', out)
+        self.assertNotIn(b'Interface patch1-0', out)
+        self.assert_iface_up(self.dev_e_client, ['inet 1.2.3.4/24'])
+
     def test_bridge_vlan(self):
         self.setup_eth(None, True)
         self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-br', 'br-%s' % self.dev_e_client])
@@ -282,44 +321,6 @@ class _CommonTests():
         (out, err) = p.communicate()
         self.assertIn('ovs0: The \'ovs-vsctl\' tool is required to setup OpenVSwitch interfaces.', err)
         self.assertNotEqual(p.returncode, 0)
-
-    def test_cleanup_interfaces(self):
-        self.setup_eth(None, False)
-        self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-br', 'ovs0'])
-        self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-br', 'ovs1'])
-        self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-port', 'patch0-1'])
-        self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-port', 'patch1-0'])
-        with open(self.config, 'w') as f:
-            f.write('''network:
-  openvswitch:
-    ports:
-      - [patch0-1, patch1-0]
-  bridges:
-    ovs0: {interfaces: [patch0-1]}
-    ovs1: {interfaces: [patch1-0]}''')
-        self.generate_and_settle()
-        # Basic verification that the bridges/ports/interfaces are there in OVS
-        out = subprocess.check_output(['ovs-vsctl', 'show'])
-        self.assertIn(b'    Bridge ovs0', out)
-        self.assertIn(b'        Port patch0-1', out)
-        self.assertIn(b'            Interface patch0-1', out)
-        self.assertIn(b'    Bridge ovs1', out)
-        self.assertIn(b'        Port patch1-0', out)
-        self.assertIn(b'            Interface patch1-0', out)
-        with open(self.config, 'w') as f:
-            f.write('''network:
-  ethernets:
-    %(ec)s: {addresses: ['1.2.3.4/24']}''' % {'ec': self.dev_e_client})
-        self.generate_and_settle()
-        # Verify that the netplan=true tagged bridges/ports have been cleaned up
-        out = subprocess.check_output(['ovs-vsctl', 'show'])
-        self.assertNotIn(b'Bridge ovs0', out)
-        self.assertNotIn(b'Port patch0-1', out)
-        self.assertNotIn(b'Interface patch0-1', out)
-        self.assertNotIn(b'Bridge ovs1', out)
-        self.assertNotIn(b'Port patch1-0', out)
-        self.assertNotIn(b'Interface patch1-0', out)
-        self.assert_iface_up(self.dev_e_client, ['inet 1.2.3.4/24'])
 
 
 @unittest.skipIf("networkd" not in test_backends,

--- a/tests/integration/ovs.py
+++ b/tests/integration/ovs.py
@@ -29,9 +29,7 @@ from base import IntegrationTestsBase, test_backends
 
 class _CommonTests():
 
-    # FIXME: Why does this test need to run first in order to pass?
-    #   We must leave some dirty state somewhere in the other tests
-    def test_1_bridge_vlan(self):
+    def test_bridge_vlan(self):
         self.setup_eth(None, True)
         self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-br', 'br-%s' % self.dev_e_client])
         self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-br', 'br-data'])

--- a/tests/integration/ovs.py
+++ b/tests/integration/ovs.py
@@ -111,8 +111,8 @@ class _CommonTests():
         self.assertIn(b'        Port %(ec)b\n            Interface %(ec)b' % {b'ec': self.dev_e_client.encode()}, out)
         self.assertIn(b'        Port %(e2c)b\n            Interface %(e2c)b' % {b'e2c': self.dev_e2_client.encode()}, out)
         # Verify the bridge was tagged 'netplan:true' correctly
-        out = subprocess.check_output(['ovs-vsctl', '--columns=name,external-ids', 'list', 'Port'])
-        self.assertIn(b'ovsbr\nexternal_ids        : {netplan="true"}', out)
+        out = subprocess.check_output(['ovs-vsctl', '--columns=name,external-ids', '-f', 'csv', '-d', 'bare', 'list', 'Bridge'])
+        self.assertIn(b'ovsbr,netplan=true', out)
         self.assert_iface('ovsbr', ['inet 192.170.1.1/24'])
 
     def test_bond_base(self):
@@ -143,8 +143,8 @@ class _CommonTests():
         self.assertIn(b'            Interface %b' % self.dev_e_client.encode(), out)
         self.assertIn(b'            Interface %b' % self.dev_e2_client.encode(), out)
         # Verify the bond was tagged 'netplan:true' correctly
-        out = subprocess.check_output(['ovs-vsctl', '--columns=name,external-ids', 'list', 'Port'])
-        self.assertIn(b'mybond\nexternal_ids        : {netplan="true"}', out)
+        out = subprocess.check_output(['ovs-vsctl', '--columns=name,external-ids', '-f', 'csv', '-d', 'bare', 'list', 'Port'])
+        self.assertIn(b'mybond,netplan=true', out)
         # Verify bond params
         out = subprocess.check_output(['ovs-appctl', 'bond/show', 'mybond'])
         self.assertIn(b'---- mybond ----', out)

--- a/tests/integration/ovs.py
+++ b/tests/integration/ovs.py
@@ -52,10 +52,11 @@ class _CommonTests():
             openvswitch: {}
             addresses: [192.168.20.1/16]
     vlans:
+        #implicitly handled by OVS because of its link
         br-%(ec)s.100:
             id: 100
             link: br-%(ec)s
-            openvswitch: {}''' % {'ec': self.dev_e_client})
+''' % {'ec': self.dev_e_client})
         self.generate_and_settle()
         # Basic verification that the interfaces/ports are set up in OVS
         out = subprocess.check_output(['ovs-vsctl', 'show'])

--- a/tests/integration/ovs.py
+++ b/tests/integration/ovs.py
@@ -218,42 +218,39 @@ class _CommonTests():
     def test_vlan_maas(self):
         self.setup_eth(None, False)
         self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-br', 'ovs0'])
+        self.addCleanup(subprocess.call, ['ip', 'link', 'delete', '%s.21' % self.dev_e_client], stderr=subprocess.DEVNULL)
         with open(self.config, 'w') as f:
             f.write('''network:
     version: 2
     bridges:
         ovs0:
-            addresses:
-            - 10.5.48.11/20
-            interfaces:
-            - %(ec)s.21
+            addresses: [10.5.48.11/20]
+            interfaces: [%(ec)s.21]
             macaddress: 00:1f:16:15:78:6f
             mtu: 1500
             nameservers:
-                addresses:
-                - 10.5.32.99
-                search:
-                - maas
+                addresses: [10.5.32.99]
+                search: [maas]
             openvswitch: {}
             parameters:
                 forward-delay: 15
                 stp: false
     ethernets:
         %(ec)s:
-            addresses:
-            - 10.5.32.26/20
+            addresses: [10.5.32.26/20]
             gateway4: 10.5.32.1
+            match:
+                macaddress: %(e_mac)s
             mtu: 1500
             nameservers:
-                addresses:
-                - 10.5.32.99
-                search:
-                - maas
+                addresses: [10.5.32.99]
+                search: [maas]
+            set-name: %(ec)s
     vlans:
         %(ec)s.21:
             id: 21
             link: %(ec)s
-            mtu: 1500''' % {'ec': self.dev_e_client})
+            mtu: 1500''' % {'ec': self.dev_e_client, 'e_mac': self.dev_e_client_mac})
         self.generate_and_settle()
         # Basic verification that the interfaces/ports are set up in OVS
         out = subprocess.check_output(['ovs-vsctl', 'show'], universal_newlines=True)


### PR DESCRIPTION
## Description
This provides general cleanup of the OVS codebase, such as test and comment improvements.

It also makes sure that left-over OVS interfaces (tagged `netplan=true`) are cleaned up during `netplan apply`, by executing `del-br/del-port` on those interfaces. All `ExecStop=` commands and `RemainAfterExit=true` have been removed and all cleanup is now done via the `netplan-ovs-cleanup.service` unit, which runs prior to the other `netplan-ovs-*.service` units.

I'm adding a new parameter `netplan apply --ovs-only` (called via `netplan-ovs-cleanup.service` as well), which will just clean up all `netplan=true` taged OVS interfaces (Bridges/Ports/Bonds), if they are not defined in the current YAML config.

I reduced the usage of `systemd_escape()` even more, to have it only escape interface names, if they are part of an escaped systemd "path" where they actually need to be escaped (such as `sys-subsystem-net-devices-<ESCAPED_ID>.device`). This avoids having normal interface names, such as `br-data` escaped, which leads to a partly escaped systemd service unit name (e.g. `netplan-ovs-br\x2ddata.service`) and unescaping problems when passing those through subprocess calls.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Closes an open bug in Launchpad.

