### PR TITLE
Openvswitch support (LP: #1728134)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ libnetplan.so.$(NETPLAN_SOVER): parse.o util.o validation.o error.o
 	ln -snf libnetplan.so.$(NETPLAN_SOVER) libnetplan.so
 
 #generate: src/generate.[hc] src/parse.[hc] src/util.[hc] src/networkd.[hc] src/nm.[hc] src/validation.[hc] src/error.[hc]
-generate: libnetplan.so.$(NETPLAN_SOVER) nm.o networkd.o generate.o
+generate: libnetplan.so.$(NETPLAN_SOVER) nm.o networkd.o openvswitch.o generate.o
 	$(CC) $(BUILDFLAGS) $(CFLAGS) $(LDFLAGS) -o $@ $^ -L. -lnetplan `pkg-config --cflags --libs glib-2.0 gio-2.0 yaml-0.1 uuid`
 
 netplan-dbus: src/dbus.c src/_features.h

--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -143,6 +143,12 @@ Virtual devices
      If openvswitch is not available on the system, netplan treats the presence of
      openvswitch configuration as an error.
 
+     Any supported network device that is declared with the ``openvswitch`` mapping
+     (or any bond/bridge that includes an interface with an openvswitch configuration)
+     will be created in openvswitch instead of the defined renderer.
+     In the case of a ``vlan`` definition declared the same way, netplan will create
+     a fake VLAN bridge in openvswitch with the requested vlan properties.
+
      ``external-ids`` (mapping) – since **0.100**
      :   Passed-through directly to OpenVSwitch
 

--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -137,35 +137,36 @@ Virtual devices
 
 :    (networkd backend only) Whether to emit LLDP packets. Off by default.
 
-``openvswitch`` (mapping)
+``openvswitch`` (mapping) – since **0.100**
 
-:    TODO: This is just a stub - we'll update it once we have more OVS structure
-     defined.
+:    This provides additional configuration for the network device for openvswitch.
+     If openvswitch is not available on the system, netplan treats the presence of
+     openvswitch configuration as an error.
 
-     ``external-ids`` (mapping)
+     ``external-ids`` (mapping) – since **0.100**
      :   Passed-through directly to OpenVSwitch
 
-     ``other-config`` (mapping)
+     ``other-config`` (mapping) – since **0.100**
      :   Passed-through directly to OpenVSwitch
 
-     ``lacp`` (scalar)
+     ``lacp`` (scalar) – since **0.100**
      :   Valid for bond interfaces. Accepts ``active``, ``passive` or ``off`` (the default).
 
-     ``fail-mode`` (scalar)
+     ``fail-mode`` (scalar) – since **0.100**
      :   Valid for bridge interfaces. Accepts ``secure`` or ``standalone`` (the default).
 
-     ``mcast-snooping`` (bool)
+     ``mcast-snooping`` (bool) – since **0.100**
      :   Valid for bridge interfaces. False by default.
 
-     ``protocols`` (sequence of scalars)
+     ``protocols`` (sequence of scalars) – since **0.100**
      :   Valid for bridge interfaces or the network section. List of protocols to be used when
          negotiating a connection with the controller. Accepts ``OpenFlow10``, ``OpenFlow11``,
          ``OpenFlow12``, ``OpenFlow13``, ``OpenFlow14``, ``OpenFlow15`` and ``OpenFlow16``.
 
-     ``rstp`` (bool)
+     ``rstp`` (bool) – since **0.100**
      :   Valid for bridge interfaces. False by default.
 
-     ``controller`` (mapping)
+     ``controller`` (mapping) – since **0.100**
      :   Valid for bridge interfaces. Specify an external OpenFlow controller.
 
           ``addresses`` (sequence of scalars)
@@ -177,7 +178,18 @@ Virtual devices
           :   Set the connection mode for the controller. Supported options are
               ``in-band`` and ``out-of-band``. The default is ``in-band``.
 
-     ``ssl`` (mapping)
+     ``ports`` (sequence of sequence of scalars) – since **0.100**
+     :   OpenvSwitch patch ports. Each port is declared as a pair of names
+         which can be referenced as interfaces in dependent virtual devices
+         (bonds, bridges).
+
+         Example:
+
+             openvswitch:
+               ports:
+                 - [patch0-1, patch1-0]
+
+     ``ssl`` (mapping) – since **0.100**
      :   Valid for global ``openvswitch`` settings. Options for configuring SSL
          server endpoint for the switch.
 

--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -165,6 +165,31 @@ Virtual devices
      ``rstp`` (bool)
      :   Valid for bridge interfaces. False by default.
 
+     ``controller`` (mapping)
+     :   Valid for bridge interfaces. Specify an external OpenFlow controller.
+
+          ``addresses`` (sequence of scalars)
+          :   Set the list of addresses to use for the controller targets. The
+              syntax of these addresses is as defined in ovs-vsctl(8). Example:
+              addresses: ``[tcp:127.0.0.1:6653, "ssl:[fe80::1234%eth0]:6653"]``
+
+          ``connection-mode`` (scalar)
+          :   Set the connection mode for the controller. Supported options are
+              ``in-band`` and ``out-of-band``. The default is ``in-band``.
+
+     ``ssl`` (mapping)
+     :   Valid for global ``openvswitch`` settings. Options for configuring SSL
+         server endpoint for the switch.
+
+          ``ca-cert`` (scalar)
+          :   Path to a file containing the CA certificate to be used.
+
+          ``certificate`` (scalar)
+          :   Path to a file containing the server certificate.
+
+          ``private-key`` (scalar)
+          :   Path to a file containing the private key for the server.
+
 ## Common properties for all device types
 
 ``renderer`` (scalar)

--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -151,6 +151,20 @@ Virtual devices
      ``lacp`` (scalar)
      :   Valid for bond interfaces. Accepts ``active``, ``passive` or ``off`` (the default).
 
+     ``fail-mode`` (scalar)
+     :   Valid for bridge interfaces. Accepts ``secure`` or ``standalone`` (the default).
+
+     ``mcast-snooping`` (bool)
+     :   Valid for bridge interfaces. False by default.
+
+     ``protocols`` (sequence of scalars)
+     :   Valid for bridge interfaces or the network section. List of protocols to be used when
+         negotiating a connection with the controller. Accepts ``OpenFlow10``, ``OpenFlow11``,
+         ``OpenFlow12``, ``OpenFlow13``, ``OpenFlow14``, ``OpenFlow15`` and ``OpenFlow16``.
+
+     ``rstp`` (bool)
+     :   Valid for bridge interfaces. False by default.
+
 ## Common properties for all device types
 
 ``renderer`` (scalar)

--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -137,6 +137,17 @@ Virtual devices
 
 :    (networkd backend only) Whether to emit LLDP packets. Off by default.
 
+``openvswitch`` (mapping)
+
+:    TODO: This is just a stub - we'll update it once we have more OVS structure
+     defined.
+
+     ``external-ids`` (mapping)
+     :   Passed-through directly to OpenVSwitch
+
+     ``other-config`` (mapping)
+     :   Passed-through directly to OpenVSwitch
+
 
 ## Common properties for all device types
 

--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -156,7 +156,7 @@ Virtual devices
      :   Passed-through directly to OpenVSwitch
 
      ``lacp`` (scalar) – since **0.100**
-     :   Valid for bond interfaces. Accepts ``active``, ``passive` or ``off`` (the default).
+     :   Valid for bond interfaces. Accepts ``active``, ``passive`` or ``off`` (the default).
 
      ``fail-mode`` (scalar) – since **0.100**
      :   Valid for bridge interfaces. Accepts ``secure`` or ``standalone`` (the default).

--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -148,6 +148,8 @@ Virtual devices
      ``other-config`` (mapping)
      :   Passed-through directly to OpenVSwitch
 
+     ``lacp`` (scalar)
+     :   Valid for bond interfaces. Accepts ``active``, ``passive` or ``off`` (the default).
 
 ## Common properties for all device types
 
@@ -822,6 +824,8 @@ wpasupplicant installed if you let the ``networkd`` renderer handle wifi.
           ``balance-rr`` (round robin). Possible values are ``balance-rr``,
           ``active-backup``, ``balance-xor``, ``broadcast``, ``802.3ad``,
           ``balance-tlb``, and ``balance-alb``.
+          For OpenVSwitch ``active-backup`` and the additional modes
+          ``balance-tcp`` and ``balance-slb`` are supported.
 
      ``lacp-rate`` (scalar)
      :    Set the rate at which LACPDUs are transmitted. This is only useful

--- a/netplan/cli/commands/apply.py
+++ b/netplan/cli/commands/apply.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2018-2020 Canonical, Ltd.
 # Author: Mathieu Trudel-Lapierre <mathieu.trudel-lapierre@canonical.com>
 # Author: Łukasz 'sil2100' Zemczak <lukasz.zemczak@canonical.com>
+# Author: Lukas 'slyon' Märdian <lukas.maerdian@canonical.com>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -28,6 +29,7 @@ import shutil
 import netplan.cli.utils as utils
 from netplan.configmanager import ConfigManager, ConfigurationError
 from netplan.cli.sriov import apply_sriov_config
+from netplan.cli.ovs import apply_ovs_cleanup
 
 import netifaces
 
@@ -38,15 +40,26 @@ class NetplanApply(utils.NetplanCommand):
         super().__init__(command_id='apply',
                          description='Apply current netplan config to running system',
                          leaf=True)
+        self.ovs_only = False
 
     def run(self):  # pragma: nocover (covered in autopkgtest)
-        self.func = NetplanApply.command_apply
+        self.parser.add_argument('--only-ovs-cleanup', action='store_true',
+                                 help='Only clean up old OpenVSwitch interfaces and exit')
+
+        self.func = self.command_apply
 
         self.parse_args()
         self.run_command()
 
-    @staticmethod
-    def command_apply(run_generate=True, sync=False, exit_on_error=True):  # pragma: nocover (covered in autopkgtest)
+    def command_apply(self, run_generate=True, sync=False, exit_on_error=True):  # pragma: nocover (covered in autopkgtest)
+        config_manager = ConfigManager()
+
+        # For certain use-cases, we might want to only apply specific configuration.
+        # If we only need OpenVSwitch cleanup, do that and exit early.
+        if self.ovs_only:
+            NetplanApply.process_ovs_cleanup(config_manager, False, False, exit_on_error)
+            return
+
         # if we are inside a snap, then call dbus to run netplan apply instead
         if "SNAP" in os.environ:
             # TODO: maybe check if we are inside a classic snap and don't do
@@ -74,7 +87,10 @@ class NetplanApply(utils.NetplanCommand):
                 return
 
         old_files_networkd = bool(glob.glob('/run/systemd/network/*netplan-*'))
-        old_files_ovs = bool(glob.glob('/run/systemd/system/netplan-ovs-*'))
+        old_ovs_glob = glob.glob('/run/systemd/system/netplan-ovs-*')
+        # Ignore netplan-ovs-cleanup.service, as it is always there
+        old_ovs_glob.remove('/run/systemd/system/netplan-ovs-cleanup.service')
+        old_files_ovs = bool(old_ovs_glob)
         old_nm_glob = glob.glob('/run/NetworkManager/system-connections/netplan-*')
         nm_ifaces = utils.nm_interfaces(old_nm_glob)
         old_files_nm = bool(old_nm_glob)
@@ -92,7 +108,6 @@ class NetplanApply(utils.NetplanCommand):
             else:
                 raise ConfigurationError("the configuration could not be generated")
 
-        config_manager = ConfigManager()
         devices = netifaces.interfaces()
 
         # Re-start service when
@@ -104,7 +119,10 @@ class NetplanApply(utils.NetplanCommand):
         restart_networkd = bool(glob.glob('/run/systemd/network/*netplan-*'))
         if not restart_networkd and old_files_networkd:
             restart_networkd = True
-        restart_ovs = bool(glob.glob('/run/systemd/system/netplan-ovs-*'))
+        restart_ovs_glob = glob.glob('/run/systemd/system/netplan-ovs-*')
+        # Ignore netplan-ovs-cleanup.service, as it is always there
+        restart_ovs_glob.remove('/run/systemd/system/netplan-ovs-cleanup.service')
+        restart_ovs = bool(restart_ovs_glob)
         if not restart_ovs and old_files_ovs:
             # OVS is managed via systemd units
             restart_networkd = True
@@ -122,14 +140,14 @@ class NetplanApply(utils.NetplanCommand):
             # so let's make sure we only run it iff we're willing to run 'netplan generate'
             if run_generate:
                 utils.systemctl_daemon_reload()
-            ovs_services = ['netplan-ovs-*.service']
+            # Clean up any old netplan related OVS ports/bonds/bridges, if applicable
+            NetplanApply.process_ovs_cleanup(config_manager, old_files_ovs, restart_ovs, exit_on_error)
             wpa_services = ['netplan-wpa-*.service']
             # Historically (up to v0.98) we had netplan-wpa@*.service files, in case of an
             # upgraded system, we need to make sure to stop those.
             if utils.systemctl_is_active('netplan-wpa@*.service'):
                 wpa_services.insert(0, 'netplan-wpa@*.service')
-            utils.systemctl_networkd('stop', sync=sync, extra_services=wpa_services + ovs_services)
-
+            utils.systemctl_networkd('stop', sync=sync, extra_services=wpa_services)
         else:
             logging.debug('no netplan generated networkd configuration exists')
 
@@ -193,7 +211,7 @@ class NetplanApply(utils.NetplanCommand):
         # (re)start backends
         if restart_networkd:
             netplan_wpa = [os.path.basename(f) for f in glob.glob('/run/systemd/system/*.wants/netplan-wpa-*.service')]
-            netplan_ovs = [os.path.basename(f) for f in glob.glob('/run/systemd/system/*.wants/netpalan-ovs-*.service')]
+            netplan_ovs = [os.path.basename(f) for f in glob.glob('/run/systemd/system/*.wants/netplan-ovs-*.service')]
             utils.systemctl_networkd('start', sync=sync, extra_services=netplan_wpa + netplan_ovs)
         if restart_nm:
             utils.systemctl_network_manager('start', sync=sync)
@@ -279,3 +297,12 @@ class NetplanApply(utils.NetplanCommand):
 
         logging.debug(changes)
         return changes
+
+    @staticmethod
+    def process_ovs_cleanup(config_manager, ovs_old, ovs_current, exit_on_error=True):  # pragma: nocover (autopkgtest)
+        try:
+            apply_ovs_cleanup(config_manager, ovs_old, ovs_current)
+        except (OSError, RuntimeError) as e:
+            logging.error(str(e))
+            if exit_on_error:
+                sys.exit(1)

--- a/netplan/cli/commands/apply.py
+++ b/netplan/cli/commands/apply.py
@@ -93,10 +93,12 @@ class NetplanApply(utils.NetplanCommand):
             else:
                 return
 
+        ovs_cleanup_service = '/run/systemd/system/netplan-ovs-cleanup.service'
         old_files_networkd = bool(glob.glob('/run/systemd/network/*netplan-*'))
         old_ovs_glob = glob.glob('/run/systemd/system/netplan-ovs-*')
-        # Ignore netplan-ovs-cleanup.service, as it is always there
-        old_ovs_glob.remove('/run/systemd/system/netplan-ovs-cleanup.service')
+        # Ignore netplan-ovs-cleanup.service, as it can always be there
+        if ovs_cleanup_service in old_ovs_glob:
+            old_ovs_glob.remove(ovs_cleanup_service)
         old_files_ovs = bool(old_ovs_glob)
         old_nm_glob = glob.glob('/run/NetworkManager/system-connections/netplan-*')
         nm_ifaces = utils.nm_interfaces(old_nm_glob, netifaces.interfaces())
@@ -127,8 +129,9 @@ class NetplanApply(utils.NetplanCommand):
         if not restart_networkd and old_files_networkd:
             restart_networkd = True
         restart_ovs_glob = glob.glob('/run/systemd/system/netplan-ovs-*')
-        # Ignore netplan-ovs-cleanup.service, as it is always there
-        restart_ovs_glob.remove('/run/systemd/system/netplan-ovs-cleanup.service')
+        # Ignore netplan-ovs-cleanup.service, as it can always be there
+        if ovs_cleanup_service in restart_ovs_glob:
+            restart_ovs_glob.remove(ovs_cleanup_service)
         restart_ovs = bool(restart_ovs_glob)
         if not restart_ovs and old_files_ovs:
             # OVS is managed via systemd units

--- a/netplan/cli/commands/try_command.py
+++ b/netplan/cli/commands/try_command.py
@@ -80,7 +80,7 @@ class NetplanTry(utils.NetplanCommand):
             self.backup()
             self.setup()
 
-            NetplanApply.command_apply(run_generate=True, sync=True, exit_on_error=False)
+            NetplanApply().command_apply(run_generate=True, sync=True, exit_on_error=False)
 
             self.t.get_confirmation_input(timeout=self.timeout)
         except netplan.terminal.InputRejected:
@@ -114,7 +114,7 @@ class NetplanTry(utils.NetplanCommand):
 
     def revert(self):  # pragma: nocover (requires user input)
         self.config_manager.revert()
-        NetplanApply.command_apply(run_generate=False, sync=True, exit_on_error=False)
+        NetplanApply().command_apply(run_generate=False, sync=True, exit_on_error=False)
         for ifname in self.new_interfaces:
             if ifname not in self.config_manager.bonds and \
                ifname not in self.config_manager.bridges and \

--- a/netplan/cli/ovs.py
+++ b/netplan/cli/ovs.py
@@ -20,6 +20,89 @@ import os
 import subprocess
 
 OPENVSWITCH_OVS_VSCTL = '/usr/bin/ovs-vsctl'
+# Defaults for non-optional settings, as defined here:
+# http://www.openvswitch.org/ovs-vswitchd.conf.db.5.pdf
+DEFAULTS = {
+    # Mandatory columns:
+    'mcast_snooping_enable': 'false',
+    'rstp_enable': 'false',
+}
+GLOBALS = {
+    # Global commands:
+    'set-ssl': ('del-ssl', 'get-ssl'),
+    'set-fail-mode': ('del-fail-mode', 'get-fail-mode'),
+    'set-controller': ('del-controller', 'get-controller'),
+}
+
+
+def _del_col(type, iface, column, value):
+    """Cleanup values from a column (i.e. "column=value")"""
+    default = DEFAULTS.get(column)
+    if default is None:
+        # removes the exact value only if it was set by netplan
+        subprocess.check_call([OPENVSWITCH_OVS_VSCTL, 'remove', type, iface, column, value])
+    elif default and default != value:
+        # reset to default, if its not the default already
+        subprocess.check_call([OPENVSWITCH_OVS_VSCTL, 'set', type, iface, '%s=%s' % (column, default)])
+
+
+def _del_dict(type, iface, column, key, value):
+    """Cleanup values from a dictionary (i.e. "column:key=value")"""
+    # removes the exact value only if it was set by netplan
+    subprocess.check_call([OPENVSWITCH_OVS_VSCTL, 'remove', type, iface, column, key, value])
+
+
+def _del_global(type, iface, key, value):
+    """Cleanup commands from the global namespace"""
+    del_cmd, get_cmd = GLOBALS.get(key, (None, None))
+    if del_cmd == 'del-ssl':
+        iface = None
+
+    if del_cmd:
+        args_get = [OPENVSWITCH_OVS_VSCTL, get_cmd]
+        args_del = [OPENVSWITCH_OVS_VSCTL, del_cmd]
+        if iface:
+            args_get.append(iface)
+            args_del.append(iface)
+        # Check the current value of a global command and compare it to the tag-value, e.g.:
+        # * get-ssl: netplan/global/set-ssl=/private/key.pem,/another/cert.pem,/some/ca-cert.pem
+        # Private key: /private/key.pem
+        # Certificate: /another/cert.pem
+        # CA Certificate: /some/ca-cert.pem
+        # Bootstrap: false
+        # * get-fail-mode: netplan/global/set-fail-mode=secure
+        # secure
+        # * get-controller: netplan/global/set-controller=tcp:127.0.0.1:1337,unix:/some/socket
+        # tcp:127.0.0.1:1337
+        # unix:/some/socket
+        out = subprocess.check_output(args_get, universal_newlines=True)
+        # Clean it only if the exact same value(s) were set by netplan.
+        # Don't touch it if other values were set by another integration.
+        if all(item in out for item in value.split(',')):
+            subprocess.check_call(args_del)
+    else:
+        raise Exception('Reset command unkown for:', key)
+
+
+def clear_setting(type, iface, setting, value):
+    """Check if this setting is in a dict or a colum and delete accordingly"""
+    split = setting.split('/', 2)
+    col = split[1]
+    if col == 'global' and len(split) > 2:
+        _del_global(type, iface, split[2], value)
+    elif len(split) > 2:
+        _del_dict(type, iface, split[1], split[2], value)
+    else:
+        _del_col(type, iface, split[1], value)
+    # Cleanup the tag itself (i.e. "netplan/column[/key]")
+    subprocess.check_call([OPENVSWITCH_OVS_VSCTL, 'remove', type, iface, 'external-ids', setting])
+
+
+def is_ovs_interface(iface, interfaces):
+    if interfaces[iface].get('openvswitch') is not None:
+        return True
+    else:
+        return any(is_ovs_interface(i, interfaces) for i in interfaces[iface].get('interfaces', []))
 
 
 def apply_ovs_cleanup(config_manager, ovs_old, ovs_current):  # pragma: nocover (covered in autopkgtest)
@@ -27,12 +110,20 @@ def apply_ovs_cleanup(config_manager, ovs_old, ovs_current):  # pragma: nocover 
     Query OpenVSwitch state through 'ovs-vsctl' and filter for netplan=true
     tagged ports/bonds and bridges. Delete interfaces which are not defined
     in the current configuration.
+    Also filter for individual settings tagged netplan/<column>[/<key]=value
+    in external-ids and clear them if they have been set by netplan.
     """
     config_manager.parse()
+    ovs_ifaces = set()
+    for i in config_manager.interfaces.keys():
+        if (is_ovs_interface(i, config_manager.interfaces)):
+            ovs_ifaces.add(i)
 
-    # Tear down old OVS interfacess, not defined in the current config
-    # Use 'del-br' on the Interface table, to delete any netplan created VLAN fake bridges
+    # Tear down old OVS interfaces, not defined in the current config.
+    # Use 'del-br' on the Interface table, to delete any netplan created VLAN fake bridges.
+    # Use 'del-bond-iface' on the Interface table, to delete netplan created patch port interfaces
     if os.path.isfile(OPENVSWITCH_OVS_VSCTL):
+        # Step 1: Delete all interfaces, which are not part of the current OVS config
         for t in (('Port', 'del-port'), ('Bridge', 'del-br'), ('Interface', 'del-br')):
             out = subprocess.check_output([OPENVSWITCH_OVS_VSCTL, '--columns=name,external-ids',
                                            '-f', 'csv', '-d', 'bare', '--no-headings', 'list', t[0]],
@@ -41,9 +132,37 @@ def apply_ovs_cleanup(config_manager, ovs_old, ovs_current):  # pragma: nocover 
                 if 'netplan=true' in line:
                     iface = line.split(',')[0]
                     # Skip cleanup if this OVS interface is part of the current netplan OVS config
-                    if config_manager.interfaces.get(iface, {}).get('openvswitch') is not None:
+                    if iface in ovs_ifaces:
                         continue
-                    subprocess.check_call([OPENVSWITCH_OVS_VSCTL, '--if-exists', t[1], iface])
+                    if t[0] == 'Interface' and subprocess.run([OPENVSWITCH_OVS_VSCTL, 'iface-to-br', iface]).returncode > 0:
+                        subprocess.check_call([OPENVSWITCH_OVS_VSCTL, '--if-exists', 'del-bond-iface', iface])
+                    else:
+                        subprocess.check_call([OPENVSWITCH_OVS_VSCTL, '--if-exists', t[1], iface])
+
+        # Step 2: Clean up the settings of the remaining interfaces
+        for t in ('Port', 'Bridge', 'Interface', 'Open_vSwitch', 'Controller'):
+            cols = 'name,external-ids'
+            if t == 'Open_vSwitch':
+                cols = 'external-ids'
+            elif t == 'Controller':
+                cols = '_uuid,external-ids'  # handle _uuid as if it would be the iface 'name'
+            out = subprocess.check_output([OPENVSWITCH_OVS_VSCTL, '--columns=%s' % cols,
+                                           '-f', 'csv', '-d', 'bare', '--no-headings', 'list', t],
+                                          universal_newlines=True)
+            for line in out.splitlines():
+                if 'netplan/' in line:
+                    iface = '.'
+                    extids = line
+                    if t != 'Open_vSwitch':
+                        iface, extids = line.split(',', 1)
+                    # Check each line (interface) if it contains any netplan tagged settings, e.g.:
+                    # ovs0,"iface-id=myhostname netplan=true netplan/external-ids/iface-id=myhostname"
+                    # ovs1,"netplan=true netplan/global/set-fail-mode=standalone netplan/mcast_snooping_enable=false"
+                    for entry in extids.strip('"').split(' '):
+                        if entry.startswith('netplan/') and '=' in entry:
+                            setting, val = entry.split('=', 1)
+                            clear_setting(t, iface, setting, val)
+
     # Show the warning only if we are or have been working with OVS definitions
     elif ovs_old or ovs_current:
         logging.warning('ovs-vsctl is missing, cannot tear down old OpenVSwitch interfaces')

--- a/netplan/cli/ovs.py
+++ b/netplan/cli/ovs.py
@@ -1,0 +1,48 @@
+#!/usr/bin/python3
+#
+# Copyright (C) 2020 Canonical, Ltd.
+# Author: Łukas 'slyon' Märdian <lukas.maerdian@canonical.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+import os
+import subprocess
+
+OPENVSWITCH_OVS_VSCTL = '/usr/bin/ovs-vsctl'
+
+
+def apply_ovs_cleanup(config_manager, ovs_old, ovs_current):  # pragma: nocover (covered in autopkgtest)
+    """
+    Query OpenVSwitch state through 'ovs-vsctl' and filter for netplan=true
+    tagged ports/bonds and bridges. Delete interfaces which are not defined
+    in the current configuration.
+    """
+    config_manager.parse()
+
+    # Tear down old OVS interfacess, not defined in the current config
+    if os.path.isfile(OPENVSWITCH_OVS_VSCTL):
+        for t in (('Port', 'del-port'), ('Bridge', 'del-br')):
+            out = subprocess.check_output([OPENVSWITCH_OVS_VSCTL, '--columns=name,external-ids',
+                                           '-f', 'csv', '-d', 'bare', '--no-headings', 'list', t[0]],
+                                          universal_newlines=True)
+            for line in out.splitlines():
+                if 'netplan=true' in line:
+                    iface = line.split(',')[0]
+                    # Skip cleanup if this OVS interface is part of the current netplan OVS config
+                    if config_manager.interfaces.get(iface, {}).get('openvswitch') is not None:
+                        continue
+                    subprocess.check_call([OPENVSWITCH_OVS_VSCTL, '--if-exists', t[1], iface])
+    # Show the warning only if we are or have been working with OVS definitions
+    elif ovs_old or ovs_current:
+        logging.warning('ovs-vsctl is missing, cannot tear down old OpenVSwitch interfaces')

--- a/netplan/cli/ovs.py
+++ b/netplan/cli/ovs.py
@@ -31,8 +31,9 @@ def apply_ovs_cleanup(config_manager, ovs_old, ovs_current):  # pragma: nocover 
     config_manager.parse()
 
     # Tear down old OVS interfacess, not defined in the current config
+    # Use 'del-br' on the Interface table, to delete any netplan created VLAN fake bridges
     if os.path.isfile(OPENVSWITCH_OVS_VSCTL):
-        for t in (('Port', 'del-port'), ('Bridge', 'del-br')):
+        for t in (('Port', 'del-port'), ('Bridge', 'del-br'), ('Interface', 'del-br')):
             out = subprocess.check_output([OPENVSWITCH_OVS_VSCTL, '--columns=name,external-ids',
                                            '-f', 'csv', '-d', 'bare', '--no-headings', 'list', t[0]],
                                           universal_newlines=True)

--- a/netplan/cli/ovs.py
+++ b/netplan/cli/ovs.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 #
 # Copyright (C) 2020 Canonical, Ltd.
-# Author: Łukas 'slyon' Märdian <lukas.maerdian@canonical.com>
+# Author: Lukas 'slyon' Märdian <lukas.maerdian@canonical.com>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/generate.c
+++ b/src/generate.c
@@ -30,6 +30,7 @@
 #include "parse.h"
 #include "networkd.h"
 #include "nm.h"
+#include "openvswitch.h"
 
 static gchar* rootdir;
 static gchar** files;
@@ -55,7 +56,9 @@ nd_iterator_list(gpointer value, gpointer user_data)
 {
     if (write_networkd_conf((NetplanNetDefinition*) value, (const char*) user_data))
         any_networkd = TRUE;
+
     write_nm_conf((NetplanNetDefinition*) value, (const char*) user_data);
+    write_ovs_conf((NetplanNetDefinition*) value, (const char*) user_data);
 }
 
 
@@ -246,6 +249,7 @@ int main(int argc, char** argv)
     /* Clean up generated config from previous runs */
     cleanup_networkd_conf(rootdir);
     cleanup_nm_conf(rootdir);
+    cleanup_ovs_conf(rootdir);
 
     if (mapping_iface && netdefs) {
         return find_interface(mapping_iface);
@@ -256,6 +260,7 @@ int main(int argc, char** argv)
         g_debug("Generating output files..");
         g_list_foreach (netdefs_ordered, nd_iterator_list, rootdir);
         write_nm_conf_finish(rootdir);
+        write_ovs_conf_finish(rootdir);
         /* We may have written .rules & .link files, thus we must
          * invalidate udevd cache of its config as by default it only
          * invalidates cache at most every 3 seconds. Not sure if this

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -812,19 +812,8 @@ write_wpa_unit(const NetplanNetDefinition* def, const char* rootdir)
 {
     g_autoptr(GError) err = NULL;
     g_autofree gchar *stdouth = NULL;
-    g_autofree gchar *stderrh = NULL;
-    gint exit_status = 0;
 
-    gchar *argv[] = {"bin" "/" "systemd-escape", def->id, NULL};
-    g_spawn_sync("/", argv, NULL, 0, NULL, NULL, &stdouth, &stderrh, &exit_status, &err);
-    g_spawn_check_exit_status(exit_status, &err);
-    if (err != NULL) {
-        // LCOV_EXCL_START
-        g_fprintf(stderr, "failed to ask systemd to escape %s; exit %d\nstdout: '%s'\nstderr: '%s'", def->id, exit_status, stdouth, stderrh);
-        exit(1);
-        // LCOV_EXCL_STOP
-    }
-    g_strstrip(stdouth);
+    stdouth = systemd_escape(def->id);
 
     GString* s = g_string_new("[Unit]\n");
     g_autofree char* path = g_strjoin(NULL, "/run/systemd/system/netplan-wpa-", stdouth, ".service", NULL);

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -583,7 +583,7 @@ write_network_file(const NetplanNetDefinition* def, const char* rootdir, const c
             g_string_append_printf(network, "PrimarySlave=true\n");
     }
 
-    if (def->has_vlans) {
+    if (def->has_vlans && def->backend != NETPLAN_BACKEND_OVS) {
         /* iterate over all netdefs to find VLANs attached to us */
         GList *l = netdefs_ordered;
         const NetplanNetDefinition* nd;

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -459,7 +459,10 @@ combine_dhcp_overrides(const NetplanNetDefinition* def, NetplanDHCPOverrides* co
     }
 }
 
-static void
+/**
+ * Write the needed networkd .network configuration for the selected netplan definition.
+ */
+void
 write_network_file(const NetplanNetDefinition* def, const char* rootdir, const char* path)
 {
     GString* network = NULL;
@@ -563,7 +566,7 @@ write_network_file(const NetplanNetDefinition* def, const char* rootdir, const c
     if (def->type >= NETPLAN_DEF_TYPE_VIRTUAL)
         g_string_append(network, "ConfigureWithoutCarrier=yes\n");
 
-    if (def->bridge) {
+    if (def->bridge && def->backend != NETPLAN_BACKEND_OVS) {
         g_string_append_printf(network, "Bridge=%s\n", def->bridge);
 
         if (def->bridge_params.path_cost || def->bridge_params.port_priority)
@@ -573,7 +576,7 @@ write_network_file(const NetplanNetDefinition* def, const char* rootdir, const c
         if (def->bridge_params.port_priority)
             g_string_append_printf(network, "Priority=%u\n", def->bridge_params.port_priority);
     }
-    if (def->bond) {
+    if (def->bond && def->backend != NETPLAN_BACKEND_OVS) {
         g_string_append_printf(network, "Bond=%s\n", def->bond);
 
         if (def->bond_params.primary_slave)

--- a/src/networkd.h
+++ b/src/networkd.h
@@ -22,3 +22,5 @@
 gboolean write_networkd_conf(const NetplanNetDefinition* def, const char* rootdir);
 void cleanup_networkd_conf(const char* rootdir);
 void enable_networkd(const char* generator_dir);
+
+void write_network_file(const NetplanNetDefinition* def, const char* rootdir, const char* path);

--- a/src/openvswitch.c
+++ b/src/openvswitch.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2020 Canonical, Ltd.
  * Author: Łukasz 'sil2100' Zemczak <lukasz.zemczak@ubuntu.com>
+ *         Lukas 'slyon' Märdian <lukas.maerdian@canonical.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -26,7 +27,7 @@
 #include "util.h"
 
 static void
-write_ovs_systemd_unit(const char* id, const GString* cmds, const char* rootdir, gboolean physical)
+write_ovs_systemd_unit(const char* id, const GString* cmds, const char* rootdir, gboolean physical, const char* dependency)
 {
     g_autofree char* link = g_strjoin(NULL, rootdir ?: "", "/run/systemd/system/systemd-networkd.service.wants/netplan-ovs-", id, ".service", NULL);
     g_autofree char* path = g_strjoin(NULL, "/run/systemd/system/netplan-ovs-", id, ".service", NULL);
@@ -38,9 +39,14 @@ write_ovs_systemd_unit(const char* id, const GString* cmds, const char* rootdir,
         g_string_append_printf(s, "Requires=sys-subsystem-net-devices-%s.device\n", id);
         g_string_append_printf(s, "After=sys-subsystem-net-devices-%s.device\n", id);
     }
-    g_string_append(s, "Before=network.target\nWants=network.target\n\n");
+    g_string_append(s, "Before=network.target\nWants=network.target\n");
+    if (dependency) {
+        g_string_append_printf(s, "Requires=netplan-ovs-%s.service\n", dependency);
+        g_string_append_printf(s, "After=netplan-ovs-%s.service\n", dependency);
+    }
 
-    g_string_append(s, "[Service]\nType=oneshot\n");
+    g_string_append(s, "\n[Service]\nType=oneshot\n");
+    g_string_append(s, "RemainAfterExit=yes\n");
     g_string_append(s, cmds->str);
 
     g_string_free_to_file(s, rootdir, path, NULL);
@@ -61,6 +67,12 @@ write_ovs_systemd_unit(const char* id, const GString* cmds, const char* rootdir,
     g_string_append_printf(s, command, __VA_ARGS__); \
     g_string_append(s, "\n"); \
 }
+#define append_systemd_stop(s, command, ...) \
+{ \
+    g_string_append(s, "ExecStop="); \
+    g_string_append_printf(s, command, __VA_ARGS__); \
+    g_string_append(s, "\n"); \
+}
 
 static char*
 netplan_type_to_table_name(const NetplanDefType type)
@@ -68,7 +80,9 @@ netplan_type_to_table_name(const NetplanDefType type)
     switch (type) {
         case NETPLAN_DEF_TYPE_BRIDGE:
             return "Bridge";
-        default: /* For regular interfaces, bonds and others */
+        case NETPLAN_DEF_TYPE_BOND:
+            return "Port";
+        default: /* For regular interfaces and others */
             return "Interface";
     }
 }
@@ -102,6 +116,72 @@ write_ovs_additional_data(GHashTable *data, const char* type, const gchar* id_es
     }
 }
 
+static char*
+write_ovs_bond_interfaces(const NetplanNetDefinition* def, const gchar* id_escaped, GString* cmds)
+{
+    NetplanNetDefinition* tmp_nd;
+    GHashTableIter iter;
+    gchar* key;
+    guint i = 0;
+    GString* s = NULL;
+
+    if (!def->bridge) {
+        g_fprintf(stderr, "Bond %s needs to be a slave of an OpenVSwitch bridge\n", def->id);
+        exit(1);
+    }
+    tmp_nd = g_hash_table_lookup(netdefs, def->bridge);
+    if (!tmp_nd || tmp_nd->backend != NETPLAN_BACKEND_OVS) {
+        g_fprintf(stderr, "Bond %s: %s needs to be handled by OpenVSwitch\n", def->id, tmp_nd->id);
+        exit(1);
+    }
+
+    s = g_string_new(OPENVSWITCH_OVS_VSCTL " add-bond");
+    g_string_append_printf(s, " %s %s", def->bridge, def->id);
+
+    g_hash_table_iter_init(&iter, netdefs);
+    while (g_hash_table_iter_next(&iter, (gpointer) &key, (gpointer) &tmp_nd)) {
+        if (!g_strcmp0(def->id, tmp_nd->bond)) {
+            /* Append and count bond interfaces */
+            g_string_append_printf(s, " %s", tmp_nd->id);
+            i++;
+        }
+    }
+    if (i < 2) {
+        g_fprintf(stderr, "Bond %s needs to have at least 2 slave interfaces\n", def->id);
+        exit(1);
+    }
+
+    append_systemd_cmd(cmds, s->str, systemd_escape(def->bridge), id_escaped);
+    append_systemd_stop(cmds, OPENVSWITCH_OVS_VSCTL " del-port %s", id_escaped);
+    g_string_free(s, TRUE);
+    return def->bridge;
+}
+
+static void
+write_ovs_tag_netplan(const gchar* id_escaped, GString* cmds)
+{
+    /* Mark this port as created by netplan */
+    append_systemd_cmd(cmds, OPENVSWITCH_OVS_VSCTL " set Port %s external-ids:netplan=true",
+                       id_escaped);
+}
+
+static void
+write_ovs_bond_mode(const NetplanNetDefinition* def, const gchar* id_escaped, GString* cmds)
+{
+    /* OVS supports only "active-backup", "balance-tcp" and "balance-slb":
+     * http://www.openvswitch.org/support/dist-docs/ovs-vswitchd.conf.db.5.txt */
+    if (!strcmp(def->bond_params.mode, "active-backup") ||
+        !strcmp(def->bond_params.mode, "balance-tcp") ||
+        !strcmp(def->bond_params.mode, "balance-slb")) {
+        append_systemd_cmd(cmds, OPENVSWITCH_OVS_VSCTL " set Port %s bond_mode=%s",
+                            id_escaped, def->bond_params.mode);
+    } else {
+        g_fprintf(stderr, "%s: bond mode '%s' not supported by openvswitch\n",
+                    def->id, def->bond_params.mode);
+        exit(1);
+    }
+}
+
 /**
  * Generate the OpenVSwitch systemd units for configuration of the selected netdef
  * @rootdir: If not %NULL, generate configuration in this root directory
@@ -112,12 +192,39 @@ write_ovs_conf(const NetplanNetDefinition* def, const char* rootdir)
 {
     GString* cmds = g_string_new(NULL);
     g_autofree gchar* id_escaped = NULL;
+    g_autofree gchar* dependency = NULL;
     const char* type = netplan_type_to_table_name(def->type);
 
     id_escaped = systemd_escape(def->id);
 
     /* TODO: error out on non-existing ovs-vsctl tool */
     /* TODO: maybe dynamically query the ovs-vsctl tool path? */
+
+    /* For other, more OVS specific settings, we expect the backend to be set to OVS.
+     * The OVS backend is implicitly set, if an interface contains an empty "openvswitch: {}"
+     * key, or an "openvswitch:" key containing only "external-ids" or "other-config". */
+    if (def->backend == NETPLAN_BACKEND_OVS) {
+        switch (def->type) {
+            case NETPLAN_DEF_TYPE_BOND:
+                dependency = write_ovs_bond_interfaces(def, id_escaped, cmds);
+                write_ovs_tag_netplan(id_escaped, cmds);
+                /* Set LACP mode, default to "off" */
+                append_systemd_cmd(cmds, OPENVSWITCH_OVS_VSCTL " set Port %s lacp=%s",
+                                   id_escaped, def->ovs_settings.lacp? def->ovs_settings.lacp : "off");
+                if (def->bond_params.mode) {
+                    write_ovs_bond_mode(def, id_escaped, cmds);
+                }
+                break;
+
+            default:
+                break;
+        }
+    } else {
+        g_debug("openvswitch: definition %s is not for us (backend %i)", def->id, def->backend);
+    }
+
+    /* Set "external-ids" and "other-config" after NETPLAN_BACKEND_OVS interfaces, as bonds,
+     * bridges, etc. might just be created before.*/
 
     /* Common OVS settings can be specified even for non-OVS interfaces */
     if (def->ovs_settings.external_ids && g_hash_table_size(def->ovs_settings.external_ids) > 0) {
@@ -130,16 +237,9 @@ write_ovs_conf(const NetplanNetDefinition* def, const char* rootdir)
                                   id_escaped, cmds, "other-config");
     }
 
-    /* For other, more OVS specific settings, we expect the backend to be set to OVS */
-    if (def->backend == NETPLAN_BACKEND_OVS) {
-        /* TODO */
-    } else {
-        g_debug("openvswitch: definition %s is not for us (backend %i)", def->id, def->backend);
-    }
-
     /* If we need to configure anything for this netdef, write the required systemd unit */
     if (cmds->len > 0)
-        write_ovs_systemd_unit(id_escaped, cmds, rootdir, netplan_type_is_physical(def->type));
+        write_ovs_systemd_unit(id_escaped, cmds, rootdir, netplan_type_is_physical(def->type), dependency);
     g_string_free(cmds, TRUE);
 }
 
@@ -165,7 +265,7 @@ write_ovs_conf_finish(const char* rootdir)
     /* TODO: Add any additional base OVS config we might need */
 
     if (cmds->len > 0)
-        write_ovs_systemd_unit("global", cmds, rootdir, FALSE);
+        write_ovs_systemd_unit("global", cmds, rootdir, FALSE, NULL);
     g_string_free(cmds, TRUE);
 }
 

--- a/src/openvswitch.c
+++ b/src/openvswitch.c
@@ -306,7 +306,8 @@ write_ovs_conf(const NetplanNetDefinition* def, const char* rootdir)
                     write_ovs_bridge_controller_targets(&(def->ovs_settings.controller), def->id, cmds);
                     /* Set controller connection mode, only applicable if at least one controller target address was set */
                     if (def->ovs_settings.controller.connection_mode)
-                        append_systemd_cmd(cmds, OPENVSWITCH_OVS_VSCTL " set controller %s connection-mode=%s", def->id, def->ovs_settings.controller.connection_mode);
+                        append_systemd_cmd(cmds, OPENVSWITCH_OVS_VSCTL " set controller %s connection-mode=%s",
+                                           def->id, def->ovs_settings.controller.connection_mode);
                 }
                 break;
 
@@ -317,8 +318,8 @@ write_ovs_conf(const NetplanNetDefinition* def, const char* rootdir)
                     g_fprintf(stderr, "%s: OpenVSwitch patch port needs to be assigned to a bridge/bond\n", def->id);
                     exit(1);
                 }
-                append_systemd_cmd(cmds, OPENVSWITCH_OVS_VSCTL " set Interface %s type=patch", def->id);
-                append_systemd_cmd(cmds, OPENVSWITCH_OVS_VSCTL " set Interface %s options:peer=%s", def->id, def->peer);
+                append_systemd_cmd(cmds, OPENVSWITCH_OVS_VSCTL " set Interface %s type=patch -- set Interface %s options:peer=%s",
+                                   def->id, def->id, def->peer);
                 write_ovs_tag_netplan(def->id, type, cmds);
                 break;
 
@@ -327,8 +328,7 @@ write_ovs_conf(const NetplanNetDefinition* def, const char* rootdir)
                 dependency = def->vlan_link->id;
                 /* Create a fake VLAN bridge */
                 append_systemd_cmd(cmds, OPENVSWITCH_OVS_VSCTL " --may-exist add-br %s %s %i", def->id, def->vlan_link->id, def->vlan_id)
-                /* This is an OVS fake VLAN bridge, not a VLAN interface */
-                write_ovs_tag_netplan(def->id, "Interface", cmds);
+                write_ovs_tag_netplan(def->id, type, cmds);
                 break;
 
             default:

--- a/src/openvswitch.c
+++ b/src/openvswitch.c
@@ -38,17 +38,17 @@ write_ovs_systemd_unit(const char* id, const GString* cmds, const char* rootdir,
     g_string_append_printf(s, "Description=OpenVSwitch configuration for %s\n", id);
     g_string_append(s, "DefaultDependencies=no\n");
     /* run any ovs-netplan unit only after openvswitch-switch.service is ready */
+    g_string_append_printf(s, "Requires=openvswitch-switch.service\n");
+    g_string_append_printf(s, "After=openvswitch-switch.service\n");
     if (physical) {
         id_escaped = systemd_escape((char*) id);
         g_string_append_printf(s, "Requires=sys-subsystem-net-devices-%s.device\n", id_escaped);
         g_string_append_printf(s, "After=sys-subsystem-net-devices-%s.device\n", id_escaped);
     }
     if (!cleanup) {
-        g_string_append_printf(s, "Requires=openvswitch-switch.service\n");
-        g_string_append_printf(s, "After=openvswitch-switch.service\n");
         g_string_append_printf(s, "After=netplan-ovs-cleanup.service\n");
     } else {
-        /* The netplan-ovs-cleanup unit might run on systems where openvswitch is not installed. */
+        /* The netplan-ovs-cleanup unit shall not run on systems where openvswitch is not installed. */
         g_string_append(s, "ConditionFileIsExecutable=" OPENVSWITCH_OVS_VSCTL "\n");
     }
     g_string_append(s, "Before=network.target\nWants=network.target\n");

--- a/src/openvswitch.c
+++ b/src/openvswitch.c
@@ -1,0 +1,180 @@
+/*
+ * Copyright (C) 2020 Canonical, Ltd.
+ * Author: Łukasz 'sil2100' Zemczak <lukasz.zemczak@ubuntu.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <unistd.h>
+#include <errno.h>
+
+#include <glib.h>
+#include <glib/gprintf.h>
+
+#include "openvswitch.h"
+#include "parse.h"
+#include "util.h"
+
+static void
+write_ovs_systemd_unit(const char* id, const GString* cmds, const char* rootdir, gboolean physical)
+{
+    g_autofree char* link = g_strjoin(NULL, rootdir ?: "", "/run/systemd/system/systemd-networkd.service.wants/netplan-ovs-", id, ".service", NULL);
+    g_autofree char* path = g_strjoin(NULL, "/run/systemd/system/netplan-ovs-", id, ".service", NULL);
+
+    GString* s = g_string_new("[Unit]\n");
+    g_string_append_printf(s, "Description=OpenVSwitch configuration for %s\n", id);
+    g_string_append(s, "DefaultDependencies=no\n");
+    if (physical) {
+        g_string_append_printf(s, "Requires=sys-subsystem-net-devices-%s.device\n", id);
+        g_string_append_printf(s, "After=sys-subsystem-net-devices-%s.device\n", id);
+    }
+    g_string_append(s, "Before=network.target\nWants=network.target\n\n");
+
+    g_string_append(s, "[Service]\nType=oneshot\n");
+    g_string_append(s, cmds->str);
+
+    g_string_free_to_file(s, rootdir, path, NULL);
+
+    safe_mkdir_p_dir(link);
+    if (symlink(path, link) < 0 && errno != EEXIST) {
+        // LCOV_EXCL_START
+        g_fprintf(stderr, "failed to create enablement symlink: %m\n");
+        exit(1);
+        // LCOV_EXCL_STOP
+    }
+}
+
+#define OPENVSWITCH_OVS_VSCTL "/usr/bin/ovs-vsctl"
+#define append_systemd_cmd(s, command, ...) \
+{ \
+    g_string_append(s, "ExecStart="); \
+    g_string_append_printf(s, command, __VA_ARGS__); \
+    g_string_append(s, "\n"); \
+}
+
+static char*
+netplan_type_to_table_name(const NetplanDefType type)
+{
+    switch (type) {
+        case NETPLAN_DEF_TYPE_BRIDGE:
+            return "Bridge";
+        default: /* For regular interfaces, bonds and others */
+            return "Interface";
+    }
+}
+
+static gboolean
+netplan_type_is_physical(const NetplanDefType type)
+{
+    switch (type) {
+        case NETPLAN_DEF_TYPE_ETHERNET:
+        // case NETPLAN_DEF_TYPE_WIFI:
+        // case NETPLAN_DEF_TYPE_MODEM:
+            return TRUE;
+        default:
+            return FALSE;
+    }
+}
+
+static void
+write_ovs_additional_data(GHashTable *data, const char* type, const gchar* id_escaped, GString* cmds, const char* setting)
+{
+    GHashTableIter iter;
+    gchar* key;
+    gchar* value;
+
+    g_hash_table_iter_init(&iter, data);
+    while (g_hash_table_iter_next(&iter, (gpointer) &key, (gpointer) &value)) {
+        /* XXX: we need to check what happens when an invalid key=value pair
+            gets supplied here. We might want to handle this somehow. */
+        append_systemd_cmd(cmds, OPENVSWITCH_OVS_VSCTL " set %s %s %s:%s=%s",
+                           type, id_escaped, setting, key, value);
+    }
+}
+
+/**
+ * Generate the OpenVSwitch systemd units for configuration of the selected netdef
+ * @rootdir: If not %NULL, generate configuration in this root directory
+ *           (useful for testing).
+ */
+void
+write_ovs_conf(const NetplanNetDefinition* def, const char* rootdir)
+{
+    GString* cmds = g_string_new(NULL);
+    g_autofree gchar* id_escaped = NULL;
+    const char* type = netplan_type_to_table_name(def->type);
+
+    id_escaped = systemd_escape(def->id);
+
+    /* TODO: error out on non-existing ovs-vsctl tool */
+    /* TODO: maybe dynamically query the ovs-vsctl tool path? */
+
+    /* Common OVS settings can be specified even for non-OVS interfaces */
+    if (def->ovs_settings.external_ids && g_hash_table_size(def->ovs_settings.external_ids) > 0) {
+        write_ovs_additional_data(def->ovs_settings.external_ids, type,
+                                  id_escaped, cmds, "external-ids");
+    }
+
+    if (def->ovs_settings.other_config && g_hash_table_size(def->ovs_settings.other_config) > 0) {
+        write_ovs_additional_data(def->ovs_settings.other_config, type,
+                                  id_escaped, cmds, "other-config");
+    }
+
+    /* For other, more OVS specific settings, we expect the backend to be set to OVS */
+    if (def->backend == NETPLAN_BACKEND_OVS) {
+        /* TODO */
+    } else {
+        g_debug("openvswitch: definition %s is not for us (backend %i)", def->id, def->backend);
+    }
+
+    /* If we need to configure anything for this netdef, write the required systemd unit */
+    if (cmds->len > 0)
+        write_ovs_systemd_unit(id_escaped, cmds, rootdir, netplan_type_is_physical(def->type));
+    g_string_free(cmds, TRUE);
+}
+
+/**
+ * Finalize the OpenVSwitch configuration (global config)
+ */
+void
+write_ovs_conf_finish(const char* rootdir)
+{
+    GString* cmds = g_string_new(NULL);
+
+    /* Global external-ids and other-config settings */
+    if (ovs_settings_global.external_ids && g_hash_table_size(ovs_settings_global.external_ids) > 0) {
+        write_ovs_additional_data(ovs_settings_global.external_ids, "open_vswitch",
+                                  ".", cmds, "external-ids");
+    }
+
+    if (ovs_settings_global.other_config && g_hash_table_size(ovs_settings_global.other_config) > 0) {
+        write_ovs_additional_data(ovs_settings_global.other_config, "open_vswitch",
+                                  ".", cmds, "other-config");
+    }
+
+    /* TODO: Add any additional base OVS config we might need */
+
+    if (cmds->len > 0)
+        write_ovs_systemd_unit("global", cmds, rootdir, FALSE);
+    g_string_free(cmds, TRUE);
+}
+
+/**
+ * Clean up all generated configurations in @rootdir from previous runs.
+ */
+void
+cleanup_ovs_conf(const char* rootdir)
+{
+    unlink_glob(rootdir, "/run/systemd/system/systemd-networkd.service.wants/netplan-ovs-*.service");
+    unlink_glob(rootdir, "/run/systemd/system/netplan-ovs-*.service");
+}

--- a/src/openvswitch.c
+++ b/src/openvswitch.c
@@ -38,7 +38,7 @@ write_ovs_systemd_unit(const char* id, const GString* cmds, const char* rootdir,
     g_string_append_printf(s, "Description=OpenVSwitch configuration for %s\n", id);
     g_string_append(s, "DefaultDependencies=no\n");
     /* run any ovs-netplan unit only after openvswitch-switch.service is ready */
-    g_string_append_printf(s, "Requires=openvswitch-switch.service\n");
+    g_string_append_printf(s, "Wants=openvswitch-switch.service\n");
     g_string_append_printf(s, "After=openvswitch-switch.service\n");
     if (physical) {
         id_escaped = systemd_escape((char*) id);
@@ -106,6 +106,29 @@ netplan_type_is_physical(const NetplanDefType type)
 }
 
 static void
+write_ovs_tag_setting(const gchar* id, const char* type, const char* col, const char* key, const char* value, GString* cmds)
+{
+    g_assert(col);
+    g_assert(value);
+    g_autofree char *clean_value = g_strdup(value);
+    /* Replace " " -> "," if value contains spaces */
+    if (strchr(value, ' ')) {
+        char **split = g_strsplit(value, " ", -1);
+        g_free(clean_value);
+        clean_value = g_strjoinv(",", split);
+        g_strfreev(split);
+    }
+
+    GString* s = g_string_new("external-ids:netplan/");
+    g_string_append_printf(s, "%s", col);
+    if (key)
+        g_string_append_printf(s, "/%s", key);
+    g_string_append_printf(s, "=%s", clean_value);
+    append_systemd_cmd(cmds, OPENVSWITCH_OVS_VSCTL " set %s %s %s", type, id, s->str);
+    g_string_free(s, TRUE);
+}
+
+static void
 write_ovs_additional_data(GHashTable *data, const char* type, const gchar* id, GString* cmds, const char* setting)
 {
     GHashTableIter iter;
@@ -118,7 +141,20 @@ write_ovs_additional_data(GHashTable *data, const char* type, const gchar* id, G
             gets supplied here. We might want to handle this somehow. */
         append_systemd_cmd(cmds, OPENVSWITCH_OVS_VSCTL " set %s %s %s:%s=%s",
                            type, id, setting, key, value);
+        write_ovs_tag_setting(id, type, setting, key, value, cmds);
     }
+}
+
+static void
+setup_patch_port(GString* s, const NetplanNetDefinition* def)
+{
+    /* Execute the setup commands to create an OVS patch port atomically within
+     * the same command where this virtual interface is created. Either as a
+     * Port+Interface of an OVS bridge or as a Interface of an OVS bond. This
+     * avoids delays in the PatchPort creation and thus potential races. */
+    g_assert(def->type == NETPLAN_DEF_TYPE_PORT);
+    g_string_append_printf(s, " -- set Interface %s type=patch options:peer=%s",
+                           def->id, def->peer);
 }
 
 static char*
@@ -129,6 +165,7 @@ write_ovs_bond_interfaces(const NetplanNetDefinition* def, GString* cmds)
     gchar* key;
     guint i = 0;
     GString* s = NULL;
+    GString* patch_ports = g_string_new("");
 
     if (!def->bridge) {
         g_fprintf(stderr, "Bond %s needs to be a slave of an OpenVSwitch bridge\n", def->id);
@@ -144,6 +181,8 @@ write_ovs_bond_interfaces(const NetplanNetDefinition* def, GString* cmds)
             /* Append and count bond interfaces */
             g_string_append_printf(s, " %s", tmp_nd->id);
             i++;
+            if (tmp_nd->type == NETPLAN_DEF_TYPE_PORT)
+                setup_patch_port(patch_ports, tmp_nd);
         }
     }
     if (i < 2) {
@@ -151,6 +190,8 @@ write_ovs_bond_interfaces(const NetplanNetDefinition* def, GString* cmds)
         exit(1);
     }
 
+    g_string_append(s, patch_ports->str);
+    g_string_free(patch_ports, TRUE);
     append_systemd_cmd(cmds, s->str, def->bridge, def->id);
     g_string_free(s, TRUE);
     return def->bridge;
@@ -167,13 +208,15 @@ write_ovs_tag_netplan(const gchar* id, const char* type, GString* cmds)
 static void
 write_ovs_bond_mode(const NetplanNetDefinition* def, GString* cmds)
 {
+    char* value = NULL;
     /* OVS supports only "active-backup", "balance-tcp" and "balance-slb":
      * http://www.openvswitch.org/support/dist-docs/ovs-vswitchd.conf.db.5.txt */
     if (!strcmp(def->bond_params.mode, "active-backup") ||
         !strcmp(def->bond_params.mode, "balance-tcp") ||
         !strcmp(def->bond_params.mode, "balance-slb")) {
-        append_systemd_cmd(cmds, OPENVSWITCH_OVS_VSCTL " set Port %s bond_mode=%s",
-                           def->id, def->bond_params.mode);
+        value = def->bond_params.mode;
+        append_systemd_cmd(cmds, OPENVSWITCH_OVS_VSCTL " set Port %s bond_mode=%s", def->id, value);
+        write_ovs_tag_setting(def->id, "Port", "bond_mode", NULL, value, cmds);
     } else {
         g_fprintf(stderr, "%s: bond mode '%s' not supported by openvswitch\n",
                   def->id, def->bond_params.mode);
@@ -195,7 +238,12 @@ write_ovs_bridge_interfaces(const NetplanNetDefinition* def, GString* cmds)
         /* OVS bonds will connect to their OVS bridge and create the interface/port themselves */
         if ((tmp_nd->type != NETPLAN_DEF_TYPE_BOND || tmp_nd->backend != NETPLAN_BACKEND_OVS)
             && !g_strcmp0(def->id, tmp_nd->bridge)) {
-            append_systemd_cmd(cmds,  OPENVSWITCH_OVS_VSCTL " --may-exist add-port %s %s", def->id, tmp_nd->id);
+            GString * patch_ports = g_string_new("");
+            if (tmp_nd->type == NETPLAN_DEF_TYPE_PORT)
+                setup_patch_port(patch_ports, tmp_nd);
+            append_systemd_cmd(cmds, OPENVSWITCH_OVS_VSCTL " --may-exist add-port %s %s%s",
+                               def->id, tmp_nd->id, patch_ports->str);
+            g_string_free(patch_ports, TRUE);
         }
     }
 }
@@ -203,20 +251,14 @@ write_ovs_bridge_interfaces(const NetplanNetDefinition* def, GString* cmds)
 static void
 write_ovs_protocols(const NetplanOVSSettings* ovs_settings, const gchar* bridge, GString* cmds)
 {
+    g_assert(bridge);
     GString* s = g_string_new(g_array_index(ovs_settings->protocols, char*, 0));
 
     for (unsigned i = 1; i < ovs_settings->protocols->len; ++i)
         g_string_append_printf(s, ",%s", g_array_index(ovs_settings->protocols, char*, i));
 
-    /* This is typically done per-bridge, but OVS also allows setting protocols
-       for when establishing an OpenFlow session. */
-    if (bridge) {
-        append_systemd_cmd(cmds, OPENVSWITCH_OVS_VSCTL " set Bridge %s protocols=%s", bridge, s->str);
-    }
-    else {
-        append_systemd_cmd(cmds, OPENVSWITCH_OVS_OFCTL " -O %s", s->str);
-    }
-
+    append_systemd_cmd(cmds, OPENVSWITCH_OVS_VSCTL " set Bridge %s protocols=%s", bridge, s->str);
+    write_ovs_tag_setting(bridge, "Bridge", "protocols", NULL, s->str, cmds);
     g_string_free(s, TRUE);
 }
 
@@ -251,6 +293,7 @@ write_ovs_bridge_controller_targets(const NetplanOVSController* controller, cons
     }
 
     append_systemd_cmd(cmds, OPENVSWITCH_OVS_VSCTL " set-controller %s %s", bridge, s->str);
+    write_ovs_tag_setting(bridge, "Bridge", "global", "set-controller", s->str, cmds);
     g_string_free(s, TRUE);
 }
 
@@ -266,6 +309,7 @@ write_ovs_conf(const NetplanNetDefinition* def, const char* rootdir)
     gchar* dependency = NULL;
     const char* type = netplan_type_to_table_name(def->type);
     g_autofree char* base_config_path = NULL;
+    char* value = NULL;
 
     /* TODO: maybe dynamically query the ovs-vsctl tool path? */
 
@@ -278,8 +322,9 @@ write_ovs_conf(const NetplanNetDefinition* def, const char* rootdir)
                 dependency = write_ovs_bond_interfaces(def, cmds);
                 write_ovs_tag_netplan(def->id, type, cmds);
                 /* Set LACP mode, default to "off" */
-                append_systemd_cmd(cmds, OPENVSWITCH_OVS_VSCTL " set Port %s lacp=%s",
-                                   def->id, def->ovs_settings.lacp? def->ovs_settings.lacp : "off");
+                value = def->ovs_settings.lacp? def->ovs_settings.lacp : "off";
+                append_systemd_cmd(cmds, OPENVSWITCH_OVS_VSCTL " set Port %s lacp=%s", def->id, value);
+                write_ovs_tag_setting(def->id, type, "lacp", NULL, value, cmds);
                 if (def->bond_params.mode) {
                     write_ovs_bond_mode(def, cmds);
                 }
@@ -289,25 +334,32 @@ write_ovs_conf(const NetplanNetDefinition* def, const char* rootdir)
                 write_ovs_bridge_interfaces(def, cmds);
                 write_ovs_tag_netplan(def->id, type, cmds);
                 /* Set fail-mode, default to "standalone" */
-                append_systemd_cmd(cmds, OPENVSWITCH_OVS_VSCTL " set-fail-mode %s %s",
-                                   def->id, def->ovs_settings.fail_mode? def->ovs_settings.fail_mode : "standalone");
+                value = def->ovs_settings.fail_mode? def->ovs_settings.fail_mode : "standalone";
+                append_systemd_cmd(cmds, OPENVSWITCH_OVS_VSCTL " set-fail-mode %s %s", def->id, value);
+                write_ovs_tag_setting(def->id, type, "global", "set-fail-mode", value, cmds);
                 /* Enable/disable mcast-snooping */ 
-                append_systemd_cmd(cmds, OPENVSWITCH_OVS_VSCTL " set Bridge %s mcast_snooping_enable=%s",
-                                   def->id, def->ovs_settings.mcast_snooping? "true" : "false");
+                value = def->ovs_settings.mcast_snooping? "true" : "false";
+                append_systemd_cmd(cmds, OPENVSWITCH_OVS_VSCTL " set Bridge %s mcast_snooping_enable=%s", def->id, value);
+                write_ovs_tag_setting(def->id, type, "mcast_snooping_enable", NULL, value, cmds);
                 /* Enable/disable rstp */
-                append_systemd_cmd(cmds, OPENVSWITCH_OVS_VSCTL " set Bridge %s rstp_enable=%s",
-                                   def->id, def->ovs_settings.rstp? "true" : "false");
+                value = def->ovs_settings.rstp? "true" : "false";
+                append_systemd_cmd(cmds, OPENVSWITCH_OVS_VSCTL " set Bridge %s rstp_enable=%s", def->id, value);
+                write_ovs_tag_setting(def->id, type, "rstp_enable", NULL, value, cmds);
                 /* Set protocols */
                 if (def->ovs_settings.protocols && def->ovs_settings.protocols->len > 0) {
                     write_ovs_protocols(&(def->ovs_settings), def->id, cmds);
+                } else if (ovs_settings_global.protocols && ovs_settings_global.protocols->len > 0) {
+                    write_ovs_protocols(&(ovs_settings_global), def->id, cmds);
                 }
                 /* Set controller target addresses */
                 if (def->ovs_settings.controller.addresses && def->ovs_settings.controller.addresses->len > 0) {
                     write_ovs_bridge_controller_targets(&(def->ovs_settings.controller), def->id, cmds);
                     /* Set controller connection mode, only applicable if at least one controller target address was set */
-                    if (def->ovs_settings.controller.connection_mode)
-                        append_systemd_cmd(cmds, OPENVSWITCH_OVS_VSCTL " set controller %s connection-mode=%s",
-                                           def->id, def->ovs_settings.controller.connection_mode);
+                    if (def->ovs_settings.controller.connection_mode) {
+                        value = def->ovs_settings.controller.connection_mode;
+                        append_systemd_cmd(cmds, OPENVSWITCH_OVS_VSCTL " set Controller %s connection-mode=%s", def->id, value);
+                        write_ovs_tag_setting(def->id, "Controller", "connection-mode", NULL, value, cmds);
+                    }
                 }
                 break;
 
@@ -318,9 +370,13 @@ write_ovs_conf(const NetplanNetDefinition* def, const char* rootdir)
                     g_fprintf(stderr, "%s: OpenVSwitch patch port needs to be assigned to a bridge/bond\n", def->id);
                     exit(1);
                 }
-                append_systemd_cmd(cmds, OPENVSWITCH_OVS_VSCTL " set Interface %s type=patch -- set Interface %s options:peer=%s",
-                                   def->id, def->id, def->peer);
-                write_ovs_tag_netplan(def->id, type, cmds);
+                /* There is no OVS Port which we could tag netplan=true if this
+                 * patch port is assigned as an OVS bond interface. Tag the
+                 * Interface instead, to clean it up from a bond. */
+                if (def->bond)
+                    write_ovs_tag_netplan(def->id, "Interface", cmds);
+                else
+                    write_ovs_tag_netplan(def->id, type, cmds);
                 break;
 
             case NETPLAN_DEF_TYPE_VLAN:
@@ -341,7 +397,18 @@ write_ovs_conf(const NetplanNetDefinition* def, const char* rootdir)
         base_config_path = g_strjoin(NULL, "run/systemd/network/10-netplan-", def->id, NULL);
         write_network_file(def, rootdir, base_config_path);
     } else {
-        g_debug("openvswitch: definition %s is not for us (backend %i)", def->id, def->backend);
+        /* Other interfaces must be part of an OVS bridge or bond to carry additional data */
+        if (   (def->ovs_settings.external_ids && g_hash_table_size(def->ovs_settings.external_ids) > 0)
+            || (def->ovs_settings.other_config && g_hash_table_size(def->ovs_settings.other_config) > 0)) {
+            dependency = def->bridge?: def->bond;
+            if (!dependency) {
+                g_fprintf(stderr, "%s: Interface needs to be assigned to an OVS bridge/bond to carry external-ids/other-config\n", def->id);
+                exit(1);
+            }
+        } else {
+            g_debug("openvswitch: definition %s is not for us (backend %i)", def->id, def->backend);
+            return;
+        }
     }
 
     /* Set "external-ids" and "other-config" after NETPLAN_BACKEND_OVS interfaces, as bonds,
@@ -383,16 +450,16 @@ write_ovs_conf_finish(const char* rootdir)
                                   ".", cmds, "other-config");
     }
 
-    if (ovs_settings_global.protocols && ovs_settings_global.protocols->len > 0) {
-        write_ovs_protocols(&ovs_settings_global, NULL, cmds);
-    }
-
     if (ovs_settings_global.ssl.client_key && ovs_settings_global.ssl.client_certificate &&
         ovs_settings_global.ssl.ca_certificate) {
-        append_systemd_cmd(cmds, OPENVSWITCH_OVS_VSCTL " set-ssl %s %s %s",
-                           ovs_settings_global.ssl.client_key,
-                           ovs_settings_global.ssl.client_certificate,
-                           ovs_settings_global.ssl.ca_certificate);
+        GString* value = g_string_new(NULL);
+        g_string_printf(value, "%s %s %s",
+                        ovs_settings_global.ssl.client_key,
+                        ovs_settings_global.ssl.client_certificate,
+                        ovs_settings_global.ssl.ca_certificate);
+        append_systemd_cmd(cmds, OPENVSWITCH_OVS_VSCTL " set-ssl %s", value->str);
+        write_ovs_tag_setting(".", "open_vswitch", "global", "set-ssl", value->str, cmds);
+        g_string_free(value, TRUE);
     }
 
     if (cmds->len > 0)

--- a/src/openvswitch.c
+++ b/src/openvswitch.c
@@ -326,7 +326,10 @@ write_ovs_conf(const NetplanNetDefinition* def, const char* rootdir)
                 append_systemd_stop(cmds, OPENVSWITCH_OVS_VSCTL " --if-exists del-port %s", def->id);
                 break;
 
-            default: g_assert_not_reached(); // LCOV_EXCL_LINE
+            default:
+                g_fprintf(stderr, "%s: This device type is not supported with the OpenVSwitch backend\n", def->id);
+                exit(1);
+                break;
         }
 
         /* Try writing out a base config */

--- a/src/openvswitch.c
+++ b/src/openvswitch.c
@@ -328,7 +328,7 @@ write_ovs_conf(const NetplanNetDefinition* def, const char* rootdir)
                 /* Create a fake VLAN bridge */
                 append_systemd_cmd(cmds, OPENVSWITCH_OVS_VSCTL " --may-exist add-br %s %s %i", def->id, def->vlan_link->id, def->vlan_id)
                 /* This is an OVS fake VLAN bridge, not a VLAN interface */
-                write_ovs_tag_netplan(def->id, "Bridge", cmds);
+                write_ovs_tag_netplan(def->id, "Interface", cmds);
                 break;
 
             default:

--- a/src/openvswitch.c
+++ b/src/openvswitch.c
@@ -224,6 +224,48 @@ write_ovs_protocols(const NetplanOVSSettings* ovs_settings, const gchar* bridge,
     g_string_free(s, TRUE);
 }
 
+static gboolean
+check_ovs_ssl(gchar* target)
+{
+    /* Check if target needs ssl */
+    if (g_str_has_prefix(target, "ssl:") || g_str_has_prefix(target, "pssl:")) {
+        /* Check if SSL is configured in ovs_settings_global.ssl */
+        if (!ovs_settings_global.ssl.ca_certificate || !ovs_settings_global.ssl.client_certificate ||
+            !ovs_settings_global.ssl.client_key) {
+            g_fprintf(stderr, "ERROR: openvswitch bridge controller target '%s' needs SSL configuration, but global 'openvswitch.ssl' settings are not set\n", target);
+            exit(1);
+        }
+        return TRUE;
+    }
+    return FALSE;
+}
+
+static void
+write_ovs_bridge_controller_targets(const NetplanOVSController* controller, const gchar* bridge, GString* cmds)
+{
+    g_autofree gchar* ssl = "";
+    gchar* target = g_array_index(controller->addresses, char*, 0);
+    gboolean needs_ssl = check_ovs_ssl(target);
+    GString* s = g_string_new(target);
+
+    for (unsigned i = 1; i < controller->addresses->len; ++i) {
+        target = g_array_index(controller->addresses, char*, i);
+        if (!needs_ssl)
+            needs_ssl = check_ovs_ssl(target);
+        g_string_append_printf(s, " %s", target);
+    }
+
+    if (needs_ssl) {
+        ssl = g_strdup_printf(" --private-key %s --certificate %s --ca-cert %s",
+                              ovs_settings_global.ssl.client_key,
+                              ovs_settings_global.ssl.client_certificate,
+                              ovs_settings_global.ssl.ca_certificate);
+    }
+
+    append_systemd_cmd(cmds, OPENVSWITCH_OVS_VSCTL "%s set-controller %s %s", ssl, bridge, s->str);
+    g_string_free(s, TRUE);
+}
+
 /**
  * Generate the OpenVSwitch systemd units for configuration of the selected netdef
  * @rootdir: If not %NULL, generate configuration in this root directory
@@ -275,10 +317,20 @@ write_ovs_conf(const NetplanNetDefinition* def, const char* rootdir)
                 if (def->ovs_settings.protocols && def->ovs_settings.protocols->len > 0) {
                     write_ovs_protocols(&(def->ovs_settings), def->id, cmds);
                 }
+                /* Set controller target addresses */
+                if (def->ovs_settings.controller.addresses && def->ovs_settings.controller.addresses->len > 0) {
+                    write_ovs_bridge_controller_targets(&(def->ovs_settings.controller), def->id, cmds);
+                    /* Set controller connection mode, only applicable if at least one controller target address was set */
+                    if (def->ovs_settings.controller.connection_mode)
+                        append_systemd_cmd(cmds, OPENVSWITCH_OVS_VSCTL " set controller %s connection-mode=%s", def->id, def->ovs_settings.controller.connection_mode);
+                }
                 break;
 
+            // LCOV_EXCL_START
             default:
-                break;
+                g_assert_not_reached();
+                //break;
+            // LCOV_EXCL_STOP
         }
 
         /* Try writing out a base config */

--- a/src/openvswitch.c
+++ b/src/openvswitch.c
@@ -326,6 +326,15 @@ write_ovs_conf(const NetplanNetDefinition* def, const char* rootdir)
                 append_systemd_stop(cmds, OPENVSWITCH_OVS_VSCTL " --if-exists del-port %s", def->id);
                 break;
 
+            case NETPLAN_DEF_TYPE_VLAN:
+                g_assert(def->vlan_link);
+                dependency = def->vlan_link->id;
+                /* Create a fake VLAN bridge */
+                append_systemd_cmd(cmds, OPENVSWITCH_OVS_VSCTL " --may-exist add-br %s %s %i", def->id, def->vlan_link->id, def->vlan_id)
+                append_systemd_stop(cmds, OPENVSWITCH_OVS_VSCTL " del-br %s", def->id);
+                write_ovs_tag_netplan(def->id, cmds);
+                break;
+
             default:
                 g_fprintf(stderr, "%s: This device type is not supported with the OpenVSwitch backend\n", def->id);
                 exit(1);

--- a/src/openvswitch.c
+++ b/src/openvswitch.c
@@ -191,7 +191,8 @@ write_ovs_bridge_interfaces(const NetplanNetDefinition* def, GString* cmds)
     g_hash_table_iter_init(&iter, netdefs);
     while (g_hash_table_iter_next(&iter, (gpointer) &key, (gpointer) &tmp_nd)) {
         /* OVS bonds will connect to their OVS bridge and create the interface/port themselves */
-        if (tmp_nd->type != NETPLAN_DEF_TYPE_BOND && !g_strcmp0(def->id, tmp_nd->bridge)) {
+        if ((tmp_nd->type != NETPLAN_DEF_TYPE_BOND || tmp_nd->backend != NETPLAN_BACKEND_OVS)
+            && !g_strcmp0(def->id, tmp_nd->bridge)) {
             append_systemd_cmd(cmds,  OPENVSWITCH_OVS_VSCTL " --may-exist add-port %s %s", def->id, tmp_nd->id);
             append_systemd_stop(cmds, OPENVSWITCH_OVS_VSCTL " del-port %s %s", def->id, tmp_nd->id);
         }

--- a/src/openvswitch.h
+++ b/src/openvswitch.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2016 Canonical, Ltd.
- * Author: Martin Pitt <martin.pitt@ubuntu.com>
+ * Copyright (C) 2020 Canonical, Ltd.
+ * Author: Łukasz 'sil2100' Zemczak <lukasz.zemczak@ubuntu.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,14 +17,8 @@
 
 #pragma once
 
-GHashTable* wifi_frequency_24;
-GHashTable* wifi_frequency_5;
+#include "parse.h"
 
-void safe_mkdir_p_dir(const char* file_path);
-void g_string_free_to_file(GString* s, const char* rootdir, const char* path, const char* suffix);
-void unlink_glob(const char* rootdir, const char* _glob);
-
-int wifi_get_freq24(int channel);
-int wifi_get_freq5(int channel);
-
-gchar* systemd_escape(char* string);
+void write_ovs_conf(const NetplanNetDefinition* def, const char* rootdir);
+void write_ovs_conf_finish(const char* rootdir);
+void cleanup_ovs_conf(const char* rootdir);

--- a/src/parse.c
+++ b/src/parse.c
@@ -178,6 +178,56 @@ assert_valid_id(yaml_node_t* node, GError** error)
     return TRUE;
 }
 
+static void
+initialize_dhcp_overrides(NetplanDHCPOverrides* overrides)
+{
+    overrides->use_dns = TRUE;
+    overrides->use_domains = NULL;
+    overrides->use_ntp = TRUE;
+    overrides->send_hostname = TRUE;
+    overrides->use_hostname = TRUE;
+    overrides->use_mtu = TRUE;
+    overrides->use_routes = TRUE;
+    overrides->hostname = NULL;
+    overrides->metric = NETPLAN_METRIC_UNSPEC;
+}
+
+static void
+initialize_ovs_settings(NetplanOVSSettings* ovs_settings)
+{
+    ovs_settings->mcast_snooping = FALSE;
+    ovs_settings->rstp = FALSE;
+}
+
+static  NetplanNetDefinition*
+netplan_netdef_new(const char* id, NetplanDefType type, NetplanBackend backend)
+{
+    /* create new network definition */
+    cur_netdef = g_new0(NetplanNetDefinition, 1);
+    cur_netdef->type = type;
+    cur_netdef->backend = backend ?: NETPLAN_BACKEND_NONE;
+    cur_netdef->id = g_strdup(id);
+
+    /* Set some default values */
+    cur_netdef->vlan_id = G_MAXUINT; /* 0 is a valid ID */
+    cur_netdef->tunnel.mode = NETPLAN_TUNNEL_MODE_UNKNOWN;
+    cur_netdef->dhcp_identifier = g_strdup("duid"); /* keep networkd's default */
+    /* systemd-networkd defaults to IPv6 LL enabled; keep that default */
+    cur_netdef->linklocal.ipv6 = TRUE;
+    cur_netdef->sriov_vlan_filter = FALSE;
+
+    /* DHCP override defaults */
+    initialize_dhcp_overrides(&cur_netdef->dhcp4_overrides);
+    initialize_dhcp_overrides(&cur_netdef->dhcp6_overrides);
+
+    /* OpenVSwitch defaults */
+    initialize_ovs_settings(&cur_netdef->ovs_settings);
+
+    g_hash_table_insert(netdefs, cur_netdef->id, cur_netdef);
+    netdefs_ordered = g_list_append(netdefs_ordered, cur_netdef);
+    return cur_netdef;
+}
+
 /****************************************************
  * Data types and functions for interpreting YAML nodes
  ****************************************************/
@@ -839,11 +889,16 @@ handle_addresses(yaml_document_t* doc, yaml_node_t* node, const void* _, GError*
         if (is_ip4_address(addr)) {
             if (prefix_len_num == 0 || prefix_len_num > 32)
                 return yaml_error(node, error, "invalid prefix length in address '%s'", scalar(entry));
-
             if (!cur_netdef->ip4_addresses)
                 cur_netdef->ip4_addresses = g_array_new(FALSE, FALSE, sizeof(char*));
+
+            /* Do not append the same IP (on multiple passes), if it is already contained */
+            for (unsigned i = 0; i < cur_netdef->ip4_addresses->len; ++i)
+                if (!g_strcmp0(scalar(entry), g_array_index(cur_netdef->ip4_addresses, char*, i)))
+                    goto skip_ip4;
             char* s = g_strdup(scalar(entry));
             g_array_append_val(cur_netdef->ip4_addresses, s);
+skip_ip4:
             continue;
         }
 
@@ -853,8 +908,14 @@ handle_addresses(yaml_document_t* doc, yaml_node_t* node, const void* _, GError*
                 return yaml_error(node, error, "invalid prefix length in address '%s'", scalar(entry));
             if (!cur_netdef->ip6_addresses)
                 cur_netdef->ip6_addresses = g_array_new(FALSE, FALSE, sizeof(char*));
+
+            /* Do not append the same IP (on multiple passes), if it is already contained */
+            for (unsigned i = 0; i < cur_netdef->ip6_addresses->len; ++i)
+                if (!g_strcmp0(scalar(entry), g_array_index(cur_netdef->ip6_addresses, char*, i)))
+                    goto skip_ip6;
             char* s = g_strdup(scalar(entry));
             g_array_append_val(cur_netdef->ip6_addresses, s);
+skip_ip6:
             continue;
         }
 
@@ -944,7 +1005,11 @@ handle_bridge_interfaces(yaml_document_t* doc, yaml_node_t* node, const void* da
             if (component->bond)
                 return yaml_error(node, error, "%s: interface '%s' is already assigned to bond %s",
                                   cur_netdef->id, scalar(entry), component->bond);
-           component->bridge = g_strdup(cur_netdef->id);
+            component->bridge = g_strdup(cur_netdef->id);
+            if (component->backend == NETPLAN_BACKEND_OVS) {
+                g_debug("%s: Bridge contains openvswitch interface, choosing OVS backend", cur_netdef->id);
+                cur_netdef->backend = NETPLAN_BACKEND_OVS;
+            }
         }
     }
 
@@ -1005,6 +1070,10 @@ handle_bond_interfaces(yaml_document_t* doc, yaml_node_t* node, const void* data
                 return yaml_error(node, error, "%s: interface '%s' is already assigned to bond %s",
                                   cur_netdef->id, scalar(entry), component->bond);
             component->bond = g_strdup(cur_netdef->id);
+            if (component->backend == NETPLAN_BACKEND_OVS) {
+                g_debug("%s: Bond contains openvswitch interface, choosing OVS backend", cur_netdef->id);
+                cur_netdef->backend = NETPLAN_BACKEND_OVS;
+            }
         }
     }
 
@@ -2067,25 +2136,58 @@ handle_network_ovs_settings_global_protocol(yaml_document_t* doc, yaml_node_t* n
     return handle_ovs_protocol(doc, node, &ovs_settings_global, data, error);
 }
 
-static void
-initialize_dhcp_overrides(NetplanDHCPOverrides* overrides)
+static gboolean
+handle_network_ovs_settings_global_ports(yaml_document_t* doc, yaml_node_t* node, const void* data, GError** error)
 {
-    overrides->use_dns = TRUE;
-    overrides->use_domains = NULL;
-    overrides->use_ntp = TRUE;
-    overrides->send_hostname = TRUE;
-    overrides->use_hostname = TRUE;
-    overrides->use_mtu = TRUE;
-    overrides->use_routes = TRUE;
-    overrides->hostname = NULL;
-    overrides->metric = NETPLAN_METRIC_UNSPEC;
-}
+    yaml_node_t* port = NULL;
+    yaml_node_t* peer = NULL;
+    yaml_node_t* pair = NULL;
+    yaml_node_item_t *item = NULL;
+    NetplanNetDefinition *component = NULL;
 
-static void
-initialize_ovs_settings(NetplanOVSSettings* ovs_settings)
-{
-    ovs_settings->mcast_snooping = FALSE;
-    ovs_settings->rstp = FALSE;
+    for (yaml_node_item_t *iter = node->data.sequence.items.start; iter < node->data.sequence.items.top; iter++) {
+        pair = yaml_document_get_node(doc, *iter);
+        assert_type(pair, YAML_SEQUENCE_NODE);
+
+        item = pair->data.sequence.items.start;
+        /* A peer port definition must contain exactly 2 ports */
+        if (item+2 != pair->data.sequence.items.top) {
+            return yaml_error(pair, error, "An openvswitch peer port sequence must have exactly two entries");
+        }
+
+        port = yaml_document_get_node(doc, *item);
+        assert_type(port, YAML_SCALAR_NODE);
+        peer = yaml_document_get_node(doc, *(item+1));
+        assert_type(peer, YAML_SCALAR_NODE);
+
+        /* Create port 1 netdef */
+        component = g_hash_table_lookup(netdefs, scalar(port));
+        if (!component) {
+            component = netplan_netdef_new(scalar(port), NETPLAN_DEF_TYPE_PORT, NETPLAN_BACKEND_OVS);
+            if (g_hash_table_remove(missing_id, scalar(port)))
+                missing_ids_found++;
+        }
+
+        if (component->peer && g_strcmp0(component->peer, scalar(peer)))
+            return yaml_error(port, error, "openvswitch port '%s' is already assigned to peer '%s'",
+                              component->id, component->peer);
+        component->peer = g_strdup(scalar(peer));
+
+        /* Create port 2 (peer) netdef */
+        component = NULL;
+        component = g_hash_table_lookup(netdefs, scalar(peer));
+        if (!component) {
+            component = netplan_netdef_new(scalar(peer), NETPLAN_DEF_TYPE_PORT, NETPLAN_BACKEND_OVS);
+            if (g_hash_table_remove(missing_id, scalar(peer)))
+                missing_ids_found++;
+        }
+
+        if (component->peer && g_strcmp0(component->peer, scalar(port)))
+            return yaml_error(peer, error, "openvswitch port '%s' is already assigned to peer '%s'",
+                              component->id, component->peer);
+        component->peer = g_strdup(scalar(port));
+    }
+    return TRUE;
 }
 
 /**
@@ -2129,30 +2231,7 @@ handle_network_type(yaml_document_t* doc, yaml_node_t* node, const void* data, G
             if (cur_netdef->type != GPOINTER_TO_UINT(data))
                 return yaml_error(key, error, "Updated definition '%s' changes device type", scalar(key));
         } else {
-            /* create new network definition */
-            cur_netdef = g_new0(NetplanNetDefinition, 1);
-            cur_netdef->type = GPOINTER_TO_UINT(data);
-            cur_netdef->backend = backend_cur_type ?: NETPLAN_BACKEND_NONE;
-            cur_netdef->id = g_strdup(scalar(key));
-
-            /* Set some default values */
-            cur_netdef->vlan_id = G_MAXUINT; /* 0 is a valid ID */
-            cur_netdef->tunnel.mode = NETPLAN_TUNNEL_MODE_UNKNOWN;
-            cur_netdef->dhcp_identifier = g_strdup("duid"); /* keep networkd's default */
-            /* systemd-networkd defaults to IPv6 LL enabled; keep that default */
-            cur_netdef->linklocal.ipv6 = TRUE;
-            g_hash_table_insert(netdefs, cur_netdef->id, cur_netdef);
-            netdefs_ordered = g_list_append(netdefs_ordered, cur_netdef);
-            cur_netdef->sriov_vlan_filter = FALSE;
-
-            /* DHCP override defaults */
-            initialize_dhcp_overrides(&cur_netdef->dhcp4_overrides);
-            initialize_dhcp_overrides(&cur_netdef->dhcp6_overrides);
-
-            /* OpenVSwitch defaults */
-            initialize_ovs_settings(&cur_netdef->ovs_settings);
-
-            g_hash_table_insert(netdefs, cur_netdef->id, cur_netdef);
+            netplan_netdef_new(scalar(key), GPOINTER_TO_UINT(data), backend_cur_type);
         }
 
         // XXX: breaks multi-pass parsing.
@@ -2209,6 +2288,7 @@ static const mapping_entry_handler ovs_network_settings_handlers[] = {
     {"external-ids", YAML_MAPPING_NODE, handle_network_ovs_settings_global, NULL, ovs_settings_offset(external_ids)},
     {"other-config", YAML_MAPPING_NODE, handle_network_ovs_settings_global, NULL, ovs_settings_offset(other_config)},
     {"protocols", YAML_SEQUENCE_NODE, handle_network_ovs_settings_global_protocol, NULL, ovs_settings_offset(protocols)},
+    {"ports", YAML_SEQUENCE_NODE, handle_network_ovs_settings_global_ports},
     {"ssl", YAML_MAPPING_NODE, handle_ovs_global_ssl},
     {NULL}
 };

--- a/src/parse.c
+++ b/src/parse.c
@@ -459,7 +459,9 @@ handle_netdef_id(yaml_document_t* doc, yaml_node_t* node, const void* data, GErr
 
 /**
  * Generic handler for setting a cur_netdef ID/iface name field referring to an
- * existing ID from a scalar node
+ * existing ID from a scalar node. This handler also includes a special case
+ * handler for OVS VLANs, switching the backend implicitly to OVS for such
+ * interfaces
  * @data: offset into NetplanNetDefinition where the NetplanNetDefinition* field to write is
  *        located
  */
@@ -474,6 +476,11 @@ handle_netdef_id_ref(yaml_document_t* doc, yaml_node_t* node, const void* data, 
         add_missing_node(node);
     } else {
         *((NetplanNetDefinition**) ((void*) cur_netdef + offset)) = ref;
+
+        if (cur_netdef->type == NETPLAN_DEF_TYPE_VLAN && ref->backend == NETPLAN_BACKEND_OVS) {
+            g_debug("%s: VLAN defined for openvswitch interface, choosing OVS backend", cur_netdef->id);
+            cur_netdef->backend = NETPLAN_BACKEND_OVS;
+        }
     }
     return TRUE;
 }

--- a/src/parse.c
+++ b/src/parse.c
@@ -910,7 +910,8 @@ handle_addresses(yaml_document_t* doc, yaml_node_t* node, const void* _, GError*
         char* prefix_len;
         guint64 prefix_len_num;
         yaml_node_t *entry = yaml_document_get_node(doc, *i);
-        yaml_node_t *key, *value = NULL;
+        yaml_node_t *key = NULL;
+        yaml_node_t *value = NULL;
 
         if (entry->type != YAML_SCALAR_NODE && entry->type != YAML_MAPPING_NODE) {
             return yaml_error(entry, error, "expected either scalar or mapping (check indentation)");

--- a/src/parse.h
+++ b/src/parse.h
@@ -56,6 +56,7 @@ typedef enum {
     NETPLAN_BACKEND_NONE,
     NETPLAN_BACKEND_NETWORKD,
     NETPLAN_BACKEND_NM,
+    NETPLAN_BACKEND_OVS,
     NETPLAN_BACKEND_MAX_,
 } NetplanBackend;
 
@@ -63,6 +64,7 @@ static const char* const netplan_backend_to_name[NETPLAN_BACKEND_MAX_] = {
         [NETPLAN_BACKEND_NONE] = "none",
         [NETPLAN_BACKEND_NETWORKD] = "networkd",
         [NETPLAN_BACKEND_NM] = "NetworkManager",
+        [NETPLAN_BACKEND_OVS] = "OpenVSwitch",
 };
 
 typedef enum {
@@ -195,6 +197,11 @@ typedef struct dhcp_overrides {
     char* hostname;
     guint metric;
 } NetplanDHCPOverrides;
+
+typedef struct ovs_settings {
+    GHashTable* external_ids;
+    GHashTable* other_config;
+} NetplanOVSSettings;
 
 /**
  * Represent a configuration stanza
@@ -340,6 +347,10 @@ struct net_definition {
     gboolean sriov_vlan_filter;
     guint sriov_explicit_vf_count;
 
+    /* these properties are only valid for OpenVSwitch */
+    /* netplan-feature: openvswitch */
+    NetplanOVSSettings ovs_settings;
+
     union {
         struct NetplanNMSettings {
             char *name;
@@ -418,6 +429,7 @@ typedef struct {
 /* Written/updated by parse_yaml(): char* id →  net_definition */
 extern GHashTable* netdefs;
 extern GList* netdefs_ordered;
+extern NetplanOVSSettings ovs_settings_global;
 
 /****************************************************
  * Functions

--- a/src/parse.h
+++ b/src/parse.h
@@ -202,6 +202,10 @@ typedef struct ovs_settings {
     GHashTable* external_ids;
     GHashTable* other_config;
     char* lacp;
+    char* fail_mode;
+    gboolean mcast_snooping;
+    GArray* protocols;
+    gboolean rstp;
 } NetplanOVSSettings;
 
 /**

--- a/src/parse.h
+++ b/src/parse.h
@@ -201,6 +201,7 @@ typedef struct dhcp_overrides {
 typedef struct ovs_settings {
     GHashTable* external_ids;
     GHashTable* other_config;
+    char* lacp;
 } NetplanOVSSettings;
 
 /**

--- a/src/parse.h
+++ b/src/parse.h
@@ -198,6 +198,11 @@ typedef struct dhcp_overrides {
     guint metric;
 } NetplanDHCPOverrides;
 
+typedef struct ovs_controller {
+    char* connection_mode;
+    GArray* addresses;
+} NetplanOVSController;
+
 typedef struct ovs_settings {
     GHashTable* external_ids;
     GHashTable* other_config;
@@ -206,6 +211,8 @@ typedef struct ovs_settings {
     gboolean mcast_snooping;
     GArray* protocols;
     gboolean rstp;
+    NetplanOVSController controller;
+    NetplanAuthenticationSettings ssl;
 } NetplanOVSSettings;
 
 /**

--- a/src/parse.h
+++ b/src/parse.h
@@ -50,6 +50,7 @@ typedef enum {
     NETPLAN_DEF_TYPE_BOND,
     NETPLAN_DEF_TYPE_VLAN,
     NETPLAN_DEF_TYPE_TUNNEL,
+    NETPLAN_DEF_TYPE_PORT,
 } NetplanDefType;
 
 typedef enum {
@@ -261,6 +262,9 @@ struct net_definition {
     /* master ID for slave devices */
     char* bridge;
     char* bond;
+
+    /* peer ID for OVS patch ports */
+    char* peer;
 
     /* vlan */
     guint vlan_id;

--- a/src/util.c
+++ b/src/util.c
@@ -148,3 +148,29 @@ wifi_get_freq5(int channel)
     return GPOINTER_TO_INT(g_hash_table_lookup(wifi_frequency_5,
                            GINT_TO_POINTER(channel)));
 }
+
+/**
+ * Systemd-escape the given string. The caller is responsible for freeing
+ * the allocated escaped string.
+ */
+gchar*
+systemd_escape(char* string)
+{
+    g_autoptr(GError) err = NULL;
+    g_autofree gchar* stderrh = NULL;
+    gint exit_status = 0;
+    gchar *escaped;
+
+    gchar *argv[] = {"bin" "/" "systemd-escape", string, NULL};
+    g_spawn_sync("/", argv, NULL, 0, NULL, NULL, &escaped, &stderrh, &exit_status, &err);
+    g_spawn_check_exit_status(exit_status, &err);
+    if (err != NULL) {
+        // LCOV_EXCL_START
+        g_fprintf(stderr, "failed to ask systemd to escape %s; exit %d\nstdout: '%s'\nstderr: '%s'", string, exit_status, escaped, stderrh);
+        exit(1);
+        // LCOV_EXCL_STOP
+    }
+    g_strstrip(escaped);
+
+    return escaped;
+}

--- a/src/util.h
+++ b/src/util.h
@@ -28,3 +28,6 @@ int wifi_get_freq24(int channel);
 int wifi_get_freq5(int channel);
 
 gchar* systemd_escape(char* string);
+
+#define OPENVSWITCH_OVS_VSCTL "/usr/bin/ovs-vsctl"
+#define OPENVSWITCH_OVS_OFCTL "/usr/bin/ovs-ofctl"

--- a/src/util.h
+++ b/src/util.h
@@ -30,4 +30,3 @@ int wifi_get_freq5(int channel);
 gchar* systemd_escape(char* string);
 
 #define OPENVSWITCH_OVS_VSCTL "/usr/bin/ovs-vsctl"
-#define OPENVSWITCH_OVS_OFCTL "/usr/bin/ovs-ofctl"

--- a/src/validation.c
+++ b/src/validation.c
@@ -106,7 +106,6 @@ validate_ovs_target(gboolean host_first, gchar* s) {
                 host = g_strjoinv("", split);
                 g_strfreev(split);
             }
-            g_assert(vec[2] == NULL);
             g_strfreev(vec);
         }
     }

--- a/src/validation.c
+++ b/src/validation.c
@@ -57,6 +57,79 @@ is_ip6_address(const char* address)
     return FALSE;
 }
 
+/* Check sanity of OpenVSwitch controller targets */
+gboolean
+validate_ovs_target(gboolean host_first, gchar* s) {
+    static guint dport = 6653; // the default port
+    g_autofree gchar* host = NULL;
+    g_autofree gchar* port = NULL;
+    gchar** vec = NULL;
+
+    /* Format tcp:host[:port] or ssl:host[:port] */
+    if (host_first) {
+        g_assert(s != NULL);
+        // IP6 host, indicated by bracketed notation ([..IPv6..])
+        if (s[0] == '[') {
+            gchar* tmp = NULL;
+            tmp = s+1; //get rid of leading '['
+            // append default port to unify parsing
+            if (!g_strrstr(tmp, "]:"))
+                vec = g_strsplit(g_strdup_printf("%s:%u", tmp, dport), "]:", 2);
+            else
+                vec = g_strsplit(tmp, "]:", 2);
+        // IP4 host
+        } else {
+            // append default port to unify parsing
+            if (!g_strrstr(s, ":"))
+                vec = g_strsplit(g_strdup_printf("%s:%u", s, dport), ":", 2);
+            else
+                vec = g_strsplit(s, ":", 2);
+        }
+        // host and port are always set
+        host = g_strdup(vec[0]); //set host alias
+        port = g_strdup(vec[1]); //set port alias
+        g_assert(vec[2] == NULL);
+        g_strfreev(vec);
+    /* Format ptcp:[port][:host] or pssl:[port][:host] */
+    } else {
+        // special case: "ptcp:" (no port, no host)
+        if (!g_strcmp0(s, ""))
+            port = g_strdup_printf("%u", dport);
+        else {
+            vec = g_strsplit(s, ":", 2);
+            port = g_strdup(vec[0]);
+            host = g_strdup(vec[1]);
+            // get rid of leading & trailing IPv6 brackets
+            if (host && host[0] == '[') {
+                char **split = g_strsplit_set(host, "[]", 3);
+                g_free(host);
+                host = g_strjoinv("", split);
+                g_strfreev(split);
+            }
+            g_assert(vec[2] == NULL);
+            g_strfreev(vec);
+        }
+    }
+
+    g_assert(port != NULL);
+    // special case where IPv6 notation contains '%iface' name
+    if (host && g_strrstr(host, "%")) {
+        gchar** split = g_strsplit (host, "%", 2);
+        g_free(host);
+        host = g_strdup(split[0]); // designated scope for IPv6 link-level addresses
+        g_assert(split[1] != NULL && split[2] == NULL);
+        g_strfreev(split);
+    }
+
+    if (atoi(port) > 0 && atoi(port) <= 65535) {
+        if (!host)
+            return TRUE;
+        else if (host && (is_ip4_address(host) || is_ip6_address(host)))
+            return TRUE;
+    }
+    return FALSE;
+}
+
 /************************************************
  * Validation for grammar and backend rules.
  ************************************************/

--- a/src/validation.c
+++ b/src/validation.c
@@ -25,6 +25,7 @@
 
 #include "parse.h"
 #include "error.h"
+#include "util.h"
 
 
 /* Check sanity for address types */
@@ -265,6 +266,15 @@ validate_netdef_grammar(NetplanNetDefinition* nd, yaml_node_t* node, GError** er
         valid = validate_tunnel_grammar(nd, node, error);
         if (!valid)
             goto netdef_grammar_error;
+    }
+
+    if (nd->backend == NETPLAN_BACKEND_OVS) {
+        // LCOV_EXCL_START
+        if (!g_file_test(OPENVSWITCH_OVS_VSCTL, G_FILE_TEST_EXISTS)) {
+            /* Tested via integration test */
+            return yaml_error(node, error, "%s: The 'ovs-vsctl' tool is required to setup OpenVSwitch interfaces.", nd->id);
+        }
+        // LCOV_EXCL_STOP
     }
 
     valid = TRUE;

--- a/src/validation.h
+++ b/src/validation.h
@@ -22,6 +22,7 @@
 
 gboolean is_ip4_address(const char* address);
 gboolean is_ip6_address(const char* address);
+gboolean validate_ovs_target(gboolean host_first, gchar* s);
 
 gboolean
 validate_netdef_grammar(NetplanNetDefinition* nd, yaml_node_t* node, GError** error);

--- a/tests/generator/base.py
+++ b/tests/generator/base.py
@@ -51,10 +51,13 @@ Requires=openvswitch-switch.service\nAfter=openvswitch-switch.service\n'
 OVS_PHYSICAL = _OVS_BASE + 'Requires=sys-subsystem-net-devices-%(iface)s.device\nAfter=sys-subsystem-net-devices-%(iface)s\
 .device\nAfter=netplan-ovs-cleanup.service\nBefore=network.target\nWants=network.target\n%(extra)s'
 OVS_VIRTUAL = _OVS_BASE + 'After=netplan-ovs-cleanup.service\nBefore=network.target\nWants=network.target\n%(extra)s'
+OVS_BR_DEFAULT = 'ExecStart=/usr/bin/ovs-vsctl set Bridge %(iface)s external-ids:netplan=true\nExecStart=/usr/bin/ovs-vsctl \
+set-fail-mode %(iface)s standalone\nExecStart=/usr/bin/ovs-vsctl set Bridge %(iface)s external-ids:netplan/global/set-fail-mode=\
+standalone\nExecStart=/usr/bin/ovs-vsctl set Bridge %(iface)s mcast_snooping_enable=false\nExecStart=/usr/bin/ovs-vsctl set \
+Bridge %(iface)s external-ids:netplan/mcast_snooping_enable=false\nExecStart=/usr/bin/ovs-vsctl set Bridge %(iface)s \
+rstp_enable=false\nExecStart=/usr/bin/ovs-vsctl set Bridge %(iface)s external-ids:netplan/rstp_enable=false\n'
 OVS_BR_EMPTY = _OVS_BASE + 'After=netplan-ovs-cleanup.service\nBefore=network.target\nWants=network.target\n\n[Service]\n\
-Type=oneshot\nExecStart=/usr/bin/ovs-vsctl --may-exist add-br %(iface)s\nExecStart=/usr/bin/ovs-vsctl set Bridge %(iface)s \
-external-ids:netplan=true\nExecStart=/usr/bin/ovs-vsctl set-fail-mode %(iface)s standalone\nExecStart=/usr/bin/ovs-vsctl set \
-Bridge %(iface)s mcast_snooping_enable=false\nExecStart=/usr/bin/ovs-vsctl set Bridge %(iface)s rstp_enable=false\n'
+Type=oneshot\nExecStart=/usr/bin/ovs-vsctl --may-exist add-br %(iface)s\n' + OVS_BR_DEFAULT
 OVS_CLEANUP = _OVS_BASE + 'ConditionFileIsExecutable=/usr/bin/ovs-vsctl\nBefore=network.target\nWants=network.target\n\n\
 [Service]\nType=oneshot\nExecStart=/usr/sbin/netplan apply --only-ovs-cleanup\n'
 UDEV_MAC_RULE = 'SUBSYSTEM=="net", ACTION=="add", DRIVERS=="%s", ATTR{address}=="%s", NAME="%s"\n'

--- a/tests/generator/base.py
+++ b/tests/generator/base.py
@@ -44,6 +44,11 @@ ND_DHCP6 = '[Match]\nName=%s\n\n[Network]\nDHCP=ipv6\nLinkLocalAddressing=ipv6\n
 ND_DHCP6_NOMTU = '[Match]\nName=%s\n\n[Network]\nDHCP=ipv6\nLinkLocalAddressing=ipv6\n\n[DHCP]\nRouteMetric=100\nUseMTU=false\n'
 ND_DHCPYES = '[Match]\nName=%s\n\n[Network]\nDHCP=yes\nLinkLocalAddressing=ipv6\n\n[DHCP]\nRouteMetric=100\nUseMTU=true\n'
 ND_DHCPYES_NOMTU = '[Match]\nName=%s\n\n[Network]\nDHCP=yes\nLinkLocalAddressing=ipv6\n\n[DHCP]\nRouteMetric=100\nUseMTU=false\n'
+OVS_PHYSICAL = '[Unit]\nDescription=OpenVSwitch configuration for %(iface)s\nDefaultDependencies=no\n\
+Requires=sys-subsystem-net-devices-%(iface)s.device\nAfter=sys-subsystem-net-devices-%(iface)s.device\nBefore=network.target\n\
+Wants=network.target\n%(extra)s'
+OVS_VIRTUAL = '[Unit]\nDescription=OpenVSwitch configuration for %(iface)s\nDefaultDependencies=no\nBefore=network.target\n\
+Wants=network.target\n%(extra)s'
 UDEV_MAC_RULE = 'SUBSYSTEM=="net", ACTION=="add", DRIVERS=="%s", ATTR{address}=="%s", NAME="%s"\n'
 UDEV_NO_MAC_RULE = 'SUBSYSTEM=="net", ACTION=="add", DRIVERS=="%s", NAME="%s"\n'
 

--- a/tests/generator/base.py
+++ b/tests/generator/base.py
@@ -46,16 +46,19 @@ ND_DHCP6 = '[Match]\nName=%s\n\n[Network]\nDHCP=ipv6\nLinkLocalAddressing=ipv6\n
 ND_DHCP6_NOMTU = '[Match]\nName=%s\n\n[Network]\nDHCP=ipv6\nLinkLocalAddressing=ipv6\n\n[DHCP]\nRouteMetric=100\nUseMTU=false\n'
 ND_DHCPYES = '[Match]\nName=%s\n\n[Network]\nDHCP=yes\nLinkLocalAddressing=ipv6\n\n[DHCP]\nRouteMetric=100\nUseMTU=true\n'
 ND_DHCPYES_NOMTU = '[Match]\nName=%s\n\n[Network]\nDHCP=yes\nLinkLocalAddressing=ipv6\n\n[DHCP]\nRouteMetric=100\nUseMTU=false\n'
-OVS_PHYSICAL = '[Unit]\nDescription=OpenVSwitch configuration for %(iface)s\nDefaultDependencies=no\n\
-Requires=sys-subsystem-net-devices-%(iface)s.device\nAfter=sys-subsystem-net-devices-%(iface)s.device\nBefore=network.target\n\
-Wants=network.target\n%(extra)s'
-OVS_VIRTUAL = '[Unit]\nDescription=OpenVSwitch configuration for %(iface)s\nDefaultDependencies=no\nBefore=network.target\n\
-Wants=network.target\n%(extra)s'
-OVS_BR_EMPTY = '[Unit]\nDescription=OpenVSwitch configuration for %(iface)s\nDefaultDependencies=no\nBefore=network.target\n\
-Wants=network.target\n\n[Service]\nType=oneshot\nRemainAfterExit=yes\nExecStart=/usr/bin/ovs-vsctl --may-exist add-br %(iface)s\n\
-ExecStop=/usr/bin/ovs-vsctl del-br %(iface)s\nExecStart=/usr/bin/ovs-vsctl set Port %(iface)s external-ids:netplan=true\n\
-ExecStart=/usr/bin/ovs-vsctl set-fail-mode %(iface)s standalone\nExecStart=/usr/bin/ovs-vsctl set Bridge %(iface)s \
-mcast_snooping_enable=false\nExecStart=/usr/bin/ovs-vsctl set Bridge %(iface)s rstp_enable=false\n'
+_OVS_BASE = '[Unit]\nDescription=OpenVSwitch configuration for %(iface)s\nDefaultDependencies=no\n'
+OVS_PHYSICAL = _OVS_BASE + 'Requires=sys-subsystem-net-devices-%(iface)s.device\nAfter=sys-subsystem-net-devices-%(iface)s\
+.device\nRequires=openvswitch-switch.service\nAfter=openvswitch-switch.service\nAfter=netplan-ovs-cleanup.service\n\
+Before=network.target\nWants=network.target\n%(extra)s'
+OVS_VIRTUAL = _OVS_BASE + 'Requires=openvswitch-switch.service\nAfter=openvswitch-switch.service\n\
+After=netplan-ovs-cleanup.service\nBefore=network.target\nWants=network.target\n%(extra)s'
+OVS_BR_EMPTY = _OVS_BASE + 'Requires=openvswitch-switch.service\nAfter=openvswitch-switch.service\n\
+After=netplan-ovs-cleanup.service\nBefore=network.target\nWants=network.target\n\n[Service]\n\
+Type=oneshot\nExecStart=/usr/bin/ovs-vsctl --may-exist add-br %(iface)s\nExecStart=/usr/bin/ovs-vsctl set Bridge %(iface)s \
+external-ids:netplan=true\nExecStart=/usr/bin/ovs-vsctl set-fail-mode %(iface)s standalone\nExecStart=/usr/bin/ovs-vsctl set \
+Bridge %(iface)s mcast_snooping_enable=false\nExecStart=/usr/bin/ovs-vsctl set Bridge %(iface)s rstp_enable=false\n'
+OVS_CLEANUP = _OVS_BASE + 'ConditionFileIsExecutable=/usr/bin/ovs-vsctl\nBefore=network.target\nWants=network.target\n\n\
+[Service]\nType=oneshot\nExecStart=/usr/sbin/netplan apply --only-ovs-cleanup\n'
 UDEV_MAC_RULE = 'SUBSYSTEM=="net", ACTION=="add", DRIVERS=="%s", ATTR{address}=="%s", NAME="%s"\n'
 UDEV_NO_MAC_RULE = 'SUBSYSTEM=="net", ACTION=="add", DRIVERS=="%s", NAME="%s"\n'
 

--- a/tests/generator/base.py
+++ b/tests/generator/base.py
@@ -47,7 +47,7 @@ ND_DHCP6_NOMTU = '[Match]\nName=%s\n\n[Network]\nDHCP=ipv6\nLinkLocalAddressing=
 ND_DHCPYES = '[Match]\nName=%s\n\n[Network]\nDHCP=yes\nLinkLocalAddressing=ipv6\n\n[DHCP]\nRouteMetric=100\nUseMTU=true\n'
 ND_DHCPYES_NOMTU = '[Match]\nName=%s\n\n[Network]\nDHCP=yes\nLinkLocalAddressing=ipv6\n\n[DHCP]\nRouteMetric=100\nUseMTU=false\n'
 _OVS_BASE = '[Unit]\nDescription=OpenVSwitch configuration for %(iface)s\nDefaultDependencies=no\n\
-Requires=openvswitch-switch.service\nAfter=openvswitch-switch.service\n'
+Wants=openvswitch-switch.service\nAfter=openvswitch-switch.service\n'
 OVS_PHYSICAL = _OVS_BASE + 'Requires=sys-subsystem-net-devices-%(iface)s.device\nAfter=sys-subsystem-net-devices-%(iface)s\
 .device\nAfter=netplan-ovs-cleanup.service\nBefore=network.target\nWants=network.target\n%(extra)s'
 OVS_VIRTUAL = _OVS_BASE + 'After=netplan-ovs-cleanup.service\nBefore=network.target\nWants=network.target\n%(extra)s'

--- a/tests/generator/base.py
+++ b/tests/generator/base.py
@@ -46,14 +46,12 @@ ND_DHCP6 = '[Match]\nName=%s\n\n[Network]\nDHCP=ipv6\nLinkLocalAddressing=ipv6\n
 ND_DHCP6_NOMTU = '[Match]\nName=%s\n\n[Network]\nDHCP=ipv6\nLinkLocalAddressing=ipv6\n\n[DHCP]\nRouteMetric=100\nUseMTU=false\n'
 ND_DHCPYES = '[Match]\nName=%s\n\n[Network]\nDHCP=yes\nLinkLocalAddressing=ipv6\n\n[DHCP]\nRouteMetric=100\nUseMTU=true\n'
 ND_DHCPYES_NOMTU = '[Match]\nName=%s\n\n[Network]\nDHCP=yes\nLinkLocalAddressing=ipv6\n\n[DHCP]\nRouteMetric=100\nUseMTU=false\n'
-_OVS_BASE = '[Unit]\nDescription=OpenVSwitch configuration for %(iface)s\nDefaultDependencies=no\n'
+_OVS_BASE = '[Unit]\nDescription=OpenVSwitch configuration for %(iface)s\nDefaultDependencies=no\n\
+Requires=openvswitch-switch.service\nAfter=openvswitch-switch.service\n'
 OVS_PHYSICAL = _OVS_BASE + 'Requires=sys-subsystem-net-devices-%(iface)s.device\nAfter=sys-subsystem-net-devices-%(iface)s\
-.device\nRequires=openvswitch-switch.service\nAfter=openvswitch-switch.service\nAfter=netplan-ovs-cleanup.service\n\
-Before=network.target\nWants=network.target\n%(extra)s'
-OVS_VIRTUAL = _OVS_BASE + 'Requires=openvswitch-switch.service\nAfter=openvswitch-switch.service\n\
-After=netplan-ovs-cleanup.service\nBefore=network.target\nWants=network.target\n%(extra)s'
-OVS_BR_EMPTY = _OVS_BASE + 'Requires=openvswitch-switch.service\nAfter=openvswitch-switch.service\n\
-After=netplan-ovs-cleanup.service\nBefore=network.target\nWants=network.target\n\n[Service]\n\
+.device\nAfter=netplan-ovs-cleanup.service\nBefore=network.target\nWants=network.target\n%(extra)s'
+OVS_VIRTUAL = _OVS_BASE + 'After=netplan-ovs-cleanup.service\nBefore=network.target\nWants=network.target\n%(extra)s'
+OVS_BR_EMPTY = _OVS_BASE + 'After=netplan-ovs-cleanup.service\nBefore=network.target\nWants=network.target\n\n[Service]\n\
 Type=oneshot\nExecStart=/usr/bin/ovs-vsctl --may-exist add-br %(iface)s\nExecStart=/usr/bin/ovs-vsctl set Bridge %(iface)s \
 external-ids:netplan=true\nExecStart=/usr/bin/ovs-vsctl set-fail-mode %(iface)s standalone\nExecStart=/usr/bin/ovs-vsctl set \
 Bridge %(iface)s mcast_snooping_enable=false\nExecStart=/usr/bin/ovs-vsctl set Bridge %(iface)s rstp_enable=false\n'

--- a/tests/generator/base.py
+++ b/tests/generator/base.py
@@ -37,6 +37,8 @@ os.environ.update({'LD_LIBRARY_PATH': '.:{}'.format(os.environ.get('LD_LIBRARY_P
 os.environ['G_DEBUG'] = 'fatal-criticals'
 
 # common patterns for expected output
+ND_EMPTY = '[Match]\nName=%s\n\n[Network]\nLinkLocalAddressing=%s\nConfigureWithoutCarrier=yes\n'
+ND_WITHIP = '[Match]\nName=%s\n\n[Network]\nLinkLocalAddressing=ipv6\nAddress=%s\nConfigureWithoutCarrier=yes\n'
 ND_DHCP4 = '[Match]\nName=%s\n\n[Network]\nDHCP=ipv4\nLinkLocalAddressing=ipv6\n\n[DHCP]\nRouteMetric=100\nUseMTU=true\n'
 ND_DHCP4_NOMTU = '[Match]\nName=%s\n\n[Network]\nDHCP=ipv4\nLinkLocalAddressing=ipv6\n\n[DHCP]\nRouteMetric=100\nUseMTU=false\n'
 ND_WIFI_DHCP4 = '[Match]\nName=%s\n\n[Network]\nDHCP=ipv4\nLinkLocalAddressing=ipv6\n\n[DHCP]\nRouteMetric=600\nUseMTU=true\n'

--- a/tests/generator/base.py
+++ b/tests/generator/base.py
@@ -20,6 +20,7 @@
 
 import os
 import random
+import glob
 import stat
 import string
 import tempfile
@@ -171,3 +172,24 @@ class TestBase(unittest.TestCase):
             return
         with open(rule_path) as f:
             self.assertEqual(f.read(), contents)
+
+    def assert_ovs(self, file_contents_map):
+        systemd_dir = os.path.join(self.workdir.name, 'run', 'systemd', 'system')
+        if not file_contents_map:
+            # in this case we assume no OVS configuration should be present
+            self.assertFalse(glob.glob(os.path.join(systemd_dir, '*netplan-ovs-*.service')))
+            return
+
+        self.assertEqual(set(os.listdir(self.workdir.name)) - {'lib'}, {'etc', 'run'})
+        for fname, contents in file_contents_map.items():
+            fname = 'netplan-ovs-' + fname
+            with open(os.path.join(systemd_dir, fname)) as f:
+                self.assertEqual(f.read(), contents)
+            if fname.endswith('.service'):
+                link_path = os.path.join(
+                    systemd_dir, 'systemd-networkd.service.wants', fname)
+                self.assertTrue(os.path.islink(link_path))
+                link_target = os.readlink(link_path)
+                self.assertEqual(link_target,
+                                 os.path.join(
+                                    '/', 'run', 'systemd', 'system', fname))

--- a/tests/generator/test_args.py
+++ b/tests/generator/test_args.py
@@ -33,7 +33,7 @@ class TestConfigArgs(TestBase):
     def test_no_configs(self):
         self.generate('network:\n  version: 2')
         # should not write any files
-        self.assertEqual(os.listdir(self.workdir.name), ['etc', 'run'])
+        self.assertCountEqual(os.listdir(self.workdir.name), ['etc', 'run'])
         self.assert_networkd(None)
         self.assert_networkd_udev(None)
         self.assert_nm(None)
@@ -43,7 +43,7 @@ class TestConfigArgs(TestBase):
     def test_empty_config(self):
         self.generate('')
         # should not write any files
-        self.assertEqual(os.listdir(self.workdir.name), ['etc', 'run'])
+        self.assertCountEqual(os.listdir(self.workdir.name), ['etc', 'run'])
         self.assert_networkd(None)
         self.assert_networkd_udev(None)
         self.assert_nm(None)

--- a/tests/generator/test_args.py
+++ b/tests/generator/test_args.py
@@ -19,7 +19,7 @@
 import os
 import subprocess
 
-from .base import TestBase, exe_generate
+from .base import TestBase, exe_generate, OVS_CLEANUP
 
 
 class TestConfigArgs(TestBase):
@@ -33,14 +33,22 @@ class TestConfigArgs(TestBase):
     def test_no_configs(self):
         self.generate('network:\n  version: 2')
         # should not write any files
-        self.assertEqual(os.listdir(self.workdir.name), ['etc'])
+        self.assertEqual(os.listdir(self.workdir.name), ['etc', 'run'])
+        self.assert_networkd(None)
+        self.assert_networkd_udev(None)
+        self.assert_nm(None)
         self.assert_nm_udev(None)
+        self.assert_ovs({'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
 
     def test_empty_config(self):
         self.generate('')
         # should not write any files
-        self.assertEqual(os.listdir(self.workdir.name), ['etc'])
+        self.assertEqual(os.listdir(self.workdir.name), ['etc', 'run'])
+        self.assert_networkd(None)
+        self.assert_networkd_udev(None)
+        self.assert_nm(None)
         self.assert_nm_udev(None)
+        self.assert_ovs({'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
 
     def test_file_args(self):
         conf = os.path.join(self.workdir.name, 'config')
@@ -52,7 +60,13 @@ class TestConfigArgs(TestBase):
   ethernets:
     eth0:
       dhcp4: true''', extra_args=[conf])
-        self.assertEqual(set(os.listdir(self.workdir.name)), {'config', 'etc'})
+        # There is one systemd service unit 'netplan-ovs-cleanup.service' in /run,
+        # which will always be created
+        self.assertEqual(set(os.listdir(self.workdir.name)), {'config', 'etc', 'run'})
+        self.assert_networkd(None)
+        self.assert_networkd_udev(None)
+        self.assert_nm(None)
+        self.assert_nm_udev(None)
 
     def test_file_args_notfound(self):
         err = self.generate('''network:

--- a/tests/generator/test_ovs.py
+++ b/tests/generator/test_ovs.py
@@ -3,6 +3,7 @@
 #
 # Copyright (C) 2020 Canonical, Ltd.
 # Author: Łukasz 'sil2100' Zemczak <lukasz.zemczak@ubuntu.com>
+#         Lukas 'slyon' Märdian <lukas.maerdian@canonical.com>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -16,7 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from .base import TestBase, ND_DHCP4, ND_DHCP6
+from .base import TestBase, ND_DHCP4, ND_DHCP6, OVS_PHYSICAL, OVS_VIRTUAL
 
 
 class TestOpenVSwitch(TestBase):
@@ -39,31 +40,19 @@ class TestOpenVSwitch(TestBase):
         other-config:
           disable-in-band: false
 ''')
-        self.assert_ovs({'eth0.service': '''[Unit]
-Description=OpenVSwitch configuration for eth0
-DefaultDependencies=no
-Requires=sys-subsystem-net-devices-eth0.device
-After=sys-subsystem-net-devices-eth0.device
-Before=network.target
-Wants=network.target
-
+        self.assert_ovs({'eth0.service': OVS_PHYSICAL % {'iface': 'eth0', 'extra': '''
 [Service]
 Type=oneshot
+RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl set Interface eth0 external-ids:iface-id=myhostname
 ExecStart=/usr/bin/ovs-vsctl set Interface eth0 other-config:disable-in-band=true
-''',
-                         'eth1.service': '''[Unit]
-Description=OpenVSwitch configuration for eth1
-DefaultDependencies=no
-Requires=sys-subsystem-net-devices-eth1.device
-After=sys-subsystem-net-devices-eth1.device
-Before=network.target
-Wants=network.target
-
+'''},
+                         'eth1.service': OVS_PHYSICAL % {'iface': 'eth1', 'extra': '''
 [Service]
 Type=oneshot
+RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl set Interface eth1 other-config:disable-in-band=false
-'''})
+'''}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({'eth0.network': ND_DHCP6 % 'eth0',
                               'eth1.network': ND_DHCP4 % 'eth1'})
@@ -80,17 +69,13 @@ ExecStart=/usr/bin/ovs-vsctl set Interface eth1 other-config:disable-in-band=fal
           disable-in-band: true
       dhcp4: yes
 ''')
-        self.assert_ovs({'br0.service': '''[Unit]
-Description=OpenVSwitch configuration for br0
-DefaultDependencies=no
-Before=network.target
-Wants=network.target
-
+        self.assert_ovs({'br0.service': OVS_VIRTUAL % {'iface': 'br0', 'extra': '''
 [Service]
 Type=oneshot
+RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:iface-id=myhostname
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 other-config:disable-in-band=true
-'''})
+'''}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({'br0.netdev': '[NetDev]\nName=br0\nKind=bridge\n',
                               'br0.network': '''[Match]
@@ -118,17 +103,13 @@ UseMTU=true
     eth0:
       dhcp4: yes
 ''')
-        self.assert_ovs({'global.service': '''[Unit]
-Description=OpenVSwitch configuration for global
-DefaultDependencies=no
-Before=network.target
-Wants=network.target
-
+        self.assert_ovs({'global.service': OVS_VIRTUAL % {'iface': 'global', 'extra': '''
 [Service]
 Type=oneshot
+RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:iface-id=myhostname
 ExecStart=/usr/bin/ovs-vsctl set open_vswitch . other-config:disable-in-band=true
-'''})
+'''}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({'eth0.network': ND_DHCP4 % 'eth0'})
 
@@ -154,3 +135,236 @@ ExecStart=/usr/bin/ovs-vsctl set open_vswitch . other-config:disable-in-band=tru
 ''')
         self.assert_ovs(None)
         self.assert_networkd({'eth0.network': ND_DHCP4 % 'eth0'})
+
+    def test_bond_setup(self):
+        self.generate('''network:
+  version: 2
+  ethernets:
+    eth1: {}
+    eth2: {}
+  bonds:
+    bond0:
+      interfaces: [eth1, eth2]
+      openvswitch:
+        external-ids:
+          iface-id: myhostname
+  bridges:
+    br0:
+      addresses: [192.170.1.1/24]
+      interfaces: [bond0]
+      openvswitch: {}
+''')
+        self.assert_ovs({'bond0.service': OVS_VIRTUAL % {'iface': 'bond0', 'extra':
+                        '''Requires=netplan-ovs-br0.service
+After=netplan-ovs-br0.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/ovs-vsctl add-bond br0 bond0 eth1 eth2
+ExecStop=/usr/bin/ovs-vsctl del-port bond0
+ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=off
+ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:iface-id=myhostname
+'''}})
+        # Confirm that the networkd config is still sane
+        self.assert_networkd({'eth1.network': '[Match]\nName=eth1\n\n[Network]\nLinkLocalAddressing=no\nBond=bond0\n',
+                              'eth2.network': '[Match]\nName=eth2\n\n[Network]\nLinkLocalAddressing=no\nBond=bond0\n'})
+
+    def test_bond_no_bridge(self):
+        err = self.generate('''network:
+  version: 2
+  ethernets:
+    eth1: {}
+    eth2: {}
+  bonds:
+    bond0:
+      interfaces: [eth1, eth2]
+      openvswitch: {}
+''', expect_fail=True)
+        self.assertIn("Bond bond0 needs to be a slave of an OpenVSwitch bridge", err)
+
+    def test_bond_invalid_bridge(self):
+        err = self.generate('''network:
+  version: 2
+  ethernets:
+    eth1: {}
+    eth2: {}
+  bonds:
+    bond0:
+      interfaces: [eth1, eth2]
+      openvswitch: {}
+  bridges:
+    br0:
+      addresses: [192.170.1.1/24]
+      interfaces: [bond0]
+''', expect_fail=True)
+        self.assertIn("Bond bond0: br0 needs to be handled by OpenVSwitch", err)
+
+    def test_bond_not_enough_interfaces(self):
+        err = self.generate('''network:
+  version: 2
+  ethernets:
+    eth1: {}
+  bonds:
+    bond0:
+      interfaces: [eth1]
+      openvswitch: {}
+  bridges:
+    br0:
+      addresses: [192.170.1.1/24]
+      interfaces: [bond0]
+      openvswitch: {}
+''', expect_fail=True)
+        self.assertIn("Bond bond0 needs to have at least 2 slave interfaces", err)
+
+    def test_bond_lacp(self):
+        self.generate('''network:
+  version: 2
+  ethernets:
+    eth1: {}
+    eth2: {}
+  bonds:
+    bond0:
+      interfaces: [eth1, eth2]
+      openvswitch:
+        lacp: active
+  bridges:
+    br0:
+      addresses: [192.170.1.1/24]
+      interfaces: [bond0]
+      openvswitch: {}
+''')
+        self.assert_ovs({'bond0.service': OVS_VIRTUAL % {'iface': 'bond0', 'extra':
+                        '''Requires=netplan-ovs-br0.service
+After=netplan-ovs-br0.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/ovs-vsctl add-bond br0 bond0 eth1 eth2
+ExecStop=/usr/bin/ovs-vsctl del-port bond0
+ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=active
+'''}})
+        # Confirm that the networkd config is still sane
+        self.assert_networkd({'eth1.network': '[Match]\nName=eth1\n\n[Network]\nLinkLocalAddressing=no\nBond=bond0\n',
+                              'eth2.network': '[Match]\nName=eth2\n\n[Network]\nLinkLocalAddressing=no\nBond=bond0\n'})
+
+    def test_bond_lacp_invalid(self):
+        err = self.generate('''network:
+  version: 2
+  ethernets:
+    eth1: {}
+    eth2: {}
+  bonds:
+    bond0:
+      interfaces: [eth1, eth2]
+      openvswitch:
+        lacp: invalid
+  bridges:
+    br0:
+      addresses: [192.170.1.1/24]
+      interfaces: [bond0]
+      openvswitch: {}
+''', expect_fail=True)
+        self.assertIn("Value of 'lacp' needs to be 'active', 'passive' or 'off", err)
+
+    def test_bond_lacp_wrong_type(self):
+        err = self.generate('''network:
+  version: 2
+  ethernets:
+    eth1:
+      openvswitch:
+        lacp: passive
+''', expect_fail=True)
+        self.assertIn("Key 'lacp' is only valid for iterface type 'openvswitch bond'", err)
+
+    def test_bond_mode_implicit_params(self):
+        self.generate('''network:
+  version: 2
+  ethernets:
+    eth1: {}
+    eth2: {}
+  bonds:
+    bond0:
+      interfaces: [eth1, eth2]
+      parameters:
+        mode: balance-tcp # Sets OVS backend implicitly
+  bridges:
+    br0:
+      addresses: [192.170.1.1/24]
+      interfaces: [bond0]
+      openvswitch: {}
+''')
+        self.assert_ovs({'bond0.service': OVS_VIRTUAL % {'iface': 'bond0', 'extra':
+                        '''Requires=netplan-ovs-br0.service
+After=netplan-ovs-br0.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/ovs-vsctl add-bond br0 bond0 eth1 eth2
+ExecStop=/usr/bin/ovs-vsctl del-port bond0
+ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=off
+ExecStart=/usr/bin/ovs-vsctl set Port bond0 bond_mode=balance-tcp
+'''}})
+        # Confirm that the networkd config is still sane
+        self.assert_networkd({'eth1.network': '[Match]\nName=eth1\n\n[Network]\nLinkLocalAddressing=no\nBond=bond0\n',
+                              'eth2.network': '[Match]\nName=eth2\n\n[Network]\nLinkLocalAddressing=no\nBond=bond0\n'})
+
+    def test_bond_mode_explicit_params(self):
+        self.generate('''network:
+  version: 2
+  ethernets:
+    eth1: {}
+    eth2: {}
+  bonds:
+    bond0:
+      interfaces: [eth1, eth2]
+      parameters:
+        mode: active-backup
+      openvswitch: {}
+  bridges:
+    br0:
+      addresses: [192.170.1.1/24]
+      interfaces: [bond0]
+      openvswitch: {}
+''')
+        self.assert_ovs({'bond0.service': OVS_VIRTUAL % {'iface': 'bond0', 'extra':
+                        '''Requires=netplan-ovs-br0.service
+After=netplan-ovs-br0.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/ovs-vsctl add-bond br0 bond0 eth1 eth2
+ExecStop=/usr/bin/ovs-vsctl del-port bond0
+ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=off
+ExecStart=/usr/bin/ovs-vsctl set Port bond0 bond_mode=active-backup
+'''}})
+        # Confirm that the networkd config is still sane
+        self.assert_networkd({'eth1.network': '[Match]\nName=eth1\n\n[Network]\nLinkLocalAddressing=no\nBond=bond0\n',
+                              'eth2.network': '[Match]\nName=eth2\n\n[Network]\nLinkLocalAddressing=no\nBond=bond0\n'})
+
+    def test_bond_mode_ovs_invalid(self):
+        err = self.generate('''network:
+  version: 2
+  ethernets:
+    eth1: {}
+    eth2: {}
+  bonds:
+    bond0:
+      interfaces: [eth1, eth2]
+      parameters:
+        mode: balance-rr
+      openvswitch: {}
+  bridges:
+    br0:
+      addresses: [192.170.1.1/24]
+      interfaces: [bond0]
+      openvswitch: {}
+''', expect_fail=True)
+        self.assertIn("bond0: bond mode 'balance-rr' not supported by openvswitch", err)

--- a/tests/generator/test_ovs.py
+++ b/tests/generator/test_ovs.py
@@ -937,6 +937,45 @@ ExecStop=/usr/bin/ovs-vsctl --if-exists del-port patch1-0
                               'patch0\\x2d1.network': ND_EMPTY % ('patch0-1', 'no'),
                               'patch1\\x2d0.network': ND_EMPTY % ('patch1-0', 'no')})
 
+    def test_fake_vlan_bridge_setup(self):
+        self.generate('''network:
+  version: 2
+  bridges:
+    br0:
+      addresses: [192.168.1.1/24]
+      openvswitch: {}
+  vlans:
+    br0.100:
+      id: 100
+      link: br0
+      openvswitch: {}
+''')
+        self.assert_ovs({'br0.service': OVS_VIRTUAL % {'iface': 'br0', 'extra': '''
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
+ExecStop=/usr/bin/ovs-vsctl del-br br0
+ExecStart=/usr/bin/ovs-vsctl set Port br0 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set-fail-mode br0 standalone
+ExecStart=/usr/bin/ovs-vsctl set Bridge br0 mcast_snooping_enable=false
+ExecStart=/usr/bin/ovs-vsctl set Bridge br0 rstp_enable=false
+'''},
+                         'br0.100.service': OVS_VIRTUAL % {'iface': 'br0.100', 'extra':
+                                                           '''Requires=netplan-ovs-br0.service
+After=netplan-ovs-br0.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0.100 br0 100
+ExecStop=/usr/bin/ovs-vsctl del-br br0.100
+ExecStart=/usr/bin/ovs-vsctl set Port br0.100 external-ids:netplan=true
+'''}})
+        # Confirm that the networkd config is still sane
+        self.assert_networkd({'br0.network': ND_WITHIP % ('br0', '192.168.1.1/24'),
+                              'br0.100.network': ND_EMPTY % ('br0.100', 'ipv6')})
+
     def test_invalid_device_type(self):
         err = self.generate('''network:
     version: 2

--- a/tests/generator/test_ovs.py
+++ b/tests/generator/test_ovs.py
@@ -976,6 +976,46 @@ ExecStart=/usr/bin/ovs-vsctl set Port br0.100 external-ids:netplan=true
         self.assert_networkd({'br0.network': ND_WITHIP % ('br0', '192.168.1.1/24'),
                               'br0.100.network': ND_EMPTY % ('br0.100', 'ipv6')})
 
+    def test_implicit_fake_vlan_bridge_setup(self):
+        # Test if, when a VLAN is added to an OVS bridge, netplan will
+        # implicitly assume the vlan should be done via OVS as well
+        self.generate('''network:
+  version: 2
+  bridges:
+    br0:
+      addresses: [192.168.1.1/24]
+      openvswitch: {}
+  vlans:
+    br0.100:
+      id: 100
+      link: br0
+''')
+        self.assert_ovs({'br0.service': OVS_VIRTUAL % {'iface': 'br0', 'extra': '''
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
+ExecStop=/usr/bin/ovs-vsctl del-br br0
+ExecStart=/usr/bin/ovs-vsctl set Port br0 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set-fail-mode br0 standalone
+ExecStart=/usr/bin/ovs-vsctl set Bridge br0 mcast_snooping_enable=false
+ExecStart=/usr/bin/ovs-vsctl set Bridge br0 rstp_enable=false
+'''},
+                         'br0.100.service': OVS_VIRTUAL % {'iface': 'br0.100', 'extra':
+                                                           '''Requires=netplan-ovs-br0.service
+After=netplan-ovs-br0.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0.100 br0 100
+ExecStop=/usr/bin/ovs-vsctl del-br br0.100
+ExecStart=/usr/bin/ovs-vsctl set Port br0.100 external-ids:netplan=true
+'''}})
+        # Confirm that the networkd config is still sane
+        self.assert_networkd({'br0.network': ND_WITHIP % ('br0', '192.168.1.1/24'),
+                              'br0.100.network': ND_EMPTY % ('br0.100', 'ipv6')})
+
     def test_invalid_device_type(self):
         err = self.generate('''network:
     version: 2

--- a/tests/generator/test_ovs.py
+++ b/tests/generator/test_ovs.py
@@ -145,7 +145,7 @@ After=netplan-ovs-br0.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=/usr/bin/ovs-vsctl add-bond br0 bond0 eth1 eth2
+ExecStart=/usr/bin/ovs-vsctl --may-exist add-bond br0 bond0 eth1 eth2
 ExecStop=/usr/bin/ovs-vsctl del-port bond0
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=off
@@ -169,23 +169,6 @@ ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:iface-id=myhostname
       openvswitch: {}
 ''', expect_fail=True)
         self.assertIn("Bond bond0 needs to be a slave of an OpenVSwitch bridge", err)
-
-    def test_bond_invalid_bridge(self):
-        err = self.generate('''network:
-  version: 2
-  ethernets:
-    eth1: {}
-    eth2: {}
-  bonds:
-    bond0:
-      interfaces: [eth1, eth2]
-      openvswitch: {}
-  bridges:
-    br0:
-      addresses: [192.170.1.1/24]
-      interfaces: [bond0]
-''', expect_fail=True)
-        self.assertIn("Bond bond0: br0 needs to be handled by OpenVSwitch", err)
 
     def test_bond_not_enough_interfaces(self):
         err = self.generate('''network:
@@ -228,7 +211,7 @@ After=netplan-ovs-br0.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=/usr/bin/ovs-vsctl add-bond br0 bond0 eth1 eth2
+ExecStart=/usr/bin/ovs-vsctl --may-exist add-bond br0 bond0 eth1 eth2
 ExecStop=/usr/bin/ovs-vsctl del-port bond0
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=active
@@ -292,7 +275,7 @@ After=netplan-ovs-br0.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=/usr/bin/ovs-vsctl add-bond br0 bond0 eth1 eth2
+ExecStart=/usr/bin/ovs-vsctl --may-exist add-bond br0 bond0 eth1 eth2
 ExecStop=/usr/bin/ovs-vsctl del-port bond0
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=off
@@ -329,7 +312,7 @@ After=netplan-ovs-br0.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=/usr/bin/ovs-vsctl add-bond br0 bond0 eth1 eth2
+ExecStart=/usr/bin/ovs-vsctl --may-exist add-bond br0 bond0 eth1 eth2
 ExecStop=/usr/bin/ovs-vsctl del-port bond0
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=off
@@ -378,10 +361,10 @@ ExecStart=/usr/bin/ovs-vsctl set Port bond0 bond_mode=active-backup
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=/usr/bin/ovs-vsctl add-br br0
-ExecStart=/usr/bin/ovs-vsctl add-port br0 eth1
+ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
+ExecStart=/usr/bin/ovs-vsctl --may-exist add-port br0 eth1
 ExecStop=/usr/bin/ovs-vsctl del-port br0 eth1
-ExecStart=/usr/bin/ovs-vsctl add-port br0 eth2
+ExecStart=/usr/bin/ovs-vsctl --may-exist add-port br0 eth2
 ExecStop=/usr/bin/ovs-vsctl del-port br0 eth2
 ExecStop=/usr/bin/ovs-vsctl del-br br0
 ExecStart=/usr/bin/ovs-vsctl set Port br0 external-ids:netplan=true
@@ -409,7 +392,7 @@ ExecStart=/usr/bin/ovs-vsctl set Bridge br0 rstp_enable=false
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=/usr/bin/ovs-vsctl add-br br0
+ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
 ExecStop=/usr/bin/ovs-vsctl del-br br0
 ExecStart=/usr/bin/ovs-vsctl set Port br0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set-fail-mode br0 standalone
@@ -441,10 +424,10 @@ ExecStart=/usr/bin/ovs-vsctl set Bridge br0 other-config:disable-in-band=true
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=/usr/bin/ovs-vsctl add-br br0
-ExecStart=/usr/bin/ovs-vsctl add-port br0 eth1
+ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
+ExecStart=/usr/bin/ovs-vsctl --may-exist add-port br0 eth1
 ExecStop=/usr/bin/ovs-vsctl del-port br0 eth1
-ExecStart=/usr/bin/ovs-vsctl add-port br0 eth2
+ExecStart=/usr/bin/ovs-vsctl --may-exist add-port br0 eth2
 ExecStop=/usr/bin/ovs-vsctl del-port br0 eth2
 ExecStop=/usr/bin/ovs-vsctl del-br br0
 ExecStart=/usr/bin/ovs-vsctl set Port br0 external-ids:netplan=true
@@ -500,7 +483,7 @@ ExecStart=/usr/bin/ovs-vsctl set Bridge br0 rstp_enable=true
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=/usr/bin/ovs-vsctl add-br br0
+ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
 ExecStop=/usr/bin/ovs-vsctl del-br br0
 ExecStart=/usr/bin/ovs-vsctl set Port br0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set-fail-mode br0 standalone
@@ -552,16 +535,21 @@ ExecStart=/usr/bin/ovs-vsctl set Bridge br0 protocols=OpenFlow10,OpenFlow11,Open
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=/usr/bin/ovs-vsctl add-br br0
+ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
 ExecStop=/usr/bin/ovs-vsctl del-br br0
 ExecStart=/usr/bin/ovs-vsctl set Port br0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set-fail-mode br0 standalone
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 mcast_snooping_enable=false
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 rstp_enable=false
-ExecStart=/usr/bin/ovs-vsctl --private-key /key/path --certificate /some/path --ca-cert /another/path set-controller br0 ptcp: \
-ptcp:1337 ptcp:1337:[fe80::1234%eth0] pssl:1337:[fe80::1] ssl:10.10.10.1 tcp:127.0.0.1:1337 tcp:[fe80::1234%eth0] \
-tcp:[fe80::1]:1337 unix:/some/path punix:other/path
+ExecStart=/usr/bin/ovs-vsctl set-controller br0 ptcp: ptcp:1337 ptcp:1337:[fe80::1234%eth0] pssl:1337:[fe80::1] ssl:10.10.10.1 \
+tcp:127.0.0.1:1337 tcp:[fe80::1234%eth0] tcp:[fe80::1]:1337 unix:/some/path punix:other/path
 ExecStart=/usr/bin/ovs-vsctl set controller br0 connection-mode=out-of-band
+'''},
+                         'global.service': OVS_VIRTUAL % {'iface': 'global', 'extra': '''
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/ovs-vsctl set-ssl /key/path /some/path /another/path
 '''}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({'br0.network': ND_EMPTY % ('br0', 'ipv6')})
@@ -644,6 +632,24 @@ ExecStart=/usr/bin/ovs-vsctl set controller br0 connection-mode=out-of-band
         self.assert_ovs({})
         self.assert_networkd({})
 
+    def test_global_ssl(self):
+        self.generate('''network:
+  version: 2
+  openvswitch:
+    ssl:
+      ca-cert: /another/path
+      certificate: /some/path
+      private-key: /key/path
+''')
+        self.assert_ovs({'global.service': OVS_VIRTUAL % {'iface': 'global', 'extra': '''
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/ovs-vsctl set-ssl /key/path /some/path /another/path
+'''}})
+        # Confirm that the networkd config is still sane
+        self.assert_networkd({})
+
     def test_missing_ssl(self):
         err = self.generate('''network:
   version: 2
@@ -659,3 +665,270 @@ ExecStart=/usr/bin/ovs-vsctl set controller br0 connection-mode=out-of-band
 'openvswitch.ssl' settings are not set", err)
         self.assert_ovs({})
         self.assert_networkd({})
+
+    def test_global_ports(self):
+        err = self.generate('''network:
+  version: 2
+  openvswitch:
+    ports:
+      - [patch0-1, patch1-0]
+''', expect_fail=True)
+        self.assertIn('patch0-1: OpenVSwitch patch port needs to be assigned to a bridge/bond', err)
+        self.assert_ovs({})
+        self.assert_networkd({})
+
+    def test_few_ports(self):
+        err = self.generate('''network:
+  version: 2
+  openvswitch:
+    ports:
+      - [patch0-1]
+''', expect_fail=True)
+        self.assertIn("An openvswitch peer port sequence must have exactly two entries", err)
+        self.assertIn("- [patch0-1]", err)
+        self.assert_ovs({})
+        self.assert_networkd({})
+
+    def test_many_ports(self):
+        err = self.generate('''network:
+  version: 2
+  openvswitch:
+    ports:
+      - [patch0-1, "patchx", patchy]
+''', expect_fail=True)
+        self.assertIn("An openvswitch peer port sequence must have exactly two entries", err)
+        self.assertIn("- [patch0-1, \"patchx\", patchy]", err)
+        self.assert_ovs({})
+        self.assert_networkd({})
+
+    def test_ovs_invalid_port(self):
+        err = self.generate('''network:
+  version: 2
+  openvswitch:
+    ports:
+      - [patchx, patchy]
+      - [patchx, patchz]
+''', expect_fail=True)
+        self.assertIn("openvswitch port 'patchx' is already assigned to peer 'patchy'", err)
+        self.assert_ovs({})
+        self.assert_networkd({})
+
+    def test_ovs_invalid_peer(self):
+        err = self.generate('''network:
+  version: 2
+  openvswitch:
+    ports:
+      - [patchx, patchy]
+      - [patchz, patchx]
+''', expect_fail=True)
+        self.assertIn("openvswitch port 'patchx' is already assigned to peer 'patchy'", err)
+        self.assert_ovs({})
+        self.assert_networkd({})
+
+    def test_bridge_auto_ovs_backend(self):
+        self.generate('''network:
+  version: 2
+  ethernets:
+    eth1: {}
+    eth2: {}
+  bonds:
+    bond0:
+      interfaces: [eth1, eth2]
+      openvswitch: {}
+  bridges:
+    br0:
+      addresses: [192.170.1.1/24]
+      interfaces: [bond0]
+''')
+        self.assert_ovs({'br0.service': OVS_VIRTUAL % {'iface': 'br0', 'extra': '''
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
+ExecStop=/usr/bin/ovs-vsctl del-br br0
+ExecStart=/usr/bin/ovs-vsctl set Port br0 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set-fail-mode br0 standalone
+ExecStart=/usr/bin/ovs-vsctl set Bridge br0 mcast_snooping_enable=false
+ExecStart=/usr/bin/ovs-vsctl set Bridge br0 rstp_enable=false
+'''},
+                         'bond0.service': OVS_VIRTUAL % {'iface': 'bond0', 'extra':
+                                                         '''Requires=netplan-ovs-br0.service
+After=netplan-ovs-br0.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/ovs-vsctl --may-exist add-bond br0 bond0 eth1 eth2
+ExecStop=/usr/bin/ovs-vsctl del-port bond0
+ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=off
+'''}})
+        self.assert_networkd({'br0.network': ND_WITHIP % ('br0', '192.170.1.1/24'),
+                              'bond0.network': ND_EMPTY % ('bond0', 'no'),
+                              'eth1.network':
+                              '''[Match]
+Name=eth1
+
+[Network]
+LinkLocalAddressing=no
+Bond=bond0
+''',
+                              'eth2.network':
+                              '''[Match]
+Name=eth2
+
+[Network]
+LinkLocalAddressing=no
+Bond=bond0
+'''})
+
+    def test_bond_auto_ovs_backend(self):
+        self.generate('''network:
+  version: 2
+  ethernets:
+    eth0: {}
+  bonds:
+    bond0:
+      interfaces: [eth0, patchy]
+  bridges:
+    br0:
+      addresses: [192.170.1.1/24]
+      interfaces: [bond0]
+    br1:
+      addresses: [2001:FFfe::1/64]
+      interfaces: [patchx]
+  openvswitch:
+    ports:
+      - [patchx, patchy]
+''')
+        self.assert_ovs({'br0.service': OVS_VIRTUAL % {'iface': 'br0', 'extra': '''
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
+ExecStop=/usr/bin/ovs-vsctl del-br br0
+ExecStart=/usr/bin/ovs-vsctl set Port br0 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set-fail-mode br0 standalone
+ExecStart=/usr/bin/ovs-vsctl set Bridge br0 mcast_snooping_enable=false
+ExecStart=/usr/bin/ovs-vsctl set Bridge br0 rstp_enable=false
+'''},
+                         'br1.service': OVS_VIRTUAL % {'iface': 'br1', 'extra': '''
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br1
+ExecStart=/usr/bin/ovs-vsctl --may-exist add-port br1 patchx
+ExecStop=/usr/bin/ovs-vsctl del-port br1 patchx
+ExecStop=/usr/bin/ovs-vsctl del-br br1
+ExecStart=/usr/bin/ovs-vsctl set Port br1 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set-fail-mode br1 standalone
+ExecStart=/usr/bin/ovs-vsctl set Bridge br1 mcast_snooping_enable=false
+ExecStart=/usr/bin/ovs-vsctl set Bridge br1 rstp_enable=false
+'''},
+                         'bond0.service': OVS_VIRTUAL % {'iface': 'bond0', 'extra':
+                                                         '''Requires=netplan-ovs-br0.service
+After=netplan-ovs-br0.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/ovs-vsctl --may-exist add-bond br0 bond0 patchy eth0
+ExecStop=/usr/bin/ovs-vsctl del-port bond0
+ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=off
+'''},
+                         'patchx.service': OVS_VIRTUAL % {'iface': 'patchx', 'extra':
+                                                          '''Requires=netplan-ovs-br1.service
+After=netplan-ovs-br1.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/ovs-vsctl set Interface patchx type=patch
+ExecStart=/usr/bin/ovs-vsctl set Interface patchx options:peer=patchy
+ExecStop=/usr/bin/ovs-vsctl --if-exists del-port patchx
+'''},
+                         'patchy.service': OVS_VIRTUAL % {'iface': 'patchy', 'extra':
+                                                          '''Requires=netplan-ovs-bond0.service
+After=netplan-ovs-bond0.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/ovs-vsctl set Interface patchy type=patch
+ExecStart=/usr/bin/ovs-vsctl set Interface patchy options:peer=patchx
+ExecStop=/usr/bin/ovs-vsctl --if-exists del-port patchy
+'''}})
+        self.assert_networkd({'br0.network': ND_WITHIP % ('br0', '192.170.1.1/24'),
+                              'br1.network': ND_WITHIP % ('br1', '2001:FFfe::1/64'),
+                              'bond0.network': ND_EMPTY % ('bond0', 'no'),
+                              'patchx.network': ND_EMPTY % ('patchx', 'no'),
+                              'patchy.network': ND_EMPTY % ('patchy', 'no'),
+                              'eth0.network': '[Match]\nName=eth0\n\n[Network]\nLinkLocalAddressing=no\nBond=bond0\n'})
+
+    def test_patch_ports(self):
+        self.generate('''network:
+  version: 2
+  openvswitch:
+    ports:
+      - [patch0-1, patch1-0]
+  bridges:
+    br0:
+      addresses: [192.168.1.1/24]
+      interfaces: [patch0-1]
+    br1:
+      addresses: [192.168.1.2/24]
+      interfaces: [patch1-0]
+''')
+        self.assert_ovs({'br0.service': OVS_VIRTUAL % {'iface': 'br0', 'extra': '''
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
+ExecStart=/usr/bin/ovs-vsctl --may-exist add-port br0 patch0-1
+ExecStop=/usr/bin/ovs-vsctl del-port br0 patch0-1
+ExecStop=/usr/bin/ovs-vsctl del-br br0
+ExecStart=/usr/bin/ovs-vsctl set Port br0 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set-fail-mode br0 standalone
+ExecStart=/usr/bin/ovs-vsctl set Bridge br0 mcast_snooping_enable=false
+ExecStart=/usr/bin/ovs-vsctl set Bridge br0 rstp_enable=false
+'''},
+                         'br1.service': OVS_VIRTUAL % {'iface': 'br1', 'extra': '''
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br1
+ExecStart=/usr/bin/ovs-vsctl --may-exist add-port br1 patch1-0
+ExecStop=/usr/bin/ovs-vsctl del-port br1 patch1-0
+ExecStop=/usr/bin/ovs-vsctl del-br br1
+ExecStart=/usr/bin/ovs-vsctl set Port br1 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set-fail-mode br1 standalone
+ExecStart=/usr/bin/ovs-vsctl set Bridge br1 mcast_snooping_enable=false
+ExecStart=/usr/bin/ovs-vsctl set Bridge br1 rstp_enable=false
+'''},
+                         'patch0\\x2d1.service': OVS_VIRTUAL % {'iface': 'patch0\\x2d1', 'extra':
+                                                                '''Requires=netplan-ovs-br0.service
+After=netplan-ovs-br0.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/ovs-vsctl set Interface patch0-1 type=patch
+ExecStart=/usr/bin/ovs-vsctl set Interface patch0-1 options:peer=patch1-0
+ExecStop=/usr/bin/ovs-vsctl --if-exists del-port patch0-1
+'''},
+                         'patch1\\x2d0.service': OVS_VIRTUAL % {'iface': 'patch1\\x2d0', 'extra':
+                                                                '''Requires=netplan-ovs-br1.service
+After=netplan-ovs-br1.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/ovs-vsctl set Interface patch1-0 type=patch
+ExecStart=/usr/bin/ovs-vsctl set Interface patch1-0 options:peer=patch0-1
+ExecStop=/usr/bin/ovs-vsctl --if-exists del-port patch1-0
+'''}})
+        self.assert_networkd({'br0.network': ND_WITHIP % ('br0', '192.168.1.1/24'),
+                              'br1.network': ND_WITHIP % ('br1', '192.168.1.2/24'),
+                              'patch0\\x2d1.network': ND_EMPTY % ('patch0-1', 'no'),
+                              'patch1\\x2d0.network': ND_EMPTY % ('patch1-0', 'no')})

--- a/tests/generator/test_ovs.py
+++ b/tests/generator/test_ovs.py
@@ -822,8 +822,7 @@ After=netplan-ovs-br1.service
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/ovs-vsctl set Interface patchx type=patch
-ExecStart=/usr/bin/ovs-vsctl set Interface patchx options:peer=patchy
+ExecStart=/usr/bin/ovs-vsctl set Interface patchx type=patch -- set Interface patchx options:peer=patchy
 ExecStart=/usr/bin/ovs-vsctl set Port patchx external-ids:netplan=true
 '''},
                          'patchy.service': OVS_VIRTUAL % {'iface': 'patchy', 'extra':
@@ -832,8 +831,7 @@ After=netplan-ovs-bond0.service
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/ovs-vsctl set Interface patchy type=patch
-ExecStart=/usr/bin/ovs-vsctl set Interface patchy options:peer=patchx
+ExecStart=/usr/bin/ovs-vsctl set Interface patchy type=patch -- set Interface patchy options:peer=patchx
 ExecStart=/usr/bin/ovs-vsctl set Port patchy external-ids:netplan=true
 '''},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
@@ -884,8 +882,7 @@ After=netplan-ovs-br0.service
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/ovs-vsctl set Interface patch0-1 type=patch
-ExecStart=/usr/bin/ovs-vsctl set Interface patch0-1 options:peer=patch1-0
+ExecStart=/usr/bin/ovs-vsctl set Interface patch0-1 type=patch -- set Interface patch0-1 options:peer=patch1-0
 ExecStart=/usr/bin/ovs-vsctl set Port patch0-1 external-ids:netplan=true
 '''},
                          'patch1-0.service': OVS_VIRTUAL % {'iface': 'patch1-0', 'extra':
@@ -894,8 +891,7 @@ After=netplan-ovs-br1.service
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/ovs-vsctl set Interface patch1-0 type=patch
-ExecStart=/usr/bin/ovs-vsctl set Interface patch1-0 options:peer=patch0-1
+ExecStart=/usr/bin/ovs-vsctl set Interface patch1-0 type=patch -- set Interface patch1-0 options:peer=patch0-1
 ExecStart=/usr/bin/ovs-vsctl set Port patch1-0 external-ids:netplan=true
 '''},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})

--- a/tests/generator/test_ovs.py
+++ b/tests/generator/test_ovs.py
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from .base import TestBase, ND_EMPTY, ND_WITHIP, ND_DHCP4, ND_DHCP6, OVS_PHYSICAL, OVS_VIRTUAL, OVS_BR_EMPTY
+from .base import TestBase, ND_EMPTY, ND_WITHIP, ND_DHCP4, ND_DHCP6, OVS_PHYSICAL, OVS_VIRTUAL, OVS_BR_EMPTY, OVS_CLEANUP
 
 
 class TestOpenVSwitch(TestBase):
@@ -43,16 +43,15 @@ class TestOpenVSwitch(TestBase):
         self.assert_ovs({'eth0.service': OVS_PHYSICAL % {'iface': 'eth0', 'extra': '''
 [Service]
 Type=oneshot
-RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl set Interface eth0 external-ids:iface-id=myhostname
 ExecStart=/usr/bin/ovs-vsctl set Interface eth0 other-config:disable-in-band=true
 '''},
                          'eth1.service': OVS_PHYSICAL % {'iface': 'eth1', 'extra': '''
 [Service]
 Type=oneshot
-RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl set Interface eth1 other-config:disable-in-band=false
-'''}})
+'''},
+                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({'eth0.network': ND_DHCP6 % 'eth0',
                               'eth1.network': ND_DHCP4 % 'eth1'})
@@ -72,10 +71,10 @@ ExecStart=/usr/bin/ovs-vsctl set Interface eth1 other-config:disable-in-band=fal
         self.assert_ovs({'global.service': OVS_VIRTUAL % {'iface': 'global', 'extra': '''
 [Service]
 Type=oneshot
-RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:iface-id=myhostname
 ExecStart=/usr/bin/ovs-vsctl set open_vswitch . other-config:disable-in-band=true
-'''}})
+'''},
+                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({'eth0.network': ND_DHCP4 % 'eth0'})
 
@@ -91,9 +90,9 @@ ExecStart=/usr/bin/ovs-vsctl set open_vswitch . other-config:disable-in-band=tru
         self.assert_ovs({'global.service': OVS_VIRTUAL % {'iface': 'global', 'extra': '''
 [Service]
 Type=oneshot
-RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-ofctl -O OpenFlow10,OpenFlow11,OpenFlow12
-'''}})
+'''},
+                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({'eth0.network': ND_DHCP4 % 'eth0'})
 
@@ -117,7 +116,7 @@ ExecStart=/usr/bin/ovs-ofctl -O OpenFlow10,OpenFlow11,OpenFlow12
     eth0:
       dhcp4: yes
 ''')
-        self.assert_ovs(None)
+        self.assert_ovs({'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         self.assert_networkd({'eth0.network': ND_DHCP4 % 'eth0'})
 
     def test_bond_setup(self):
@@ -144,14 +143,13 @@ After=netplan-ovs-br0.service
 
 [Service]
 Type=oneshot
-RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-bond br0 bond0 eth1 eth2
-ExecStop=/usr/bin/ovs-vsctl del-port bond0
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=off
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:iface-id=myhostname
 '''},
-                         'br0.service': OVS_BR_EMPTY % {'iface': 'br0'}})
+                         'br0.service': OVS_BR_EMPTY % {'iface': 'br0'},
+                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({'eth1.network': '[Match]\nName=eth1\n\n[Network]\nLinkLocalAddressing=no\nBond=bond0\n',
                               'eth2.network': '[Match]\nName=eth2\n\n[Network]\nLinkLocalAddressing=no\nBond=bond0\n',
@@ -211,13 +209,12 @@ After=netplan-ovs-br0.service
 
 [Service]
 Type=oneshot
-RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-bond br0 bond0 eth1 eth2
-ExecStop=/usr/bin/ovs-vsctl del-port bond0
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=active
 '''},
-                         'br0.service': OVS_BR_EMPTY % {'iface': 'br0'}})
+                         'br0.service': OVS_BR_EMPTY % {'iface': 'br0'},
+                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({'eth1.network': '[Match]\nName=eth1\n\n[Network]\nLinkLocalAddressing=no\nBond=bond0\n',
                               'eth2.network': '[Match]\nName=eth2\n\n[Network]\nLinkLocalAddressing=no\nBond=bond0\n',
@@ -276,14 +273,13 @@ After=netplan-ovs-br0.service
 
 [Service]
 Type=oneshot
-RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-bond br0 bond0 eth1 eth2
-ExecStop=/usr/bin/ovs-vsctl del-port bond0
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=off
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 bond_mode=balance-tcp
 '''},
-                         'br0.service': OVS_BR_EMPTY % {'iface': 'br0'}})
+                         'br0.service': OVS_BR_EMPTY % {'iface': 'br0'},
+                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({'eth1.network': '[Match]\nName=eth1\n\n[Network]\nLinkLocalAddressing=no\nBond=bond0\n',
                               'eth2.network': '[Match]\nName=eth2\n\n[Network]\nLinkLocalAddressing=no\nBond=bond0\n',
@@ -314,14 +310,13 @@ After=netplan-ovs-br0.service
 
 [Service]
 Type=oneshot
-RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-bond br0 bond0 eth1 eth2
-ExecStop=/usr/bin/ovs-vsctl del-port bond0
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=off
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 bond_mode=active-backup
 '''},
-                         'br0.service': OVS_BR_EMPTY % {'iface': 'br0'}})
+                         'br0.service': OVS_BR_EMPTY % {'iface': 'br0'},
+                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({'eth1.network': '[Match]\nName=eth1\n\n[Network]\nLinkLocalAddressing=no\nBond=bond0\n',
                               'eth2.network': '[Match]\nName=eth2\n\n[Network]\nLinkLocalAddressing=no\nBond=bond0\n',
@@ -364,18 +359,15 @@ ExecStart=/usr/bin/ovs-vsctl set Port bond0 bond_mode=active-backup
                         '''
 [Service]
 Type=oneshot
-RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-port br0 eth1
-ExecStop=/usr/bin/ovs-vsctl del-port br0 eth1
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-port br0 eth2
-ExecStop=/usr/bin/ovs-vsctl del-port br0 eth2
-ExecStop=/usr/bin/ovs-vsctl del-br br0
-ExecStart=/usr/bin/ovs-vsctl set Port br0 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set-fail-mode br0 standalone
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 mcast_snooping_enable=false
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 rstp_enable=false
-'''}})
+'''},
+                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({'eth1.network': '[Match]\nName=eth1\n\n[Network]\nLinkLocalAddressing=no\nBridge=br0\n',
                               'eth2.network': '[Match]\nName=eth2\n\n[Network]\nLinkLocalAddressing=no\nBridge=br0\n',
@@ -395,16 +387,15 @@ ExecStart=/usr/bin/ovs-vsctl set Bridge br0 rstp_enable=false
         self.assert_ovs({'br0.service': OVS_VIRTUAL % {'iface': 'br0', 'extra': '''
 [Service]
 Type=oneshot
-RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
-ExecStop=/usr/bin/ovs-vsctl del-br br0
-ExecStart=/usr/bin/ovs-vsctl set Port br0 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set-fail-mode br0 standalone
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 mcast_snooping_enable=false
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 rstp_enable=false
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:iface-id=myhostname
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 other-config:disable-in-band=true
-'''}})
+'''},
+                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the bridge has been only configured for OVS
         self.assert_networkd({'br0.network': ND_EMPTY % ('br0', 'ipv6')})
 
@@ -427,18 +418,15 @@ ExecStart=/usr/bin/ovs-vsctl set Bridge br0 other-config:disable-in-band=true
                         '''
 [Service]
 Type=oneshot
-RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-port br0 eth1
-ExecStop=/usr/bin/ovs-vsctl del-port br0 eth1
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-port br0 eth2
-ExecStop=/usr/bin/ovs-vsctl del-port br0 eth2
-ExecStop=/usr/bin/ovs-vsctl del-br br0
-ExecStart=/usr/bin/ovs-vsctl set Port br0 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set-fail-mode br0 secure
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 mcast_snooping_enable=true
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 rstp_enable=true
-'''}})
+'''},
+                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({'eth1.network': '[Match]\nName=eth1\n\n[Network]\nLinkLocalAddressing=no\nBridge=br0\n',
                               'eth2.network': '[Match]\nName=eth2\n\n[Network]\nLinkLocalAddressing=no\nBridge=br0\n',
@@ -486,15 +474,14 @@ ExecStart=/usr/bin/ovs-vsctl set Bridge br0 rstp_enable=true
                         '''
 [Service]
 Type=oneshot
-RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
-ExecStop=/usr/bin/ovs-vsctl del-br br0
-ExecStart=/usr/bin/ovs-vsctl set Port br0 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set-fail-mode br0 standalone
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 mcast_snooping_enable=false
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 rstp_enable=false
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 protocols=OpenFlow10,OpenFlow11,OpenFlow15
-'''}})
+'''},
+                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({'br0.network': ND_EMPTY % ('br0', 'ipv6')})
 
@@ -538,10 +525,8 @@ ExecStart=/usr/bin/ovs-vsctl set Bridge br0 protocols=OpenFlow10,OpenFlow11,Open
                         '''
 [Service]
 Type=oneshot
-RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
-ExecStop=/usr/bin/ovs-vsctl del-br br0
-ExecStart=/usr/bin/ovs-vsctl set Port br0 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set-fail-mode br0 standalone
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 mcast_snooping_enable=false
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 rstp_enable=false
@@ -552,9 +537,9 @@ ExecStart=/usr/bin/ovs-vsctl set controller br0 connection-mode=out-of-band
                          'global.service': OVS_VIRTUAL % {'iface': 'global', 'extra': '''
 [Service]
 Type=oneshot
-RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl set-ssl /key/path /some/path /another/path
-'''}})
+'''},
+                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({'br0.network': ND_EMPTY % ('br0', 'ipv6')})
 
@@ -648,9 +633,9 @@ ExecStart=/usr/bin/ovs-vsctl set-ssl /key/path /some/path /another/path
         self.assert_ovs({'global.service': OVS_VIRTUAL % {'iface': 'global', 'extra': '''
 [Service]
 Type=oneshot
-RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl set-ssl /key/path /some/path /another/path
-'''}})
+'''},
+                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({})
 
@@ -747,10 +732,8 @@ ExecStart=/usr/bin/ovs-vsctl set-ssl /key/path /some/path /another/path
         self.assert_ovs({'br0.service': OVS_VIRTUAL % {'iface': 'br0', 'extra': '''
 [Service]
 Type=oneshot
-RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
-ExecStop=/usr/bin/ovs-vsctl del-br br0
-ExecStart=/usr/bin/ovs-vsctl set Port br0 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set-fail-mode br0 standalone
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 mcast_snooping_enable=false
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 rstp_enable=false
@@ -761,12 +744,11 @@ After=netplan-ovs-br0.service
 
 [Service]
 Type=oneshot
-RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-bond br0 bond0 eth1 eth2
-ExecStop=/usr/bin/ovs-vsctl del-port bond0
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=off
-'''}})
+'''},
+                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         self.assert_networkd({'br0.network': ND_WITHIP % ('br0', '192.170.1.1/24'),
                               'bond0.network': ND_EMPTY % ('bond0', 'no'),
                               'eth1.network':
@@ -808,10 +790,8 @@ Bond=bond0
         self.assert_ovs({'br0.service': OVS_VIRTUAL % {'iface': 'br0', 'extra': '''
 [Service]
 Type=oneshot
-RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
-ExecStop=/usr/bin/ovs-vsctl del-br br0
-ExecStart=/usr/bin/ovs-vsctl set Port br0 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set-fail-mode br0 standalone
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 mcast_snooping_enable=false
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 rstp_enable=false
@@ -819,12 +799,9 @@ ExecStart=/usr/bin/ovs-vsctl set Bridge br0 rstp_enable=false
                          'br1.service': OVS_VIRTUAL % {'iface': 'br1', 'extra': '''
 [Service]
 Type=oneshot
-RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br1
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-port br1 patchx
-ExecStop=/usr/bin/ovs-vsctl del-port br1 patchx
-ExecStop=/usr/bin/ovs-vsctl del-br br1
-ExecStart=/usr/bin/ovs-vsctl set Port br1 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Bridge br1 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set-fail-mode br1 standalone
 ExecStart=/usr/bin/ovs-vsctl set Bridge br1 mcast_snooping_enable=false
 ExecStart=/usr/bin/ovs-vsctl set Bridge br1 rstp_enable=false
@@ -835,9 +812,7 @@ After=netplan-ovs-br0.service
 
 [Service]
 Type=oneshot
-RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-bond br0 bond0 patchy eth0
-ExecStop=/usr/bin/ovs-vsctl del-port bond0
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=off
 '''},
@@ -847,10 +822,9 @@ After=netplan-ovs-br1.service
 
 [Service]
 Type=oneshot
-RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl set Interface patchx type=patch
 ExecStart=/usr/bin/ovs-vsctl set Interface patchx options:peer=patchy
-ExecStop=/usr/bin/ovs-vsctl --if-exists del-port patchx
+ExecStart=/usr/bin/ovs-vsctl set Port patchx external-ids:netplan=true
 '''},
                          'patchy.service': OVS_VIRTUAL % {'iface': 'patchy', 'extra':
                                                           '''Requires=netplan-ovs-bond0.service
@@ -858,11 +832,11 @@ After=netplan-ovs-bond0.service
 
 [Service]
 Type=oneshot
-RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl set Interface patchy type=patch
 ExecStart=/usr/bin/ovs-vsctl set Interface patchy options:peer=patchx
-ExecStop=/usr/bin/ovs-vsctl --if-exists del-port patchy
-'''}})
+ExecStart=/usr/bin/ovs-vsctl set Port patchy external-ids:netplan=true
+'''},
+                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         self.assert_networkd({'br0.network': ND_WITHIP % ('br0', '192.170.1.1/24'),
                               'br1.network': ND_WITHIP % ('br1', '2001:FFfe::1/64'),
                               'bond0.network': ND_EMPTY % ('bond0', 'no'),
@@ -887,12 +861,9 @@ ExecStop=/usr/bin/ovs-vsctl --if-exists del-port patchy
         self.assert_ovs({'br0.service': OVS_VIRTUAL % {'iface': 'br0', 'extra': '''
 [Service]
 Type=oneshot
-RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-port br0 patch0-1
-ExecStop=/usr/bin/ovs-vsctl del-port br0 patch0-1
-ExecStop=/usr/bin/ovs-vsctl del-br br0
-ExecStart=/usr/bin/ovs-vsctl set Port br0 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set-fail-mode br0 standalone
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 mcast_snooping_enable=false
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 rstp_enable=false
@@ -900,42 +871,38 @@ ExecStart=/usr/bin/ovs-vsctl set Bridge br0 rstp_enable=false
                          'br1.service': OVS_VIRTUAL % {'iface': 'br1', 'extra': '''
 [Service]
 Type=oneshot
-RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br1
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-port br1 patch1-0
-ExecStop=/usr/bin/ovs-vsctl del-port br1 patch1-0
-ExecStop=/usr/bin/ovs-vsctl del-br br1
-ExecStart=/usr/bin/ovs-vsctl set Port br1 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Bridge br1 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set-fail-mode br1 standalone
 ExecStart=/usr/bin/ovs-vsctl set Bridge br1 mcast_snooping_enable=false
 ExecStart=/usr/bin/ovs-vsctl set Bridge br1 rstp_enable=false
 '''},
-                         'patch0\\x2d1.service': OVS_VIRTUAL % {'iface': 'patch0\\x2d1', 'extra':
-                                                                '''Requires=netplan-ovs-br0.service
+                         'patch0-1.service': OVS_VIRTUAL % {'iface': 'patch0-1', 'extra':
+                                                            '''Requires=netplan-ovs-br0.service
 After=netplan-ovs-br0.service
 
 [Service]
 Type=oneshot
-RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl set Interface patch0-1 type=patch
 ExecStart=/usr/bin/ovs-vsctl set Interface patch0-1 options:peer=patch1-0
-ExecStop=/usr/bin/ovs-vsctl --if-exists del-port patch0-1
+ExecStart=/usr/bin/ovs-vsctl set Port patch0-1 external-ids:netplan=true
 '''},
-                         'patch1\\x2d0.service': OVS_VIRTUAL % {'iface': 'patch1\\x2d0', 'extra':
-                                                                '''Requires=netplan-ovs-br1.service
+                         'patch1-0.service': OVS_VIRTUAL % {'iface': 'patch1-0', 'extra':
+                                                            '''Requires=netplan-ovs-br1.service
 After=netplan-ovs-br1.service
 
 [Service]
 Type=oneshot
-RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl set Interface patch1-0 type=patch
 ExecStart=/usr/bin/ovs-vsctl set Interface patch1-0 options:peer=patch0-1
-ExecStop=/usr/bin/ovs-vsctl --if-exists del-port patch1-0
-'''}})
+ExecStart=/usr/bin/ovs-vsctl set Port patch1-0 external-ids:netplan=true
+'''},
+                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         self.assert_networkd({'br0.network': ND_WITHIP % ('br0', '192.168.1.1/24'),
                               'br1.network': ND_WITHIP % ('br1', '192.168.1.2/24'),
-                              'patch0\\x2d1.network': ND_EMPTY % ('patch0-1', 'no'),
-                              'patch1\\x2d0.network': ND_EMPTY % ('patch1-0', 'no')})
+                              'patch0-1.network': ND_EMPTY % ('patch0-1', 'no'),
+                              'patch1-0.network': ND_EMPTY % ('patch1-0', 'no')})
 
     def test_fake_vlan_bridge_setup(self):
         self.generate('''network:
@@ -953,10 +920,8 @@ ExecStop=/usr/bin/ovs-vsctl --if-exists del-port patch1-0
         self.assert_ovs({'br0.service': OVS_VIRTUAL % {'iface': 'br0', 'extra': '''
 [Service]
 Type=oneshot
-RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
-ExecStop=/usr/bin/ovs-vsctl del-br br0
-ExecStart=/usr/bin/ovs-vsctl set Port br0 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set-fail-mode br0 standalone
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 mcast_snooping_enable=false
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 rstp_enable=false
@@ -967,11 +932,10 @@ After=netplan-ovs-br0.service
 
 [Service]
 Type=oneshot
-RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0.100 br0 100
-ExecStop=/usr/bin/ovs-vsctl del-br br0.100
-ExecStart=/usr/bin/ovs-vsctl set Port br0.100 external-ids:netplan=true
-'''}})
+ExecStart=/usr/bin/ovs-vsctl set Bridge br0.100 external-ids:netplan=true
+'''},
+                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({'br0.network': ND_WITHIP % ('br0', '192.168.1.1/24'),
                               'br0.100.network': ND_EMPTY % ('br0.100', 'ipv6')})
@@ -993,10 +957,8 @@ ExecStart=/usr/bin/ovs-vsctl set Port br0.100 external-ids:netplan=true
         self.assert_ovs({'br0.service': OVS_VIRTUAL % {'iface': 'br0', 'extra': '''
 [Service]
 Type=oneshot
-RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
-ExecStop=/usr/bin/ovs-vsctl del-br br0
-ExecStart=/usr/bin/ovs-vsctl set Port br0 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set-fail-mode br0 standalone
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 mcast_snooping_enable=false
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 rstp_enable=false
@@ -1007,11 +969,10 @@ After=netplan-ovs-br0.service
 
 [Service]
 Type=oneshot
-RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0.100 br0 100
-ExecStop=/usr/bin/ovs-vsctl del-br br0.100
-ExecStart=/usr/bin/ovs-vsctl set Port br0.100 external-ids:netplan=true
-'''}})
+ExecStart=/usr/bin/ovs-vsctl set Bridge br0.100 external-ids:netplan=true
+'''},
+                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({'br0.network': ND_WITHIP % ('br0', '192.168.1.1/24'),
                               'br0.100.network': ND_EMPTY % ('br0.100', 'ipv6')})
@@ -1041,24 +1002,22 @@ ExecStart=/usr/bin/ovs-vsctl set Port br0.100 external-ids:netplan=true
             interfaces: [non-ovs-bond]
             openvswitch: {}
 ''')
-        self.assert_ovs({'ovs\\x2dbr.service': OVS_VIRTUAL % {'iface': 'ovs\\x2dbr', 'extra': '''
+        self.assert_ovs({'ovs-br.service': OVS_VIRTUAL % {'iface': 'ovs-br', 'extra': '''
 [Service]
 Type=oneshot
-RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br ovs-br
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-port ovs-br non-ovs-bond
-ExecStop=/usr/bin/ovs-vsctl del-port ovs-br non-ovs-bond
-ExecStop=/usr/bin/ovs-vsctl del-br ovs-br
-ExecStart=/usr/bin/ovs-vsctl set Port ovs-br external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Bridge ovs-br external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set-fail-mode ovs-br standalone
 ExecStart=/usr/bin/ovs-vsctl set Bridge ovs-br mcast_snooping_enable=false
 ExecStart=/usr/bin/ovs-vsctl set Bridge ovs-br rstp_enable=false
-'''}})
+'''},
+                         'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({'non-ovs-bond.network': ND_EMPTY % ('non-ovs-bond', 'no') + 'Bridge=ovs-br\n',
                               'eth1.network': (ND_EMPTY % ('eth1', 'no')).replace('ConfigureWithoutCarrier=yes',
                               'Bond=non-ovs-bond'),
                               'eth0.network': (ND_EMPTY % ('eth0', 'no')).replace('ConfigureWithoutCarrier=yes',
                               'Bond=non-ovs-bond'),
-                              'ovs\\x2dbr.network': ND_EMPTY % ('ovs-br', 'ipv6'),
+                              'ovs-br.network': ND_EMPTY % ('ovs-br', 'ipv6'),
                               'non-ovs-bond.netdev': '[NetDev]\nName=non-ovs-bond\nKind=bond\n'})

--- a/tests/generator/test_ovs.py
+++ b/tests/generator/test_ovs.py
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from .base import TestBase, ND_DHCP4, ND_DHCP6, OVS_PHYSICAL, OVS_VIRTUAL
+from .base import TestBase, ND_EMPTY, ND_WITHIP, ND_DHCP4, ND_DHCP6, OVS_PHYSICAL, OVS_VIRTUAL
 
 
 class TestOpenVSwitch(TestBase):
@@ -57,40 +57,6 @@ ExecStart=/usr/bin/ovs-vsctl set Interface eth1 other-config:disable-in-band=fal
         self.assert_networkd({'eth0.network': ND_DHCP6 % 'eth0',
                               'eth1.network': ND_DHCP4 % 'eth1'})
 
-    def test_bridge_external_ids_other_config(self):
-        self.generate('''network:
-  version: 2
-  bridges:
-    br0:
-      openvswitch:
-        external-ids:
-          iface-id: myhostname
-        other-config:
-          disable-in-band: true
-      dhcp4: yes
-''')
-        self.assert_ovs({'br0.service': OVS_VIRTUAL % {'iface': 'br0', 'extra': '''
-[Service]
-Type=oneshot
-RemainAfterExit=yes
-ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:iface-id=myhostname
-ExecStart=/usr/bin/ovs-vsctl set Bridge br0 other-config:disable-in-band=true
-'''}})
-        # Confirm that the networkd config is still sane
-        self.assert_networkd({'br0.netdev': '[NetDev]\nName=br0\nKind=bridge\n',
-                              'br0.network': '''[Match]
-Name=br0
-
-[Network]
-DHCP=ipv4
-LinkLocalAddressing=ipv6
-ConfigureWithoutCarrier=yes
-
-[DHCP]
-RouteMetric=100
-UseMTU=true
-'''})
-
     def test_global_external_ids_other_config(self):
         self.generate('''network:
   version: 2
@@ -109,6 +75,24 @@ Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:iface-id=myhostname
 ExecStart=/usr/bin/ovs-vsctl set open_vswitch . other-config:disable-in-band=true
+'''}})
+        # Confirm that the networkd config is still sane
+        self.assert_networkd({'eth0.network': ND_DHCP4 % 'eth0'})
+
+    def test_global_set_protocols(self):
+        self.generate('''network:
+  version: 2
+  openvswitch:
+    protocols: [OpenFlow10, OpenFlow11, OpenFlow12]
+  ethernets:
+    eth0:
+      dhcp4: yes
+''')
+        self.assert_ovs({'global.service': OVS_VIRTUAL % {'iface': 'global', 'extra': '''
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/ovs-ofctl -O OpenFlow10,OpenFlow11,OpenFlow12
 '''}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({'eth0.network': ND_DHCP4 % 'eth0'})
@@ -169,7 +153,9 @@ ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:iface-id=myhostname
 '''}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({'eth1.network': '[Match]\nName=eth1\n\n[Network]\nLinkLocalAddressing=no\nBond=bond0\n',
-                              'eth2.network': '[Match]\nName=eth2\n\n[Network]\nLinkLocalAddressing=no\nBond=bond0\n'})
+                              'eth2.network': '[Match]\nName=eth2\n\n[Network]\nLinkLocalAddressing=no\nBond=bond0\n',
+                              'br0.network': ND_WITHIP % ('br0', '192.170.1.1/24'),
+                              'bond0.network': ND_EMPTY % ('bond0', 'no')})
 
     def test_bond_no_bridge(self):
         err = self.generate('''network:
@@ -249,7 +235,9 @@ ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=active
 '''}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({'eth1.network': '[Match]\nName=eth1\n\n[Network]\nLinkLocalAddressing=no\nBond=bond0\n',
-                              'eth2.network': '[Match]\nName=eth2\n\n[Network]\nLinkLocalAddressing=no\nBond=bond0\n'})
+                              'eth2.network': '[Match]\nName=eth2\n\n[Network]\nLinkLocalAddressing=no\nBond=bond0\n',
+                              'br0.network': ND_WITHIP % ('br0', '192.170.1.1/24'),
+                              'bond0.network': ND_EMPTY % ('bond0', 'no')})
 
     def test_bond_lacp_invalid(self):
         err = self.generate('''network:
@@ -312,7 +300,9 @@ ExecStart=/usr/bin/ovs-vsctl set Port bond0 bond_mode=balance-tcp
 '''}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({'eth1.network': '[Match]\nName=eth1\n\n[Network]\nLinkLocalAddressing=no\nBond=bond0\n',
-                              'eth2.network': '[Match]\nName=eth2\n\n[Network]\nLinkLocalAddressing=no\nBond=bond0\n'})
+                              'eth2.network': '[Match]\nName=eth2\n\n[Network]\nLinkLocalAddressing=no\nBond=bond0\n',
+                              'br0.network': ND_WITHIP % ('br0', '192.170.1.1/24'),
+                              'bond0.network': ND_EMPTY % ('bond0', 'no')})
 
     def test_bond_mode_explicit_params(self):
         self.generate('''network:
@@ -347,7 +337,9 @@ ExecStart=/usr/bin/ovs-vsctl set Port bond0 bond_mode=active-backup
 '''}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({'eth1.network': '[Match]\nName=eth1\n\n[Network]\nLinkLocalAddressing=no\nBond=bond0\n',
-                              'eth2.network': '[Match]\nName=eth2\n\n[Network]\nLinkLocalAddressing=no\nBond=bond0\n'})
+                              'eth2.network': '[Match]\nName=eth2\n\n[Network]\nLinkLocalAddressing=no\nBond=bond0\n',
+                              'br0.network': ND_WITHIP % ('br0', '192.170.1.1/24'),
+                              'bond0.network': ND_EMPTY % ('bond0', 'no')})
 
     def test_bond_mode_ovs_invalid(self):
         err = self.generate('''network:
@@ -368,3 +360,173 @@ ExecStart=/usr/bin/ovs-vsctl set Port bond0 bond_mode=active-backup
       openvswitch: {}
 ''', expect_fail=True)
         self.assertIn("bond0: bond mode 'balance-rr' not supported by openvswitch", err)
+
+    def test_bridge_setup(self):
+        self.generate('''network:
+  version: 2
+  ethernets:
+    eth1: {}
+    eth2: {}
+  bridges:
+    br0:
+      addresses: [192.170.1.1/24]
+      interfaces: [eth1, eth2]
+      openvswitch: {}
+''')
+        self.assert_ovs({'br0.service': OVS_VIRTUAL % {'iface': 'br0', 'extra':
+                        '''
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/ovs-vsctl add-br br0
+ExecStart=/usr/bin/ovs-vsctl add-port br0 eth1
+ExecStop=/usr/bin/ovs-vsctl del-port br0 eth1
+ExecStart=/usr/bin/ovs-vsctl add-port br0 eth2
+ExecStop=/usr/bin/ovs-vsctl del-port br0 eth2
+ExecStop=/usr/bin/ovs-vsctl del-br br0
+ExecStart=/usr/bin/ovs-vsctl set Port br0 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set-fail-mode br0 standalone
+ExecStart=/usr/bin/ovs-vsctl set Bridge br0 mcast_snooping_enable=false
+ExecStart=/usr/bin/ovs-vsctl set Bridge br0 rstp_enable=false
+'''}})
+        # Confirm that the networkd config is still sane
+        self.assert_networkd({'eth1.network': '[Match]\nName=eth1\n\n[Network]\nLinkLocalAddressing=no\nBridge=br0\n',
+                              'eth2.network': '[Match]\nName=eth2\n\n[Network]\nLinkLocalAddressing=no\nBridge=br0\n',
+                              'br0.network': ND_WITHIP % ('br0', '192.170.1.1/24')})
+
+    def test_bridge_external_ids_other_config(self):
+        self.generate('''network:
+  version: 2
+  bridges:
+    br0:
+      openvswitch:
+        external-ids:
+          iface-id: myhostname
+        other-config:
+          disable-in-band: true
+''')
+        self.assert_ovs({'br0.service': OVS_VIRTUAL % {'iface': 'br0', 'extra': '''
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/ovs-vsctl add-br br0
+ExecStop=/usr/bin/ovs-vsctl del-br br0
+ExecStart=/usr/bin/ovs-vsctl set Port br0 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set-fail-mode br0 standalone
+ExecStart=/usr/bin/ovs-vsctl set Bridge br0 mcast_snooping_enable=false
+ExecStart=/usr/bin/ovs-vsctl set Bridge br0 rstp_enable=false
+ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:iface-id=myhostname
+ExecStart=/usr/bin/ovs-vsctl set Bridge br0 other-config:disable-in-band=true
+'''}})
+        # Confirm that the bridge has been only configured for OVS
+        self.assert_networkd({'br0.network': ND_EMPTY % ('br0', 'ipv6')})
+
+    def test_bridge_non_default_parameters(self):
+        self.generate('''network:
+  version: 2
+  ethernets:
+    eth1: {}
+    eth2: {}
+  bridges:
+    br0:
+      addresses: [192.170.1.1/24]
+      interfaces: [eth1, eth2]
+      openvswitch:
+        fail-mode: secure
+        mcast-snooping: true
+        rstp: true
+''')
+        self.assert_ovs({'br0.service': OVS_VIRTUAL % {'iface': 'br0', 'extra':
+                        '''
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/ovs-vsctl add-br br0
+ExecStart=/usr/bin/ovs-vsctl add-port br0 eth1
+ExecStop=/usr/bin/ovs-vsctl del-port br0 eth1
+ExecStart=/usr/bin/ovs-vsctl add-port br0 eth2
+ExecStop=/usr/bin/ovs-vsctl del-port br0 eth2
+ExecStop=/usr/bin/ovs-vsctl del-br br0
+ExecStart=/usr/bin/ovs-vsctl set Port br0 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set-fail-mode br0 secure
+ExecStart=/usr/bin/ovs-vsctl set Bridge br0 mcast_snooping_enable=true
+ExecStart=/usr/bin/ovs-vsctl set Bridge br0 rstp_enable=true
+'''}})
+        # Confirm that the networkd config is still sane
+        self.assert_networkd({'eth1.network': '[Match]\nName=eth1\n\n[Network]\nLinkLocalAddressing=no\nBridge=br0\n',
+                              'eth2.network': '[Match]\nName=eth2\n\n[Network]\nLinkLocalAddressing=no\nBridge=br0\n',
+                              'br0.network': ND_WITHIP % ('br0', '192.170.1.1/24')})
+
+    def test_bridge_fail_mode_invalid(self):
+        err = self.generate('''network:
+  version: 2
+  bridges:
+    br0:
+      openvswitch:
+        fail-mode: glorious
+''', expect_fail=True)
+        self.assertIn("Value of 'fail-mode' needs to be 'standalone' or 'secure'", err)
+
+    def test_fail_mode_non_bridge(self):
+        err = self.generate('''network:
+  version: 2
+  ethernets:
+    eth0:
+      openvswitch:
+        fail-mode: glorious
+''', expect_fail=True)
+        self.assertIn("Key 'fail-mode' is only valid for iterface type 'openvswitch bridge'", err)
+
+    def test_rstp_non_bridge(self):
+        err = self.generate('''network:
+  version: 2
+  ethernets:
+    eth0:
+      openvswitch:
+        rstp: true
+''', expect_fail=True)
+        self.assertIn("Key is only valid for iterface type 'openvswitch bridge'", err)
+
+    def test_bridge_set_protocols(self):
+        self.generate('''network:
+  version: 2
+  bridges:
+    br0:
+      openvswitch:
+        protocols: [OpenFlow10, OpenFlow11, OpenFlow15]
+''')
+        self.assert_ovs({'br0.service': OVS_VIRTUAL % {'iface': 'br0', 'extra':
+                        '''
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/ovs-vsctl add-br br0
+ExecStop=/usr/bin/ovs-vsctl del-br br0
+ExecStart=/usr/bin/ovs-vsctl set Port br0 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set-fail-mode br0 standalone
+ExecStart=/usr/bin/ovs-vsctl set Bridge br0 mcast_snooping_enable=false
+ExecStart=/usr/bin/ovs-vsctl set Bridge br0 rstp_enable=false
+ExecStart=/usr/bin/ovs-vsctl set Bridge br0 protocols=OpenFlow10,OpenFlow11,OpenFlow15
+'''}})
+        # Confirm that the networkd config is still sane
+        self.assert_networkd({'br0.network': ND_EMPTY % ('br0', 'ipv6')})
+
+    def test_bridge_set_protocols_invalid(self):
+        err = self.generate('''network:
+  version: 2
+  bridges:
+    br0:
+      openvswitch:
+        protocols: [OpenFlow10, OpenFooBar13, OpenFlow15]
+''', expect_fail=True)
+        self.assertIn("Unsupported OVS 'protocol' value: OpenFooBar13", err)
+
+    def test_set_protocols_invalid_interface(self):
+        err = self.generate('''network:
+  version: 2
+  ethernets:
+    eth0:
+      openvswitch:
+        protocols: [OpenFlow10, OpenFlow15]
+''', expect_fail=True)
+        self.assertIn("Key 'protocols' is only valid for iterface type 'openvswitch bridge'", err)

--- a/tests/generator/test_ovs.py
+++ b/tests/generator/test_ovs.py
@@ -933,7 +933,7 @@ After=netplan-ovs-br0.service
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0.100 br0 100
-ExecStart=/usr/bin/ovs-vsctl set Bridge br0.100 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Interface br0.100 external-ids:netplan=true
 '''},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane
@@ -970,7 +970,7 @@ After=netplan-ovs-br0.service
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0.100 br0 100
-ExecStart=/usr/bin/ovs-vsctl set Bridge br0.100 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Interface br0.100 external-ids:netplan=true
 '''},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane

--- a/tests/generator/test_ovs.py
+++ b/tests/generator/test_ovs.py
@@ -1,0 +1,156 @@
+#
+# Common tests for netplan OpenVSwitch support
+#
+# Copyright (C) 2020 Canonical, Ltd.
+# Author: Łukasz 'sil2100' Zemczak <lukasz.zemczak@ubuntu.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from .base import TestBase, ND_DHCP4, ND_DHCP6
+
+
+class TestOpenVSwitch(TestBase):
+    '''OVS output'''
+
+    def test_interface_external_ids_other_config(self):
+        self.generate('''network:
+  version: 2
+  ethernets:
+    eth0:
+      openvswitch:
+        external-ids:
+          iface-id: myhostname
+        other-config:
+          disable-in-band: true
+      dhcp6: true
+    eth1:
+      dhcp4: true
+      openvswitch:
+        other-config:
+          disable-in-band: false
+''')
+        self.assert_ovs({'eth0.service': '''[Unit]
+Description=OpenVSwitch configuration for eth0
+DefaultDependencies=no
+Requires=sys-subsystem-net-devices-eth0.device
+After=sys-subsystem-net-devices-eth0.device
+Before=network.target
+Wants=network.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/ovs-vsctl set Interface eth0 external-ids:iface-id=myhostname
+ExecStart=/usr/bin/ovs-vsctl set Interface eth0 other-config:disable-in-band=true
+''',
+                         'eth1.service': '''[Unit]
+Description=OpenVSwitch configuration for eth1
+DefaultDependencies=no
+Requires=sys-subsystem-net-devices-eth1.device
+After=sys-subsystem-net-devices-eth1.device
+Before=network.target
+Wants=network.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/ovs-vsctl set Interface eth1 other-config:disable-in-band=false
+'''})
+        # Confirm that the networkd config is still sane
+        self.assert_networkd({'eth0.network': ND_DHCP6 % 'eth0',
+                              'eth1.network': ND_DHCP4 % 'eth1'})
+
+    def test_bridge_external_ids_other_config(self):
+        self.generate('''network:
+  version: 2
+  bridges:
+    br0:
+      openvswitch:
+        external-ids:
+          iface-id: myhostname
+        other-config:
+          disable-in-band: true
+      dhcp4: yes
+''')
+        self.assert_ovs({'br0.service': '''[Unit]
+Description=OpenVSwitch configuration for br0
+DefaultDependencies=no
+Before=network.target
+Wants=network.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:iface-id=myhostname
+ExecStart=/usr/bin/ovs-vsctl set Bridge br0 other-config:disable-in-band=true
+'''})
+        # Confirm that the networkd config is still sane
+        self.assert_networkd({'br0.netdev': '[NetDev]\nName=br0\nKind=bridge\n',
+                              'br0.network': '''[Match]
+Name=br0
+
+[Network]
+DHCP=ipv4
+LinkLocalAddressing=ipv6
+ConfigureWithoutCarrier=yes
+
+[DHCP]
+RouteMetric=100
+UseMTU=true
+'''})
+
+    def test_global_external_ids_other_config(self):
+        self.generate('''network:
+  version: 2
+  openvswitch:
+    external-ids:
+      iface-id: myhostname
+    other-config:
+      disable-in-band: true
+  ethernets:
+    eth0:
+      dhcp4: yes
+''')
+        self.assert_ovs({'global.service': '''[Unit]
+Description=OpenVSwitch configuration for global
+DefaultDependencies=no
+Before=network.target
+Wants=network.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:iface-id=myhostname
+ExecStart=/usr/bin/ovs-vsctl set open_vswitch . other-config:disable-in-band=true
+'''})
+        # Confirm that the networkd config is still sane
+        self.assert_networkd({'eth0.network': ND_DHCP4 % 'eth0'})
+
+    def test_duplicate_map_entry(self):
+        err = self.generate('''network:
+  version: 2
+  openvswitch:
+    external-ids:
+      iface-id: myhostname
+      iface-id: foobar
+  ethernets:
+    eth0:
+      dhcp4: yes
+''', expect_fail=True)
+        self.assertIn("duplicate map entry 'iface-id'", err)
+
+    def test_no_ovs_config(self):
+        self.generate('''network:
+  version: 2
+  ethernets:
+    eth0:
+      dhcp4: yes
+''')
+        self.assert_ovs(None)
+        self.assert_networkd({'eth0.network': ND_DHCP4 % 'eth0'})

--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -94,7 +94,7 @@ class IntegrationTestsBase(unittest.TestCase):
 
     def tearDown(self):
         subprocess.call(['systemctl', 'stop', 'NetworkManager', 'systemd-networkd', 'netplan-wpa-*',
-                                              'systemd-networkd.socket'])
+                         'netplan-ovs-*', 'systemd-networkd.socket'])
         # NM has KillMode=process and leaks dhclient processes
         subprocess.call(['systemctl', 'kill', 'NetworkManager'])
         subprocess.call(['systemctl', 'reset-failed', 'NetworkManager', 'systemd-networkd'],

--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -359,7 +359,7 @@ class IntegrationTestsBase(unittest.TestCase):
         subprocess.check_call(['systemctl', 'start', '--no-block', 'NetworkManager.service'])
         # wait until networkd is done
         if self.is_active('systemd-networkd.service'):
-            if subprocess.call(['/lib/systemd/systemd-networkd-wait-online', '--quiet', '--timeout=50']) != 0:
+            if subprocess.call(['/lib/systemd/systemd-networkd-wait-online', '--quiet', '--timeout=20']) != 0:
                 subprocess.call(['journalctl', '-b', '--no-pager', '-t', 'systemd-networkd'])
                 st = subprocess.check_output(['networkctl'], stderr=subprocess.PIPE, universal_newlines=True)
                 st_e = subprocess.check_output(['networkctl', 'status', self.dev_e_client],

--- a/tests/integration/ovs.py
+++ b/tests/integration/ovs.py
@@ -71,11 +71,10 @@ class _CommonTests():
                           ['inet 192.168.5.[0-9]+/16', 'mtu 9000'])  # from DHCP
         self.assert_iface('br-data', ['inet 192.168.20.1/16'])
         self.assert_iface(self.dev_e_client, ['mtu 9000', 'master ovs-system'])
-        vid = subprocess.check_output(['ovs-vsctl', 'br-to-vlan',
-                                       'br-%s.100' % self.dev_e_client])
-        self.assertIn(b'100', vid)
-        parent = subprocess.check_output(['ovs-vsctl', 'br-to-parent',
-                                          'br-%s.100' % self.dev_e_client])
+        self.assertIn(b'100', subprocess.check_output(['ovs-vsctl', 'br-to-vlan',
+                      'br-%s.100' % self.dev_e_client]))
+        self.assertIn(b'br-%b' % self.dev_e_client.encode(), subprocess.check_output(
+                      ['ovs-vsctl', 'br-to-parent', 'br-%s.100' % self.dev_e_client]))
         self.assertIn(b'br-%b' % self.dev_e_client.encode(), out)
 
     def test_bridge_base(self):

--- a/tests/integration/ovs.py
+++ b/tests/integration/ovs.py
@@ -29,6 +29,55 @@ from base import IntegrationTestsBase, test_backends
 
 class _CommonTests():
 
+    # FIXME: Why does this test need to run first in order to pass?
+    #   We must leave some dirty state somewhere in the other tests
+    def test_1_bridge_vlan(self):
+        self.setup_eth(None, True)
+        self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-br', 'br-%s' % self.dev_e_client])
+        self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-br', 'br-data'])
+        self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-br', 'br-%s.100' % self.dev_e_client])
+        with open(self.config, 'w') as f:
+            f.write('''network:
+    version: 2
+    ethernets:
+        %(ec)s:
+            mtu: 9000
+    bridges:
+        br-%(ec)s:
+            dhcp4: true
+            mtu: 9000
+            interfaces: [%(ec)s]
+            openvswitch: {}
+        br-data:
+            openvswitch: {}
+            addresses: [192.168.20.1/16]
+    vlans:
+        br-%(ec)s.100:
+            id: 100
+            link: br-%(ec)s
+            openvswitch: {}''' % {'ec': self.dev_e_client})
+        self.generate_and_settle()
+        # Basic verification that the interfaces/ports are set up in OVS
+        out = subprocess.check_output(['ovs-vsctl', 'show'])
+        self.assertIn(b'    Bridge br-%b' % self.dev_e_client.encode(), out)
+        self.assertIn(b'''        Port %(ec)b
+            Interface %(ec)b''' % {b'ec': self.dev_e_client.encode()}, out)
+        self.assertIn(b'''        Port br-%(ec)b.100
+            tag: 100
+            Interface br-%(ec)b.100
+                type: internal''' % {b'ec': self.dev_e_client.encode()}, out)
+        self.assertIn(b'    Bridge br-data', out)
+        self.assert_iface('br-%s' % self.dev_e_client,
+                          ['inet 192.168.5.[0-9]+/16', 'mtu 9000'])  # from DHCP
+        self.assert_iface('br-data', ['inet 192.168.20.1/16'])
+        self.assert_iface(self.dev_e_client, ['mtu 9000', 'master ovs-system'])
+        vid = subprocess.check_output(['ovs-vsctl', 'br-to-vlan',
+                                       'br-%s.100' % self.dev_e_client])
+        self.assertIn(b'100', vid)
+        parent = subprocess.check_output(['ovs-vsctl', 'br-to-parent',
+                                          'br-%s.100' % self.dev_e_client])
+        self.assertIn(b'br-%b' % self.dev_e_client.encode(), out)
+
     def test_bridge_base(self):
         self.setup_eth(None, False)
         self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-br', 'ovsbr'])
@@ -138,42 +187,6 @@ class _CommonTests():
                 options: {peer=patch0-1}''', out)
         self.assert_iface('br0', ['inet 192.168.1.1/24'])
         self.assert_iface('br1', ['inet 192.168.2.1/24'])
-
-    def test_bridge_vlan(self):
-        self.setup_eth(None, True)
-        self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-br', 'br-%s' % self.dev_e_client])
-        self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-br', 'br-data'])
-        with open(self.config, 'w') as f:
-            f.write('''network:
-    version: 2
-    ethernets:
-        %(ec)s:
-            mtu: 9000
-    bridges:
-        br-%(ec)s:
-            dhcp4: true
-            mtu: 9000
-            interfaces: [%(ec)s]
-            openvswitch: {}
-        br-data:
-            openvswitch: {}
-            addresses: [192.168.20.1/16]
-#    vlans:
-#        br-%(ec)s.100:
-#            id: 100
-#            link: br-%(ec)s
-#            openvswitch: {}''' % {'ec': self.dev_e_client})
-        self.generate_and_settle()
-        # Basic verification that the interfaces/ports are set up in OVS
-        out = subprocess.check_output(['ovs-vsctl', 'show'])
-        self.assertIn(b'    Bridge br-%b' % self.dev_e_client.encode(), out)
-        self.assertIn(b'''        Port %(ec)b
-            Interface %(ec)b''' % {b'ec': self.dev_e_client.encode()}, out)
-        self.assertIn(b'    Bridge br-data', out)
-        self.assert_iface('br-%s' % self.dev_e_client,
-                          ['inet 192.168.5.[0-9]+/16', 'mtu 9000'])  # from DHCP
-        self.assert_iface('br-data', ['inet 192.168.20.1/16'])
-        self.assert_iface(self.dev_e_client, ['mtu 9000', 'master ovs-system'])
 
 
 @unittest.skipIf("networkd" not in test_backends,

--- a/tests/integration/ovs.py
+++ b/tests/integration/ovs.py
@@ -1,0 +1,80 @@
+#!/usr/bin/python3
+#
+# Integration tests for bonds
+#
+# These need to be run in a VM and do change the system
+# configuration.
+#
+# Copyright (C) 2020 Canonical, Ltd.
+# Author: Lukas Märdian <lukas.maerdian@canonical.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import sys
+import subprocess
+import unittest
+
+from base import IntegrationTestsBase, test_backends
+
+
+class _CommonTests():
+
+    def test_bond_base(self):
+        self.setup_eth(None, False)
+        self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-br', 'ovsbr'])
+        self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-port', 'mybond'])
+        # XXX: Temporary bridge setup, until netplan-ovs can do it itself
+        subprocess.call(['ovs-vsctl', 'add-br', 'ovsbr'])
+        with open(self.config, 'w') as f:
+            f.write('''network:
+  ethernets:
+    %(ec)s: {}
+    %(e2c)s: {}
+  bonds:
+    mybond:
+      interfaces: [%(ec)s, %(e2c)s]
+      parameters:
+        mode: balance-slb
+      openvswitch:
+        lacp: off
+  bridges:
+    ovsbr:
+      addresses: [192.170.1.1/24]
+      interfaces: [mybond]
+      openvswitch: {}''' % {'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
+        self.generate_and_settle()
+        # Basic verification that the interfaces/ports are in OVS
+        out = subprocess.check_output(['ovs-vsctl', 'show'])
+        self.assertIn(b'    Bridge ovsbr', out)
+        self.assertIn(b'        Port mybond', out)
+        self.assertIn(b'            Interface eth42', out)
+        self.assertIn(b'            Interface eth43', out)
+        # Verify the bridge was tagged 'netplan:true' correctly
+        out = subprocess.check_output(['ovs-vsctl', '--columns=name,external-ids', 'list', 'Port'])
+        self.assertIn(b'mybond\nexternal_ids        : {netplan="true"}', out)
+        # Verify bond params
+        out = subprocess.check_output(['ovs-appctl', 'bond/show', 'mybond'])
+        self.assertIn(b'---- mybond ----', out)
+        self.assertIn(b'bond_mode: balance-slb', out)
+        self.assertIn(b'lacp_status: off', out)
+        self.assertIn(b'slave eth42: enabled', out)
+        self.assertIn(b'slave eth43: enabled', out)
+
+
+@unittest.skipIf("networkd" not in test_backends,
+                     "skipping as networkd backend tests are disabled")
+class TestOVS(IntegrationTestsBase, _CommonTests):
+    backend = 'networkd'
+
+
+unittest.main(testRunner=unittest.TextTestRunner(stream=sys.stdout, verbosity=2))

--- a/tests/test_ovs.py
+++ b/tests/test_ovs.py
@@ -1,0 +1,129 @@
+#!/usr/bin/python3
+#
+# Copyright (C) 2020 Canonical, Ltd.
+# Author: Lukas Märdian <lukas.maerdian@canonical.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from unittest.mock import patch, call
+from netplan.cli.ovs import OPENVSWITCH_OVS_VSCTL as OVS
+
+import netplan.cli.ovs as ovs
+
+
+class TestOVS(unittest.TestCase):
+
+    @patch('subprocess.check_call')
+    def test_clear_settings_tag(self, mock):
+        ovs.clear_setting('Bridge', 'ovs0', 'netplan/external-ids/key', 'value')
+        mock.assert_called_with([OVS, 'remove', 'Bridge', 'ovs0', 'external-ids', 'netplan/external-ids/key'])
+
+    @patch('subprocess.check_output')
+    @patch('subprocess.check_call')
+    def test_clear_global_ssl(self, mock, mock_out):
+        mock_out.return_value = '''
+Private key: /private/key.pem
+Certificate: /another/cert.pem
+CA Certificate: /some/ca-cert.pem
+Bootstrap: false'''
+        ovs.clear_setting('Open_vSwitch', '.', 'netplan/global/set-ssl', '/private/key.pem,/another/cert.pem,/some/ca-cert.pem')
+        mock_out.assert_called_once_with([OVS, 'get-ssl'], universal_newlines=True)
+        mock.assert_has_calls([
+            call([OVS, 'del-ssl']),
+            call([OVS, 'remove', 'Open_vSwitch', '.', 'external-ids', 'netplan/global/set-ssl'])
+        ])
+
+    @patch('subprocess.check_output')
+    @patch('subprocess.check_call')
+    def test_no_clear_global_ssl_different(self, mock, mock_out):
+        mock_out.return_value = '''
+Private key: /private/key.pem
+Certificate: /another/cert.pem
+CA Certificate: /some/ca-cert.pem
+Bootstrap: false'''
+        ovs.clear_setting('Open_vSwitch', '.', 'netplan/global/set-ssl', '/some/key.pem,/other/cert.pem,/some/cert.pem')
+        mock_out.assert_called_once_with([OVS, 'get-ssl'], universal_newlines=True)
+        mock.assert_has_calls([
+            call([OVS, 'remove', 'Open_vSwitch', '.', 'external-ids', 'netplan/global/set-ssl'])
+        ])
+
+    def test_clear_global_unknown(self):
+        with self.assertRaises(Exception):
+            ovs.clear_setting('Bridge', 'ovs0', 'netplan/global/set-something', 'INVALID')
+
+    @patch('subprocess.check_output')
+    @patch('subprocess.check_call')
+    def test_clear_global(self, mock, mock_out):
+        mock_out.return_value = 'tcp:127.0.0.1:1337\nunix:/some/socket'
+        ovs.clear_setting('Bridge', 'ovs0', 'netplan/global/set-controller', 'tcp:127.0.0.1:1337,unix:/some/socket')
+        mock_out.assert_called_once_with([OVS, 'get-controller', 'ovs0'], universal_newlines=True)
+        mock.assert_has_calls([
+            call([OVS, 'del-controller', 'ovs0']),
+            call([OVS, 'remove', 'Bridge', 'ovs0', 'external-ids', 'netplan/global/set-controller'])
+        ])
+
+    @patch('subprocess.check_output')
+    @patch('subprocess.check_call')
+    def test_no_clear_global_different(self, mock, mock_out):
+        mock_out.return_value = 'unix:/var/run/openvswitch/ovs0.mgmt'
+        ovs.clear_setting('Bridge', 'ovs0', 'netplan/global/set-controller', 'tcp:127.0.0.1:1337,unix:/some/socket')
+        mock_out.assert_called_once_with([OVS, 'get-controller', 'ovs0'], universal_newlines=True)
+        mock.assert_has_calls([
+            call([OVS, 'remove', 'Bridge', 'ovs0', 'external-ids', 'netplan/global/set-controller'])
+        ])
+
+    @patch('subprocess.check_call')
+    def test_clear_dict(self, mock):
+        ovs.clear_setting('Bridge', 'ovs0', 'netplan/other-config/key', 'value')
+        mock.assert_has_calls([
+            call([OVS, 'remove', 'Bridge', 'ovs0', 'other-config', 'key', 'value']),
+            call([OVS, 'remove', 'Bridge', 'ovs0', 'external-ids', 'netplan/other-config/key'])
+        ])
+
+    @patch('subprocess.check_call')
+    def test_clear_col(self, mock):
+        ovs.clear_setting('Port', 'bond0', 'netplan/bond_mode', 'balance-tcp')
+        mock.assert_has_calls([
+            call([OVS, 'remove', 'Port', 'bond0', 'bond_mode', 'balance-tcp']),
+            call([OVS, 'remove', 'Port', 'bond0', 'external-ids', 'netplan/bond_mode'])
+        ])
+
+    @patch('subprocess.check_call')
+    def test_clear_col_default(self, mock):
+        ovs.clear_setting('Bridge', 'ovs0', 'netplan/rstp_enable', 'true')
+        mock.assert_has_calls([
+            call([OVS, 'set', 'Bridge', 'ovs0', 'rstp_enable=false']),
+            call([OVS, 'remove', 'Bridge', 'ovs0', 'external-ids', 'netplan/rstp_enable'])
+        ])
+
+    def test_is_ovs_interface(self):
+        interfaces = dict()
+        interfaces['ovs0'] = {'openvswitch': {'set-fail-mode': 'secure'}}
+        self.assertTrue(ovs.is_ovs_interface('ovs0', interfaces))
+
+    def test_is_ovs_interface_false(self):
+        interfaces = dict()
+        interfaces['br0'] = {'interfaces': ['eth0', 'eth1']}
+        interfaces['eth0'] = {}
+        interfaces['eth1'] = {}
+        self.assertFalse(ovs.is_ovs_interface('br0', interfaces))
+
+    def test_is_ovs_interface_recursive(self):
+        interfaces = dict()
+        interfaces['patchx'] = {'peer': 'patchy', 'openvswitch': {}}
+        interfaces['patchy'] = {'peer': 'patchx', 'openvswitch': {}}
+        interfaces['ovs0'] = {'interfaces': ['bond0']}
+        interfaces['bond0'] = {'interfaces': ['patchx', 'patchy']}
+        self.assertTrue(ovs.is_ovs_interface('ovs0', interfaces))

--- a/tests/validate_docs.sh
+++ b/tests/validate_docs.sh
@@ -22,7 +22,7 @@ for term in $(sed -n 's/[ ]\+{"\([a-z0-9-]\+\)", YAML_[A-Z]\+_NODE.*/\1/p' src/p
     fi
 
     # 2. "[blah, ]``blah``[, ``blah2``]: (scalar|bool|...)
-    if egrep "\`\`$term\`\`.*\((scalar|bool|mapping|sequence of scalars)" doc/netplan.md > /dev/null; then
+    if egrep "\`\`$term\`\`.*\((scalar|bool|mapping|sequence of scalars|sequence of sequence of scalars)" doc/netplan.md > /dev/null; then
         continue
     fi
 


### PR DESCRIPTION
## Description

Finally merge the work-in-progress OpenVSwitch support branch to master. Currently the branch should be feature-complete as per the initial specification, meaning we support:
 * OVS bridges
 * OVS bonds
 * OVS patch ports
 * Custom settings like SSL config, other-config, external-ids etc.
 * Fake VLAN bridges

This version also attempts to do smart cleanup of the configuration, removing no-longer relevant configuration on every `netplan apply` or system reboot.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [x] New/changed keys in YAML format are documented.
- [x] \(Optional\) Closes an open bug in Launchpad: https://bugs.launchpad.net/netplan/+bug/1728134

