### PR TITLE
Fix OVS cleanup and systemd race conditions

### DIFF
--- a/netplan/cli/commands/apply.py
+++ b/netplan/cli/commands/apply.py
@@ -41,7 +41,7 @@ class NetplanApply(utils.NetplanCommand):
                          description='Apply current netplan config to running system',
                          leaf=True)
         self.sriov_only = False
-        self.ovs_only = False
+        self.only_ovs_cleanup = False
 
     def run(self):  # pragma: nocover (covered in autopkgtest)
         self.parser.add_argument('--sriov-only', action='store_true',
@@ -63,7 +63,7 @@ class NetplanApply(utils.NetplanCommand):
             NetplanApply.process_sriov_config(config_manager, exit_on_error)
             return
         # If we only need OpenVSwitch cleanup, do that and exit early.
-        elif self.ovs_only:
+        elif self.only_ovs_cleanup:
             NetplanApply.process_ovs_cleanup(config_manager, False, False, exit_on_error)
             return
 

--- a/netplan/cli/commands/apply.py
+++ b/netplan/cli/commands/apply.py
@@ -214,7 +214,9 @@ class NetplanApply(utils.NetplanCommand):
         if restart_networkd:
             netplan_wpa = [os.path.basename(f) for f in glob.glob('/run/systemd/system/*.wants/netplan-wpa-*.service')]
             netplan_ovs = [os.path.basename(f) for f in glob.glob('/run/systemd/system/*.wants/netplan-ovs-*.service')]
-            utils.systemctl_networkd('start', sync=sync, extra_services=netplan_wpa + netplan_ovs)
+            # Run 'systemctl start' command synchronously, to avoid race conditions
+            # with 'oneshot' systemd service units, e.g. netplan-ovs-*.service.
+            utils.systemctl_networkd('start', sync=True, extra_services=netplan_wpa + netplan_ovs)
         if restart_nm:
             utils.systemctl_network_manager('start', sync=sync)
 

--- a/netplan/cli/ovs.py
+++ b/netplan/cli/ovs.py
@@ -31,8 +31,9 @@ def apply_ovs_cleanup(config_manager, ovs_old, ovs_current):  # pragma: nocover 
     config_manager.parse()
 
     # Tear down old OVS interfacess, not defined in the current config
+    # Use 'del-br' on the Interface table, to delete any netplan created VLAN fake bridges
     if os.path.isfile(OPENVSWITCH_OVS_VSCTL):
-        for t in (('Port', 'del-port'), ('Bridge', 'del-br')):
+        for t in (('Port', 'del-port'), ('Bridge', 'del-br'), ('Interface', 'del-br')):
             out = subprocess.check_output([OPENVSWITCH_OVS_VSCTL, '--columns=name,external-ids',
                                            '-f', 'csv', '-d', 'bare', '--no-headings', 'list', t[0]],
                                           universal_newlines=True)

--- a/src/openvswitch.c
+++ b/src/openvswitch.c
@@ -318,8 +318,8 @@ write_ovs_conf(const NetplanNetDefinition* def, const char* rootdir)
                     g_fprintf(stderr, "%s: OpenVSwitch patch port needs to be assigned to a bridge/bond\n", def->id);
                     exit(1);
                 }
-                append_systemd_cmd(cmds, OPENVSWITCH_OVS_VSCTL " set Interface %s type=patch", def->id);
-                append_systemd_cmd(cmds, OPENVSWITCH_OVS_VSCTL " set Interface %s options:peer=%s", def->id, def->peer);
+                append_systemd_cmd(cmds, OPENVSWITCH_OVS_VSCTL " set Interface %s type=patch -- set Interface %s options:peer=%s",
+                                   def->id, def->id, def->peer);
                 write_ovs_tag_netplan(def->id, type, cmds);
                 break;
 

--- a/src/openvswitch.c
+++ b/src/openvswitch.c
@@ -306,7 +306,8 @@ write_ovs_conf(const NetplanNetDefinition* def, const char* rootdir)
                     write_ovs_bridge_controller_targets(&(def->ovs_settings.controller), def->id, cmds);
                     /* Set controller connection mode, only applicable if at least one controller target address was set */
                     if (def->ovs_settings.controller.connection_mode)
-                        append_systemd_cmd(cmds, OPENVSWITCH_OVS_VSCTL " set controller %s connection-mode=%s", def->id, def->ovs_settings.controller.connection_mode);
+                        append_systemd_cmd(cmds, OPENVSWITCH_OVS_VSCTL " set controller %s connection-mode=%s",
+                                           def->id, def->ovs_settings.controller.connection_mode);
                 }
                 break;
 

--- a/src/openvswitch.c
+++ b/src/openvswitch.c
@@ -328,8 +328,7 @@ write_ovs_conf(const NetplanNetDefinition* def, const char* rootdir)
                 dependency = def->vlan_link->id;
                 /* Create a fake VLAN bridge */
                 append_systemd_cmd(cmds, OPENVSWITCH_OVS_VSCTL " --may-exist add-br %s %s %i", def->id, def->vlan_link->id, def->vlan_id)
-                /* This is an OVS fake VLAN bridge, not a VLAN interface */
-                write_ovs_tag_netplan(def->id, "Interface", cmds);
+                write_ovs_tag_netplan(def->id, type, cmds);
                 break;
 
             default:

