### PR TITLE
Fix GCC-10 -fno-common linker errors (LP: #1875412)

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -62,6 +62,11 @@ GList* netdefs_ordered;
  * existing definition */
 static GHashTable* ids_in_file;
 
+/* Global variables, defined in this file */
+int missing_ids_found;
+const char* current_file;
+GHashTable* missing_id;
+
 /**
  * Load YAML file name into a yaml_document_t.
  *

--- a/src/parse.h
+++ b/src/parse.h
@@ -25,14 +25,14 @@
 
 
 /* file that is currently being processed, for useful error messages */
-const char* current_file;
+extern const char* current_file;
 
 /* List of "seen" ids not found in netdefs yet by the parser.
  * These are removed when it exists in this list and we reach the point of
  * creating a netdef for that id; so by the time we're done parsing the yaml
  * document it should be empty. */
-GHashTable *missing_id;
-int missing_ids_found;
+extern GHashTable *missing_id;
+extern int missing_ids_found;
 
 /****************************************************
  * Parsed definitions

--- a/src/util.c
+++ b/src/util.c
@@ -24,6 +24,9 @@
 
 #include "util.h"
 
+GHashTable* wifi_frequency_24;
+GHashTable* wifi_frequency_5;
+
 /**
  * Create the parent directories of given file path. Exit program on failure.
  */

--- a/src/util.h
+++ b/src/util.h
@@ -17,8 +17,8 @@
 
 #pragma once
 
-GHashTable* wifi_frequency_24;
-GHashTable* wifi_frequency_5;
+extern GHashTable* wifi_frequency_24;
+extern GHashTable* wifi_frequency_5;
 
 void safe_mkdir_p_dir(const char* file_path);
 void g_string_free_to_file(GString* s, const char* rootdir, const char* path, const char* suffix);


### PR DESCRIPTION
## Description
GCC-10 defaults to `-fno-common`. Netplan fails to link with GCC 10 due to a repeated non-extern variable declaration in a header used across multiple source files.

https://bugs.debian.org/957603
https://gcc.gnu.org/gcc-10/porting_to.html

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [x] \(Optional\) Closes an open bug in Launchpad: https://bugs.launchpad.net/netplan/+bug/1875412

