### PR TITLE
First boot OVS/WPA workaround for cloud-init

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,6 +122,7 @@ install: default
 	install -m 644 examples/*.yaml $(DESTDIR)/$(DOCDIR)/netplan/examples/
 	install -m 644 doc/*.5 $(DESTDIR)/$(MANDIR)/man5/
 	install -m 644 doc/*.8 $(DESTDIR)/$(MANDIR)/man8/
+	install -D -m 644 src/netplan.target $(DESTDIR)/$(SYSTEMD_UNIT_DIR)/netplan.target
 	install -T -D -m 644 netplan.completions $(DESTDIR)/$(BASH_COMPLETIONS_DIR)/netplan
 	# dbus
 	mkdir -p $(DESTDIR)/$(DATADIR)/dbus-1/system.d $(DESTDIR)/$(DATADIR)/dbus-1/system-services

--- a/netplan/cli/commands/generate.py
+++ b/netplan/cli/commands/generate.py
@@ -51,11 +51,4 @@ class NetplanGenerate(utils.NetplanCommand):
             argv += ['--mapping', self.mapping]
         logging.debug('command generate: running %s', argv)
         # FIXME: os.execv(argv[0], argv) would be better but fails coverage
-        ret = subprocess.call(argv)
-        # Simulate cloud-init calling 'systemctl start netplan.target' after calling
-        # 'netplan generate' during the sytemd boot transaction (after generator stage)
-        # netplan.target and its dependencies (created by 'netplan generate'), will be
-        # lazy loaded and started.
-        # Requires systemd v246 (https://github.com/systemd/systemd/pull/16371)
-        subprocess.check_call(['systemctl', 'start', 'netplan.target'])
-        sys.exit(ret)
+        sys.exit(subprocess.call(argv))

--- a/netplan/cli/commands/generate.py
+++ b/netplan/cli/commands/generate.py
@@ -51,4 +51,11 @@ class NetplanGenerate(utils.NetplanCommand):
             argv += ['--mapping', self.mapping]
         logging.debug('command generate: running %s', argv)
         # FIXME: os.execv(argv[0], argv) would be better but fails coverage
-        sys.exit(subprocess.call(argv))
+        ret = subprocess.call(argv)
+        # Simulate cloud-init calling 'systemctl start netplan.target' after calling
+        # 'netplan generate' during the sytemd boot transaction (after generator stage)
+        # netplan.target and its dependencies (created by 'netplan generate'), will be
+        # lazy loaded and started.
+        # Requires systemd v246 (https://github.com/systemd/systemd/pull/16371)
+        subprocess.check_call(['systemctl', 'start', 'netplan.target'])
+        sys.exit(ret)

--- a/src/netplan.target
+++ b/src/netplan.target
@@ -1,0 +1,4 @@
+[Unit]
+Description=This target can be lazy loaded by systemd to start all the netplan-*.service units. It depends on systemd v246 (https://github.com/systemd/systemd/pull/16371). Dependencies for all service units are put in place as symlinks during runtime (netplan generate).
+Conflicts=shutdown.target
+

--- a/tests/generator/base.py
+++ b/tests/generator/base.py
@@ -203,6 +203,7 @@ class TestBase(unittest.TestCase):
         self.assertEqual(set(os.listdir(self.workdir.name)) - {'lib'}, {'etc', 'run'})
         ovs_systemd_dir = set(os.listdir(systemd_dir))
         ovs_systemd_dir.remove('systemd-networkd.service.wants')
+        ovs_systemd_dir.remove('netplan.target.wants')
         self.assertEqual(ovs_systemd_dir, {'netplan-ovs-' + f for f in file_contents_map})
         for fname, contents in file_contents_map.items():
             fname = 'netplan-ovs-' + fname

--- a/tests/generator/test_wifis.py
+++ b/tests/generator/test_wifis.py
@@ -136,6 +136,8 @@ network={
             self.workdir.name, 'run/systemd/system/netplan-wpa-wl0.service')))
         self.assertTrue(os.path.islink(os.path.join(
             self.workdir.name, 'run/systemd/system/systemd-networkd.service.wants/netplan-wpa-wl0.service')))
+        self.assertTrue(os.path.islink(os.path.join(
+            self.workdir.name, 'run/systemd/system/netplan.target.wants/netplan-wpa-wl0.service')))
 
     def test_wifi_upgrade(self):
         # pretend an old 'netplan-wpa@*.service' link still exists on an upgraded system
@@ -171,6 +173,8 @@ ExecStart=/sbin/wpa_supplicant -c /run/netplan/wpa-%I.conf -i%I''')
             self.workdir.name, 'run/systemd/system/netplan-wpa-wl0.service')))
         self.assertTrue(os.path.islink(os.path.join(
             self.workdir.name, 'run/systemd/system/systemd-networkd.service.wants/netplan-wpa-wl0.service')))
+        self.assertTrue(os.path.islink(os.path.join(
+            self.workdir.name, 'run/systemd/system/netplan.target.wants/netplan-wpa-wl0.service')))
         # old files/links
         self.assertTrue(os.path.isfile(os.path.join(
             self.workdir.name, 'lib/systemd/system/netplan-wpa@.service')))
@@ -196,6 +200,8 @@ ExecStart=/sbin/wpa_supplicant -c /run/netplan/wpa-%I.conf -i%I''')
             self.workdir.name, 'run/systemd/system/netplan-wpa-wl1.service')))
         self.assertTrue(os.path.islink(os.path.join(
             self.workdir.name, 'run/systemd/system/systemd-networkd.service.wants/netplan-wpa-wl1.service')))
+        self.assertTrue(os.path.islink(os.path.join(
+            self.workdir.name, 'run/systemd/system/netplan.target.wants/netplan-wpa-wl1.service')))
         # old files/links
         self.assertTrue(os.path.isfile(os.path.join(
             self.workdir.name, 'lib/systemd/system/netplan-wpa@.service')))
@@ -207,6 +213,8 @@ ExecStart=/sbin/wpa_supplicant -c /run/netplan/wpa-%I.conf -i%I''')
             self.workdir.name, 'run/systemd/system/netplan-wpa-wl0.service')))
         self.assertFalse(os.path.islink(os.path.join(
             self.workdir.name, 'run/systemd/system/systemd-networkd.service.wants/netplan-wpa-wl0.service')))
+        self.assertFalse(os.path.islink(os.path.join(
+            self.workdir.name, 'run/systemd/system/netplan.target.wants/netplan-wpa-wl0.service')))
 
     def test_wifi_route(self):
         self.generate('''network:
@@ -309,6 +317,8 @@ network={
             self.workdir.name, 'run/systemd/system/netplan-wpa-wl0.service')))
         self.assertTrue(os.path.islink(os.path.join(
             self.workdir.name, 'run/systemd/system/systemd-networkd.service.wants/netplan-wpa-wl0.service')))
+        self.assertTrue(os.path.islink(os.path.join(
+            self.workdir.name, 'run/systemd/system/netplan.target.wants/netplan-wpa-wl0.service')))
 
     def test_wifi_wowlan_default(self):
         self.generate('''network:
@@ -344,6 +354,8 @@ network={
             self.workdir.name, 'run/systemd/system/netplan-wpa-wl0.service')))
         self.assertTrue(os.path.islink(os.path.join(
             self.workdir.name, 'run/systemd/system/systemd-networkd.service.wants/netplan-wpa-wl0.service')))
+        self.assertTrue(os.path.islink(os.path.join(
+            self.workdir.name, 'run/systemd/system/netplan.target.wants/netplan-wpa-wl0.service')))
 
 
 class TestNetworkManager(TestBase):


### PR DESCRIPTION
## Description
[Cloud-init](https://cloud-init.io/) makes use of the netplan generator, but calls `netplan generate` manually at runtime (during the systemd boot transaction), instead of running it as intended at systemd generator stage, due to restrictions it has regarding fetching of its data source (e.g. netplan YAML config).

This leads to problems at first boot, as the systemd unit dependencies are calculated after the generator stage, but ahead of the boot transaction (e.g. via `systemctl daemon-reload`), therefore the new service units and its dependencies, which are generated by manually calling `netplan generate` are ignored during the first-boot transaction. In subsequent boots (where the cloud-init data source, netplan YAML config and unit files are already in place), everything works as expected.

Systemd v246 introduced a new feature, where target units can be lazy-loaded at runtime, if they are known ahead of a transaction (but still unloaded) and changed on disk in the meantime. Therefore, we always place a new `netplan.target` systemd unit in `/lib/systemd/system/netplan.target`, which does almost nothing and isn't loaded by default, but is available at all times on disk. When executing `netplan generate` we create new symlinks/dependencies as `/run/systemd/system/netplan.target.wants/netplan-[ovs|wpa]-*.service`, so that cloud-init (or any other service) can call `systemctl start netplan.target` after having called `netplan generate` to have the target unit **incl.** its new dependencies lazy loaded and started – even during a systemd (boot-) transaction.

We cannot statically link the `netplan.target` e.g. via `/lib/systemd/system/network.target.wants/netplan.target`, as my experiments showed that it would then already be loaded (read from disk) when the initial dependencies are calculated (ahead of the boot transaction) and therefor it does not know about the netplan service units, which are generated at a later stage by cloud-init calling `netplan generate` after it put the YAML config in place.

So in order to get this beast working, we need:
* The changes from this pull request in netplan
* The changes from https://github.com/systemd/systemd/pull/16371 in systemd (backported or v246)
  * https://launchpad.net/~ci-train-ppa-service/+archive/ubuntu/4177
* Changes in cloud-init to call `systemctl start netplan.target` after calling `netplan generate` in [cloudinit/net/netplan.py:243](https://github.com/canonical/cloud-init/blob/3c551f6ebc12f7729a2755c89b19b9000e27cc88/cloudinit/net/netplan.py#L243)

## Reproducer
* clean.sh: https://paste.ubuntu.com/p/zCY6zRjSP8/
* 3 netplan DEBs from https://slyon.de/files/netplan/PR-157/ (build of this PR branch, excl. revert https://github.com/CanonicalLtd/netplan/commit/3ab718fe6796ffb78120161d941ff757e0d79b86)
  * This build contains commit https://github.com/CanonicalLtd/netplan/commit/cd1acbc2d257159df331d3ef0688138c6d7d8533 to simulate cloud-init calling `systemctl start netplan.target`
  * That commit (https://github.com/CanonicalLtd/netplan/commit/cd1acbc2d257159df331d3ef0688138c6d7d8533) is reverted in this PR as it must be part of cloud-init in a real environment
  * It cannot be built on Launchpad/PPA, as this commit crashes the tests
```
lxc profile copy default myovs
lxc profile edit myovs
# Add this config:
config:
  user.network-config: |
    # cloud-config
    version: 2
    bridges:
      ovs0:
        addresses: [10.10.10.20/24]
        interfaces: [eth0.21]
        parameters:
          stp: false
        openvswitch: {}
    ethernets:
      eth0:
        dhcp4: true
        addresses: [10.10.10.30/24]
    vlans:
      eth0.21:
        id: 21
        link: eth0
description: My OVS debugging profile

lxc remote add --protocol simplestreams ubuntu-minimal-daily https://cloud-images.ubuntu.com/minimal/daily/
lxc launch ubuntu-minimal-daily:groovy ovs-init
lxc file push clean.sh *netplan*_0.99-0ubuntu5_amd64.deb ovs-init/root/
lxc exec ovs-init bash
$ apt update
$ apt install software-properties-common
$ add-apt-repository ppa:ci-train-ppa-service/4177 # backported systemd features
$ apt install systemd openvswitch-switch
$ dpkg -i *netplan*_0.99-0ubuntu5_amd64.deb
$ ./clean.sh && poweroff
lxc snapshot ovs-init # prepare snapshot image of the state we prepared

lxc copy ovs-init/snap0 ovs-debug --profile myovs # start new instance with OVS netplan datasource
lxc start ovs-debug
lxc exec ovs-debug bash
$ ip a
$ ovs-vsctl show
$ ovsdb-tool show-log
$ systemctl list-dependencies netplan.target
$ systemctl status netplan-ovs-cleanup.service
$ systemctl status netplan-ovs-ovs0.service
$ cat /etc/netplan/*.yaml
$ netplan apply
$ reboot
$ ./clean && reboot # to simulate a first-boot
```

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [x] \(Optional\) Closes an open bug in Launchpad: [LP#1870346](https://bugs.launchpad.net/ubuntu/+source/cloud-init/+bug/1870346) (partly)