--- a/tests/generator/test_ovs.py
+++ b/tests/generator/test_ovs.py
@@ -822,8 +822,7 @@ After=netplan-ovs-br1.service
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/ovs-vsctl set Interface patchx type=patch
-ExecStart=/usr/bin/ovs-vsctl set Interface patchx options:peer=patchy
+ExecStart=/usr/bin/ovs-vsctl set Interface patchx type=patch -- set Interface patchx options:peer=patchy
 ExecStart=/usr/bin/ovs-vsctl set Port patchx external-ids:netplan=true
 '''},
                          'patchy.service': OVS_VIRTUAL % {'iface': 'patchy', 'extra':
@@ -832,8 +831,7 @@ After=netplan-ovs-bond0.service
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/ovs-vsctl set Interface patchy type=patch
-ExecStart=/usr/bin/ovs-vsctl set Interface patchy options:peer=patchx
+ExecStart=/usr/bin/ovs-vsctl set Interface patchy type=patch -- set Interface patchy options:peer=patchx
 ExecStart=/usr/bin/ovs-vsctl set Port patchy external-ids:netplan=true
 '''},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
@@ -884,8 +882,7 @@ After=netplan-ovs-br0.service
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/ovs-vsctl set Interface patch0-1 type=patch
-ExecStart=/usr/bin/ovs-vsctl set Interface patch0-1 options:peer=patch1-0
+ExecStart=/usr/bin/ovs-vsctl set Interface patch0-1 type=patch -- set Interface patch0-1 options:peer=patch1-0
 ExecStart=/usr/bin/ovs-vsctl set Port patch0-1 external-ids:netplan=true
 '''},
                          'patch1-0.service': OVS_VIRTUAL % {'iface': 'patch1-0', 'extra':
@@ -894,8 +891,7 @@ After=netplan-ovs-br1.service
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/ovs-vsctl set Interface patch1-0 type=patch
-ExecStart=/usr/bin/ovs-vsctl set Interface patch1-0 options:peer=patch0-1
+ExecStart=/usr/bin/ovs-vsctl set Interface patch1-0 type=patch -- set Interface patch1-0 options:peer=patch0-1
 ExecStart=/usr/bin/ovs-vsctl set Port patch1-0 external-ids:netplan=true
 '''},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})

--- a/tests/integration/ovs.py
+++ b/tests/integration/ovs.py
@@ -121,6 +121,7 @@ class _CommonTests():
     def test_bridge_base(self):
         self.setup_eth(None, False)
         self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-br', 'ovsbr'])
+        self.addCleanup(subprocess.call, ['ovs-vsctl', 'del-ssl'])
         with open(self.config, 'w') as f:
             f.write('''network:
   ethernets:
@@ -325,6 +326,14 @@ class _CommonTests():
         (out, err) = p.communicate()
         self.assertIn('ovs0: The \'ovs-vsctl\' tool is required to setup OpenVSwitch interfaces.', err)
         self.assertNotEqual(p.returncode, 0)
+
+    @unittest.skip("For debugging only")
+    def test_zzz_ovs_debugging(self):  # Runs as the last test, to collect all logs
+        """Display OVS logs of the previous tests"""
+        out = subprocess.check_output(['cat', '/var/log/openvswitch/ovs-vswitchd.log'], universal_newlines=True)
+        print(out)
+        out = subprocess.check_output(['ovsdb-tool', 'show-log'], universal_newlines=True)
+        print(out)
 
 
 @unittest.skipIf("networkd" not in test_backends,

--- a/tests/integration/ovs.py
+++ b/tests/integration/ovs.py
@@ -29,8 +29,7 @@ from base import IntegrationTestsBase, test_backends
 
 class _CommonTests():
 
-    # FIXME: Why does this test need to run first, in order to pass?
-    def test_1_cleanup_interfaces(self):
+    def test_cleanup_interfaces(self):
         self.setup_eth(None, False)
         self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-br', 'ovs0'])
         self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-br', 'ovs1'])
@@ -38,12 +37,17 @@ class _CommonTests():
         self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-port', 'patch1-0'])
         with open(self.config, 'w') as f:
             f.write('''network:
+  ethernets:
+    # Add a normal interface, to avoid networkd-wait-online.service timeout.
+    # If we have just OVS interfaces/ports networkd/networkctl will not be
+    # aware that our network is ready.
+    %(ec)s: {addresses: [10.10.10.20/24]}
   openvswitch:
     ports:
       - [patch0-1, patch1-0]
   bridges:
     ovs0: {interfaces: [patch0-1]}
-    ovs1: {interfaces: [patch1-0]}''')
+    ovs1: {interfaces: [patch1-0]}''' % {'ec': self.dev_e_client})
         self.generate_and_settle()
         # Basic verification that the bridges/ports/interfaces are there in OVS
         out = subprocess.check_output(['ovs-vsctl', 'show'])


### PR DESCRIPTION
## Description
* Fix `only_ovs_cleanup` argument, to make it execute the correct code.
* Execute the `oneshot` OVS systemd units synchronously, to avoid race conditions during `systemctl start ...`.
* Set OVS patch ports atomically, to avoid logging errors.
* Clean up OVS fake VLAN bridges from the `Interface` table via `del-br`

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Closes an open bug in Launchpad.

