### PR TITLE
Tagging & cleanup of individual OVS settings

### DIFF
--- a/netplan/cli/ovs.py
+++ b/netplan/cli/ovs.py
@@ -20,13 +20,66 @@ import os
 import subprocess
 
 OPENVSWITCH_OVS_VSCTL = '/usr/bin/ovs-vsctl'
+# Defaults for non-optional settings, as defined here:
+# http://www.openvswitch.org//ovs-vswitchd.conf.db.5.pdf
+DEFAULTS = {
+    # Mandatory columns:
+    'mcast_snooping_enable': 'false',
+    'rstp_enable': 'false',
+}
+GLOBALS = {
+    # Global commands:
+    'set-fail-mode': 'del-fail-mode',
+    'set-ssl': 'del-ssl',
+}
 
+
+def del_col(type, iface, column, value):
+    """Cleanup values from a column (i.e. "column=value")"""
+    default = DEFAULTS.get(column)
+    if default is None:
+        # removes the exact value only if it was set by netplan
+        subprocess.check_call([OPENVSWITCH_OVS_VSCTL, 'remove', type, iface, column, value])
+    elif default and default != value:
+        # reset to default, if its not the default already
+        subprocess.check_call([OPENVSWITCH_OVS_VSCTL, 'set', type, iface, '%s=%s' % (column, default)])
+
+def del_dict(type, iface, column, key, value):
+    """Cleanup values from a dictionary (i.e. "column:key=value")"""
+    # removes the exact value only if it was set by netplan
+    subprocess.check_call([OPENVSWITCH_OVS_VSCTL, 'remove', type, iface, column, key, value])
+
+def del_global(type, iface, key, value):
+    """Cleanup commands from the global namespace"""
+    cmd = GLOBALS.get(key)
+    # TODO: do noting if values are the same
+    if cmd == 'del-ssl':
+        subprocess.check_call([OPENVSWITCH_OVS_VSCTL, cmd])
+    elif cmd == 'del-fail-mode':
+        subprocess.check_call([OPENVSWITCH_OVS_VSCTL, cmd, iface])
+    else:
+        raise Exception('Reset command unkown for:', key)
+
+def clear_setting(type, iface, setting, value):
+    """Check if this setting is in a dict or a colum and delete accordingly"""
+    split = setting.split('/', 2)
+    col = split[1]
+    if col == 'global' and len(split) > 2:
+        del_global(type, iface, split[2], value)
+    elif len(split) > 2:
+        del_dict(type, iface, split[1], split[2], value)
+    else:
+        del_col(type, iface, split[1], value)
+    #Cleanup the tag itself (i.e. "netplan/column[/key]")
+    subprocess.check_call([OPENVSWITCH_OVS_VSCTL, 'remove', type, iface, 'external-ids', setting])
 
 def apply_ovs_cleanup(config_manager, ovs_old, ovs_current):  # pragma: nocover (covered in autopkgtest)
     """
     Query OpenVSwitch state through 'ovs-vsctl' and filter for netplan=true
     tagged ports/bonds and bridges. Delete interfaces which are not defined
     in the current configuration.
+    Also filter for individual settings tagged netplan/<column>[/<key]=value
+    in external-ids and clear them if they have been set by netplan.
     """
     config_manager.parse()
     ovs_ifaces = []
@@ -41,6 +94,7 @@ def apply_ovs_cleanup(config_manager, ovs_old, ovs_current):  # pragma: nocover 
     # Tear down old OVS interfaces, not defined in the current config.
     # Use 'del-br' on the Interface table, to delete any netplan created VLAN fake bridges.
     if os.path.isfile(OPENVSWITCH_OVS_VSCTL):
+        # Step 1: Delete all interfaces, which are not part of the current OVS config
         for t in (('Port', 'del-port'), ('Bridge', 'del-br'), ('Interface', 'del-br')):
             out = subprocess.check_output([OPENVSWITCH_OVS_VSCTL, '--columns=name,external-ids',
                                            '-f', 'csv', '-d', 'bare', '--no-headings', 'list', t[0]],
@@ -52,6 +106,26 @@ def apply_ovs_cleanup(config_manager, ovs_old, ovs_current):  # pragma: nocover 
                     if iface in ovs_ifaces:
                         continue
                     subprocess.check_call([OPENVSWITCH_OVS_VSCTL, '--if-exists', t[1], iface])
+
+        # Step 2: Clean up the settings of the remaining interfaces
+        for t in ('Port', 'Bridge', 'Interface', 'open_vswitch'):  # TODO: , 'Controller'):
+            cols = 'external-ids' if t == 'open_vswitch' else 'name,external-ids'
+            out = subprocess.check_output([OPENVSWITCH_OVS_VSCTL, '--columns=%s' % cols,
+                                           '-f', 'csv', '-d', 'bare', '--no-headings', 'list', t],
+                                          universal_newlines=True)
+            for line in out.splitlines():
+                if 'netplan/' in line:
+                    iface = '.'
+                    extids = line
+                    if t != 'open_vswitch':
+                        iface, extids = line.split(',', 1)
+
+                    # TODO: Make sure our values do not contain (white-)spaces!
+                    for entry in extids.strip('"').split(' '):
+                        if entry.startswith('netplan/') and '=' in entry:
+                            setting, val = entry.split('=', 1)
+                            clear_setting(t, iface, setting, val)
+
     # Show the warning only if we are or have been working with OVS definitions
     elif ovs_old or ovs_current:
         logging.warning('ovs-vsctl is missing, cannot tear down old OpenVSwitch interfaces')

--- a/netplan/cli/ovs.py
+++ b/netplan/cli/ovs.py
@@ -44,10 +44,12 @@ def del_col(type, iface, column, value):
         # reset to default, if its not the default already
         subprocess.check_call([OPENVSWITCH_OVS_VSCTL, 'set', type, iface, '%s=%s' % (column, default)])
 
+
 def del_dict(type, iface, column, key, value):
     """Cleanup values from a dictionary (i.e. "column:key=value")"""
     # removes the exact value only if it was set by netplan
     subprocess.check_call([OPENVSWITCH_OVS_VSCTL, 'remove', type, iface, column, key, value])
+
 
 def del_global(type, iface, key, value):
     """Cleanup commands from the global namespace"""
@@ -60,6 +62,7 @@ def del_global(type, iface, key, value):
     else:
         raise Exception('Reset command unkown for:', key)
 
+
 def clear_setting(type, iface, setting, value):
     """Check if this setting is in a dict or a colum and delete accordingly"""
     split = setting.split('/', 2)
@@ -70,8 +73,9 @@ def clear_setting(type, iface, setting, value):
         del_dict(type, iface, split[1], split[2], value)
     else:
         del_col(type, iface, split[1], value)
-    #Cleanup the tag itself (i.e. "netplan/column[/key]")
+    # Cleanup the tag itself (i.e. "netplan/column[/key]")
     subprocess.check_call([OPENVSWITCH_OVS_VSCTL, 'remove', type, iface, 'external-ids', setting])
+
 
 def apply_ovs_cleanup(config_manager, ovs_old, ovs_current):  # pragma: nocover (covered in autopkgtest)
     """

--- a/netplan/cli/ovs.py
+++ b/netplan/cli/ovs.py
@@ -59,15 +59,17 @@ def _del_global(type, iface, key, value):
         iface = None
 
     if del_cmd:
-        out = subprocess.check_output([OPENVSWITCH_OVS_VSCTL, get_cmd], universal_newlines=True)
-        is_same = all(item in out for item in value.split(' '))
+        args_get = [OPENVSWITCH_OVS_VSCTL, get_cmd]
+        args_del = [OPENVSWITCH_OVS_VSCTL, del_cmd]
+        if iface:
+            args_get.append(iface)
+            args_del.append(iface)
+        out = subprocess.check_output(args_get, universal_newlines=True)
+        is_same = all(item in out for item in value.split(','))
         # Clean it only if the exact same value(s) were set by netplan.
         # Don't touch it if other values were set by another integration.
         if is_same:
-            args = [OPENVSWITCH_OVS_VSCTL, del_cmd]
-            if iface:
-                args.append(iface)
-            subprocess.check_call(args)
+            subprocess.check_call(args_del)
     else:
         raise Exception('Reset command unkown for:', key)
 

--- a/src/openvswitch.c
+++ b/src/openvswitch.c
@@ -372,9 +372,9 @@ write_ovs_conf(const NetplanNetDefinition* def, const char* rootdir)
                     g_fprintf(stderr, "%s: OpenVSwitch patch port needs to be assigned to a bridge/bond\n", def->id);
                     exit(1);
                 }
-                /* There is not OVS Port which we could tag netplan=true if
-                 * this patch port is assigned as an OVS bond interface.
-                 * Tag the Interface instead, to clean it up from a bond. */
+                /* There is no OVS Port which we could tag netplan=true if this
+                 * patch port is assigned as an OVS bond interface. Tag the
+                 * Interface instead, to clean it up from a bond. */
                 if (def->bond)
                     write_ovs_tag_netplan(def->id, "Interface", cmds);
                 else

--- a/src/openvswitch.c
+++ b/src/openvswitch.c
@@ -38,7 +38,7 @@ write_ovs_systemd_unit(const char* id, const GString* cmds, const char* rootdir,
     g_string_append_printf(s, "Description=OpenVSwitch configuration for %s\n", id);
     g_string_append(s, "DefaultDependencies=no\n");
     /* run any ovs-netplan unit only after openvswitch-switch.service is ready */
-    g_string_append_printf(s, "Requires=openvswitch-switch.service\n");
+    g_string_append_printf(s, "Wants=openvswitch-switch.service\n");
     g_string_append_printf(s, "After=openvswitch-switch.service\n");
     if (physical) {
         id_escaped = systemd_escape((char*) id);

--- a/src/openvswitch.c
+++ b/src/openvswitch.c
@@ -451,7 +451,7 @@ write_ovs_conf_finish(const char* rootdir)
                            ovs_settings_global.ssl.client_certificate,
                            ovs_settings_global.ssl.ca_certificate);
         GString* value = g_string_new(NULL);
-        g_string_printf(value, "%s,%s,%s",
+        g_string_printf(value, "%s %s %s",
                         ovs_settings_global.ssl.client_key,
                         ovs_settings_global.ssl.client_certificate,
                         ovs_settings_global.ssl.ca_certificate);

--- a/src/openvswitch.c
+++ b/src/openvswitch.c
@@ -371,9 +371,11 @@ write_ovs_conf(const NetplanNetDefinition* def, const char* rootdir)
                     exit(1);
                 }
                 /* There is not OVS Port which we could tag netplan=true if
-                 * this patch port is assigned as an OVS bond interface. */
-                /* TODO: How can we tag/handle/clean those bond interfaces? */
-                if (!def->bond)
+                 * this patch port is assigned as an OVS bond interface.
+                 * Tag the Interface instead, to clean it up from a bond. */
+                if (def->bond)
+                    write_ovs_tag_netplan(def->id, "Interface", cmds);
+                else
                     write_ovs_tag_netplan(def->id, type, cmds);
                 break;
 

--- a/src/parse.c
+++ b/src/parse.c
@@ -910,7 +910,8 @@ handle_addresses(yaml_document_t* doc, yaml_node_t* node, const void* _, GError*
         char* prefix_len;
         guint64 prefix_len_num;
         yaml_node_t *entry = yaml_document_get_node(doc, *i);
-        yaml_node_t *key, *value = NULL;
+        yaml_node_t *key = NULL;
+        yaml_node_t *value = NULL;
 
         if (entry->type != YAML_SCALAR_NODE && entry->type != YAML_MAPPING_NODE) {
             return yaml_error(entry, error, "expected either scalar or mapping (check indentation)");

--- a/src/util.h
+++ b/src/util.h
@@ -30,4 +30,3 @@ int wifi_get_freq5(int channel);
 gchar* systemd_escape(char* string);
 
 #define OPENVSWITCH_OVS_VSCTL "/usr/bin/ovs-vsctl"
-#define OPENVSWITCH_OVS_OFCTL "/usr/bin/ovs-ofctl"

--- a/tests/generator/base.py
+++ b/tests/generator/base.py
@@ -51,10 +51,14 @@ Requires=openvswitch-switch.service\nAfter=openvswitch-switch.service\n'
 OVS_PHYSICAL = _OVS_BASE + 'Requires=sys-subsystem-net-devices-%(iface)s.device\nAfter=sys-subsystem-net-devices-%(iface)s\
 .device\nAfter=netplan-ovs-cleanup.service\nBefore=network.target\nWants=network.target\n%(extra)s'
 OVS_VIRTUAL = _OVS_BASE + 'After=netplan-ovs-cleanup.service\nBefore=network.target\nWants=network.target\n%(extra)s'
+OVS_BR_DEFAULT = 'ExecStart=/usr/bin/ovs-vsctl set Bridge %(iface)s external-ids:netplan=true\nExecStart=/usr/bin/ovs-vsctl set \
+Bridge %(iface)s external-ids:netplan/external-ids/netplan=true\nExecStart=/usr/bin/ovs-vsctl set-fail-mode %(iface)s standalone\
+\nExecStart=/usr/bin/ovs-vsctl set Bridge %(iface)s external-ids:netplan/global/set-fail-mode=standalone\nExecStart=\
+/usr/bin/ovs-vsctl set Bridge %(iface)s mcast_snooping_enable=false\nExecStart=/usr/bin/ovs-vsctl set Bridge %(iface)s \
+external-ids:netplan/mcast_snooping_enable=false\nExecStart=/usr/bin/ovs-vsctl set Bridge %(iface)s rstp_enable=false\n\
+ExecStart=/usr/bin/ovs-vsctl set Bridge %(iface)s external-ids:netplan/rstp_enable=false\n'
 OVS_BR_EMPTY = _OVS_BASE + 'After=netplan-ovs-cleanup.service\nBefore=network.target\nWants=network.target\n\n[Service]\n\
-Type=oneshot\nExecStart=/usr/bin/ovs-vsctl --may-exist add-br %(iface)s\nExecStart=/usr/bin/ovs-vsctl set Bridge %(iface)s \
-external-ids:netplan=true\nExecStart=/usr/bin/ovs-vsctl set-fail-mode %(iface)s standalone\nExecStart=/usr/bin/ovs-vsctl set \
-Bridge %(iface)s mcast_snooping_enable=false\nExecStart=/usr/bin/ovs-vsctl set Bridge %(iface)s rstp_enable=false\n'
+Type=oneshot\nExecStart=/usr/bin/ovs-vsctl --may-exist add-br %(iface)s\n' + OVS_BR_DEFAULT
 OVS_CLEANUP = _OVS_BASE + 'ConditionFileIsExecutable=/usr/bin/ovs-vsctl\nBefore=network.target\nWants=network.target\n\n\
 [Service]\nType=oneshot\nExecStart=/usr/sbin/netplan apply --only-ovs-cleanup\n'
 UDEV_MAC_RULE = 'SUBSYSTEM=="net", ACTION=="add", DRIVERS=="%s", ATTR{address}=="%s", NAME="%s"\n'

--- a/tests/generator/base.py
+++ b/tests/generator/base.py
@@ -51,12 +51,11 @@ Requires=openvswitch-switch.service\nAfter=openvswitch-switch.service\n'
 OVS_PHYSICAL = _OVS_BASE + 'Requires=sys-subsystem-net-devices-%(iface)s.device\nAfter=sys-subsystem-net-devices-%(iface)s\
 .device\nAfter=netplan-ovs-cleanup.service\nBefore=network.target\nWants=network.target\n%(extra)s'
 OVS_VIRTUAL = _OVS_BASE + 'After=netplan-ovs-cleanup.service\nBefore=network.target\nWants=network.target\n%(extra)s'
-OVS_BR_DEFAULT = 'ExecStart=/usr/bin/ovs-vsctl set Bridge %(iface)s external-ids:netplan=true\nExecStart=/usr/bin/ovs-vsctl set \
-Bridge %(iface)s external-ids:netplan/external-ids/netplan=true\nExecStart=/usr/bin/ovs-vsctl set-fail-mode %(iface)s standalone\
-\nExecStart=/usr/bin/ovs-vsctl set Bridge %(iface)s external-ids:netplan/global/set-fail-mode=standalone\nExecStart=\
-/usr/bin/ovs-vsctl set Bridge %(iface)s mcast_snooping_enable=false\nExecStart=/usr/bin/ovs-vsctl set Bridge %(iface)s \
-external-ids:netplan/mcast_snooping_enable=false\nExecStart=/usr/bin/ovs-vsctl set Bridge %(iface)s rstp_enable=false\n\
-ExecStart=/usr/bin/ovs-vsctl set Bridge %(iface)s external-ids:netplan/rstp_enable=false\n'
+OVS_BR_DEFAULT = 'ExecStart=/usr/bin/ovs-vsctl set Bridge %(iface)s external-ids:netplan=true\nExecStart=/usr/bin/ovs-vsctl \
+set-fail-mode %(iface)s standalone\nExecStart=/usr/bin/ovs-vsctl set Bridge %(iface)s external-ids:netplan/global/set-fail-mode=\
+standalone\nExecStart=/usr/bin/ovs-vsctl set Bridge %(iface)s mcast_snooping_enable=false\nExecStart=/usr/bin/ovs-vsctl set \
+Bridge %(iface)s external-ids:netplan/mcast_snooping_enable=false\nExecStart=/usr/bin/ovs-vsctl set Bridge %(iface)s \
+rstp_enable=false\nExecStart=/usr/bin/ovs-vsctl set Bridge %(iface)s external-ids:netplan/rstp_enable=false\n'
 OVS_BR_EMPTY = _OVS_BASE + 'After=netplan-ovs-cleanup.service\nBefore=network.target\nWants=network.target\n\n[Service]\n\
 Type=oneshot\nExecStart=/usr/bin/ovs-vsctl --may-exist add-br %(iface)s\n' + OVS_BR_DEFAULT
 OVS_CLEANUP = _OVS_BASE + 'ConditionFileIsExecutable=/usr/bin/ovs-vsctl\nBefore=network.target\nWants=network.target\n\n\

--- a/tests/generator/test_ovs.py
+++ b/tests/generator/test_ovs.py
@@ -17,7 +17,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from .base import TestBase, ND_EMPTY, ND_WITHIP, ND_DHCP4, ND_DHCP6, OVS_PHYSICAL, OVS_VIRTUAL, OVS_BR_EMPTY, OVS_CLEANUP
+from .base import TestBase, ND_EMPTY, ND_WITHIP, ND_DHCP4, ND_DHCP6, \
+                            OVS_PHYSICAL, OVS_VIRTUAL, \
+                            OVS_BR_EMPTY, OVS_BR_DEFAULT, \
+                            OVS_CLEANUP
 
 
 class TestOpenVSwitch(TestBase):
@@ -44,12 +47,15 @@ class TestOpenVSwitch(TestBase):
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl set Interface eth0 external-ids:iface-id=myhostname
+ExecStart=/usr/bin/ovs-vsctl set Interface eth0 external-ids:netplan/external-ids/iface-id=myhostname
 ExecStart=/usr/bin/ovs-vsctl set Interface eth0 other-config:disable-in-band=true
+ExecStart=/usr/bin/ovs-vsctl set Interface eth0 external-ids:netplan/other-config/disable-in-band=true
 '''},
                          'eth1.service': OVS_PHYSICAL % {'iface': 'eth1', 'extra': '''
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl set Interface eth1 other-config:disable-in-band=false
+ExecStart=/usr/bin/ovs-vsctl set Interface eth1 external-ids:netplan/other-config/disable-in-band=false
 '''},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane
@@ -72,7 +78,9 @@ ExecStart=/usr/bin/ovs-vsctl set Interface eth1 other-config:disable-in-band=fal
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:iface-id=myhostname
+ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:netplan/external-ids/iface-id=myhostname
 ExecStart=/usr/bin/ovs-vsctl set open_vswitch . other-config:disable-in-band=true
+ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:netplan/other-config/disable-in-band=true
 '''},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane
@@ -145,8 +153,11 @@ After=netplan-ovs-br0.service
 Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-bond br0 bond0 eth1 eth2
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan/external-ids/netplan=true
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=off
+ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan/lacp=off
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:iface-id=myhostname
+ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan/external-ids/iface-id=myhostname
 '''},
                          'br0.service': OVS_BR_EMPTY % {'iface': 'br0'},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
@@ -211,7 +222,9 @@ After=netplan-ovs-br0.service
 Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-bond br0 bond0 eth1 eth2
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan/external-ids/netplan=true
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=active
+ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan/lacp=active
 '''},
                          'br0.service': OVS_BR_EMPTY % {'iface': 'br0'},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
@@ -275,8 +288,11 @@ After=netplan-ovs-br0.service
 Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-bond br0 bond0 eth1 eth2
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan/external-ids/netplan=true
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=off
+ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan/lacp=off
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 bond_mode=balance-tcp
+ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan/bond_mode=balance-tcp
 '''},
                          'br0.service': OVS_BR_EMPTY % {'iface': 'br0'},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
@@ -312,8 +328,11 @@ After=netplan-ovs-br0.service
 Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-bond br0 bond0 eth1 eth2
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan/external-ids/netplan=true
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=off
+ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan/lacp=off
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 bond_mode=active-backup
+ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan/bond_mode=active-backup
 '''},
                          'br0.service': OVS_BR_EMPTY % {'iface': 'br0'},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
@@ -362,11 +381,7 @@ Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-port br0 eth1
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-port br0 eth2
-ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan=true
-ExecStart=/usr/bin/ovs-vsctl set-fail-mode br0 standalone
-ExecStart=/usr/bin/ovs-vsctl set Bridge br0 mcast_snooping_enable=false
-ExecStart=/usr/bin/ovs-vsctl set Bridge br0 rstp_enable=false
-'''},
+''' + OVS_BR_DEFAULT % {'iface': 'br0'}},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({'eth1.network': '[Match]\nName=eth1\n\n[Network]\nLinkLocalAddressing=no\nBridge=br0\n',
@@ -388,12 +403,11 @@ ExecStart=/usr/bin/ovs-vsctl set Bridge br0 rstp_enable=false
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
-ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan=true
-ExecStart=/usr/bin/ovs-vsctl set-fail-mode br0 standalone
-ExecStart=/usr/bin/ovs-vsctl set Bridge br0 mcast_snooping_enable=false
-ExecStart=/usr/bin/ovs-vsctl set Bridge br0 rstp_enable=false
+''' + OVS_BR_DEFAULT % {'iface': 'br0'} + '''\
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:iface-id=myhostname
+ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan/external-ids/iface-id=myhostname
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 other-config:disable-in-band=true
+ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan/other-config/disable-in-band=true
 '''},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the bridge has been only configured for OVS
@@ -422,9 +436,13 @@ ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-port br0 eth1
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-port br0 eth2
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan/external-ids/netplan=true
 ExecStart=/usr/bin/ovs-vsctl set-fail-mode br0 secure
+ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan/global/set-fail-mode=secure
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 mcast_snooping_enable=true
+ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan/mcast_snooping_enable=true
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 rstp_enable=true
+ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan/rstp_enable=true
 '''},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane
@@ -475,11 +493,9 @@ ExecStart=/usr/bin/ovs-vsctl set Bridge br0 rstp_enable=true
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
-ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan=true
-ExecStart=/usr/bin/ovs-vsctl set-fail-mode br0 standalone
-ExecStart=/usr/bin/ovs-vsctl set Bridge br0 mcast_snooping_enable=false
-ExecStart=/usr/bin/ovs-vsctl set Bridge br0 rstp_enable=false
+''' + OVS_BR_DEFAULT % {'iface': 'br0'} + '''\
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 protocols=OpenFlow10,OpenFlow11,OpenFlow15
+ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan/protocols=OpenFlow10,OpenFlow11,OpenFlow15
 '''},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane
@@ -526,18 +542,20 @@ ExecStart=/usr/bin/ovs-vsctl set Bridge br0 protocols=OpenFlow10,OpenFlow11,Open
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
-ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan=true
-ExecStart=/usr/bin/ovs-vsctl set-fail-mode br0 standalone
-ExecStart=/usr/bin/ovs-vsctl set Bridge br0 mcast_snooping_enable=false
-ExecStart=/usr/bin/ovs-vsctl set Bridge br0 rstp_enable=false
+''' + OVS_BR_DEFAULT % {'iface': 'br0'} + '''\
 ExecStart=/usr/bin/ovs-vsctl set-controller br0 ptcp: ptcp:1337 ptcp:1337:[fe80::1234%eth0] pssl:1337:[fe80::1] ssl:10.10.10.1 \
 tcp:127.0.0.1:1337 tcp:[fe80::1234%eth0] tcp:[fe80::1]:1337 unix:/some/path punix:other/path
-ExecStart=/usr/bin/ovs-vsctl set controller br0 connection-mode=out-of-band
+ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan/global/set-controller=ptcp: ptcp:1337 \
+ptcp:1337:[fe80::1234%eth0] pssl:1337:[fe80::1] ssl:10.10.10.1 tcp:127.0.0.1:1337 tcp:[fe80::1234%eth0] tcp:[fe80::1]:1337 \
+unix:/some/path punix:other/path
+ExecStart=/usr/bin/ovs-vsctl set Controller br0 connection-mode=out-of-band
+ExecStart=/usr/bin/ovs-vsctl set Controller br0 external-ids:netplan/connection-mode=out-of-band
 '''},
                          'global.service': OVS_VIRTUAL % {'iface': 'global', 'extra': '''
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl set-ssl /key/path /some/path /another/path
+ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:netplan/global/set-ssl=/key/path;/some/path;/another/path
 '''},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane
@@ -634,6 +652,7 @@ ExecStart=/usr/bin/ovs-vsctl set-ssl /key/path /some/path /another/path
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl set-ssl /key/path /some/path /another/path
+ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:netplan/global/set-ssl=/key/path;/some/path;/another/path
 '''},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane
@@ -729,15 +748,7 @@ ExecStart=/usr/bin/ovs-vsctl set-ssl /key/path /some/path /another/path
       addresses: [192.170.1.1/24]
       interfaces: [bond0]
 ''')
-        self.assert_ovs({'br0.service': OVS_VIRTUAL % {'iface': 'br0', 'extra': '''
-[Service]
-Type=oneshot
-ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
-ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan=true
-ExecStart=/usr/bin/ovs-vsctl set-fail-mode br0 standalone
-ExecStart=/usr/bin/ovs-vsctl set Bridge br0 mcast_snooping_enable=false
-ExecStart=/usr/bin/ovs-vsctl set Bridge br0 rstp_enable=false
-'''},
+        self.assert_ovs({'br0.service': OVS_BR_EMPTY % {'iface': 'br0'},
                          'bond0.service': OVS_VIRTUAL % {'iface': 'bond0', 'extra':
                                                          '''Requires=netplan-ovs-br0.service
 After=netplan-ovs-br0.service
@@ -746,7 +757,9 @@ After=netplan-ovs-br0.service
 Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-bond br0 bond0 eth1 eth2
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan/external-ids/netplan=true
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=off
+ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan/lacp=off
 '''},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         self.assert_networkd({'br0.network': ND_WITHIP % ('br0', '192.170.1.1/24'),
@@ -787,25 +800,13 @@ Bond=bond0
     ports:
       - [patchx, patchy]
 ''')
-        self.assert_ovs({'br0.service': OVS_VIRTUAL % {'iface': 'br0', 'extra': '''
-[Service]
-Type=oneshot
-ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
-ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan=true
-ExecStart=/usr/bin/ovs-vsctl set-fail-mode br0 standalone
-ExecStart=/usr/bin/ovs-vsctl set Bridge br0 mcast_snooping_enable=false
-ExecStart=/usr/bin/ovs-vsctl set Bridge br0 rstp_enable=false
-'''},
+        self.assert_ovs({'br0.service': OVS_BR_EMPTY % {'iface': 'br0'},
                          'br1.service': OVS_VIRTUAL % {'iface': 'br1', 'extra': '''
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br1
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-port br1 patchx
-ExecStart=/usr/bin/ovs-vsctl set Bridge br1 external-ids:netplan=true
-ExecStart=/usr/bin/ovs-vsctl set-fail-mode br1 standalone
-ExecStart=/usr/bin/ovs-vsctl set Bridge br1 mcast_snooping_enable=false
-ExecStart=/usr/bin/ovs-vsctl set Bridge br1 rstp_enable=false
-'''},
+''' + OVS_BR_DEFAULT % {'iface': 'br1'}},
                          'bond0.service': OVS_VIRTUAL % {'iface': 'bond0', 'extra':
                                                          '''Requires=netplan-ovs-br0.service
 After=netplan-ovs-br0.service
@@ -814,7 +815,9 @@ After=netplan-ovs-br0.service
 Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-bond br0 bond0 patchy eth0
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan/external-ids/netplan=true
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=off
+ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan/lacp=off
 '''},
                          'patchx.service': OVS_VIRTUAL % {'iface': 'patchx', 'extra':
                                                           '''Requires=netplan-ovs-br1.service
@@ -824,6 +827,9 @@ After=netplan-ovs-br1.service
 Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl set Interface patchx type=patch -- set Interface patchx options:peer=patchy
 ExecStart=/usr/bin/ovs-vsctl set Port patchx external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Port patchx external-ids:netplan/external-ids/netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Interface patchx external-ids:netplan/type=patch
+ExecStart=/usr/bin/ovs-vsctl set Interface patchx external-ids:netplan/options/peer=patchy
 '''},
                          'patchy.service': OVS_VIRTUAL % {'iface': 'patchy', 'extra':
                                                           '''Requires=netplan-ovs-bond0.service
@@ -833,6 +839,9 @@ After=netplan-ovs-bond0.service
 Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl set Interface patchy type=patch -- set Interface patchy options:peer=patchx
 ExecStart=/usr/bin/ovs-vsctl set Port patchy external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Port patchy external-ids:netplan/external-ids/netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Interface patchy external-ids:netplan/type=patch
+ExecStart=/usr/bin/ovs-vsctl set Interface patchy external-ids:netplan/options/peer=patchx
 '''},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         self.assert_networkd({'br0.network': ND_WITHIP % ('br0', '192.170.1.1/24'),
@@ -861,21 +870,13 @@ ExecStart=/usr/bin/ovs-vsctl set Port patchy external-ids:netplan=true
 Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-port br0 patch0-1
-ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan=true
-ExecStart=/usr/bin/ovs-vsctl set-fail-mode br0 standalone
-ExecStart=/usr/bin/ovs-vsctl set Bridge br0 mcast_snooping_enable=false
-ExecStart=/usr/bin/ovs-vsctl set Bridge br0 rstp_enable=false
-'''},
+''' + OVS_BR_DEFAULT % {'iface': 'br0'}},
                          'br1.service': OVS_VIRTUAL % {'iface': 'br1', 'extra': '''
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br1
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-port br1 patch1-0
-ExecStart=/usr/bin/ovs-vsctl set Bridge br1 external-ids:netplan=true
-ExecStart=/usr/bin/ovs-vsctl set-fail-mode br1 standalone
-ExecStart=/usr/bin/ovs-vsctl set Bridge br1 mcast_snooping_enable=false
-ExecStart=/usr/bin/ovs-vsctl set Bridge br1 rstp_enable=false
-'''},
+''' + OVS_BR_DEFAULT % {'iface': 'br1'}},
                          'patch0-1.service': OVS_VIRTUAL % {'iface': 'patch0-1', 'extra':
                                                             '''Requires=netplan-ovs-br0.service
 After=netplan-ovs-br0.service
@@ -884,6 +885,9 @@ After=netplan-ovs-br0.service
 Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl set Interface patch0-1 type=patch -- set Interface patch0-1 options:peer=patch1-0
 ExecStart=/usr/bin/ovs-vsctl set Port patch0-1 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Port patch0-1 external-ids:netplan/external-ids/netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Interface patch0-1 external-ids:netplan/type=patch
+ExecStart=/usr/bin/ovs-vsctl set Interface patch0-1 external-ids:netplan/options/peer=patch1-0
 '''},
                          'patch1-0.service': OVS_VIRTUAL % {'iface': 'patch1-0', 'extra':
                                                             '''Requires=netplan-ovs-br1.service
@@ -893,6 +897,9 @@ After=netplan-ovs-br1.service
 Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl set Interface patch1-0 type=patch -- set Interface patch1-0 options:peer=patch0-1
 ExecStart=/usr/bin/ovs-vsctl set Port patch1-0 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Port patch1-0 external-ids:netplan/external-ids/netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Interface patch1-0 external-ids:netplan/type=patch
+ExecStart=/usr/bin/ovs-vsctl set Interface patch1-0 external-ids:netplan/options/peer=patch0-1
 '''},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         self.assert_networkd({'br0.network': ND_WITHIP % ('br0', '192.168.1.1/24'),
@@ -917,11 +924,7 @@ ExecStart=/usr/bin/ovs-vsctl set Port patch1-0 external-ids:netplan=true
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
-ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan=true
-ExecStart=/usr/bin/ovs-vsctl set-fail-mode br0 standalone
-ExecStart=/usr/bin/ovs-vsctl set Bridge br0 mcast_snooping_enable=false
-ExecStart=/usr/bin/ovs-vsctl set Bridge br0 rstp_enable=false
-'''},
+''' + OVS_BR_DEFAULT % {'iface': 'br0'}},
                          'br0.100.service': OVS_VIRTUAL % {'iface': 'br0.100', 'extra':
                                                            '''Requires=netplan-ovs-br0.service
 After=netplan-ovs-br0.service
@@ -930,6 +933,7 @@ After=netplan-ovs-br0.service
 Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0.100 br0 100
 ExecStart=/usr/bin/ovs-vsctl set Interface br0.100 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Interface br0.100 external-ids:netplan/external-ids/netplan=true
 '''},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane
@@ -950,15 +954,7 @@ ExecStart=/usr/bin/ovs-vsctl set Interface br0.100 external-ids:netplan=true
       id: 100
       link: br0
 ''')
-        self.assert_ovs({'br0.service': OVS_VIRTUAL % {'iface': 'br0', 'extra': '''
-[Service]
-Type=oneshot
-ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
-ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan=true
-ExecStart=/usr/bin/ovs-vsctl set-fail-mode br0 standalone
-ExecStart=/usr/bin/ovs-vsctl set Bridge br0 mcast_snooping_enable=false
-ExecStart=/usr/bin/ovs-vsctl set Bridge br0 rstp_enable=false
-'''},
+        self.assert_ovs({'br0.service': OVS_BR_EMPTY % {'iface': 'br0'},
                          'br0.100.service': OVS_VIRTUAL % {'iface': 'br0.100', 'extra':
                                                            '''Requires=netplan-ovs-br0.service
 After=netplan-ovs-br0.service
@@ -967,6 +963,7 @@ After=netplan-ovs-br0.service
 Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0.100 br0 100
 ExecStart=/usr/bin/ovs-vsctl set Interface br0.100 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Interface br0.100 external-ids:netplan/external-ids/netplan=true
 '''},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane
@@ -1003,11 +1000,7 @@ ExecStart=/usr/bin/ovs-vsctl set Interface br0.100 external-ids:netplan=true
 Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br ovs-br
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-port ovs-br non-ovs-bond
-ExecStart=/usr/bin/ovs-vsctl set Bridge ovs-br external-ids:netplan=true
-ExecStart=/usr/bin/ovs-vsctl set-fail-mode ovs-br standalone
-ExecStart=/usr/bin/ovs-vsctl set Bridge ovs-br mcast_snooping_enable=false
-ExecStart=/usr/bin/ovs-vsctl set Bridge ovs-br rstp_enable=false
-'''},
+''' + OVS_BR_DEFAULT % {'iface': 'ovs-br'}},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane
         self.assert_networkd({'non-ovs-bond.network': ND_EMPTY % ('non-ovs-bond', 'no') + 'Bridge=ovs-br\n',

--- a/tests/generator/test_ovs.py
+++ b/tests/generator/test_ovs.py
@@ -574,9 +574,9 @@ ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
 ''' + OVS_BR_DEFAULT % {'iface': 'br0'} + '''\
 ExecStart=/usr/bin/ovs-vsctl set-controller br0 ptcp: ptcp:1337 ptcp:1337:[fe80::1234%eth0] pssl:1337:[fe80::1] ssl:10.10.10.1 \
 tcp:127.0.0.1:1337 tcp:[fe80::1234%eth0] tcp:[fe80::1]:1337 unix:/some/path punix:other/path
-ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan/global/set-controller=ptcp: ptcp:1337 \
-ptcp:1337:[fe80::1234%eth0] pssl:1337:[fe80::1] ssl:10.10.10.1 tcp:127.0.0.1:1337 tcp:[fe80::1234%eth0] tcp:[fe80::1]:1337 \
-unix:/some/path punix:other/path
+ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan/global/set-controller=ptcp:,ptcp:1337,\
+ptcp:1337:[fe80::1234%eth0],pssl:1337:[fe80::1],ssl:10.10.10.1,tcp:127.0.0.1:1337,tcp:[fe80::1234%eth0],tcp:[fe80::1]:1337,\
+unix:/some/path,punix:other/path
 ExecStart=/usr/bin/ovs-vsctl set Controller br0 connection-mode=out-of-band
 ExecStart=/usr/bin/ovs-vsctl set Controller br0 external-ids:netplan/connection-mode=out-of-band
 '''},
@@ -584,7 +584,7 @@ ExecStart=/usr/bin/ovs-vsctl set Controller br0 external-ids:netplan/connection-
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl set-ssl /key/path /some/path /another/path
-ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:netplan/global/set-ssl=/key/path /some/path /another/path
+ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:netplan/global/set-ssl=/key/path,/some/path,/another/path
 '''},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane
@@ -681,7 +681,7 @@ ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:netplan/global/set-
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl set-ssl /key/path /some/path /another/path
-ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:netplan/global/set-ssl=/key/path /some/path /another/path
+ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:netplan/global/set-ssl=/key/path,/some/path,/another/path
 '''},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane

--- a/tests/generator/test_ovs.py
+++ b/tests/generator/test_ovs.py
@@ -831,7 +831,7 @@ Bond=bond0
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br1
-ExecStart=/usr/bin/ovs-vsctl --may-exist add-port br1 patchx
+ExecStart=/usr/bin/ovs-vsctl --may-exist add-port br1 patchx -- set Interface patchx type=patch options:peer=patchy
 ''' + OVS_BR_DEFAULT % {'iface': 'br1'}},
                          'bond0.service': OVS_VIRTUAL % {'iface': 'bond0', 'extra':
                                                          '''Requires=netplan-ovs-br0.service
@@ -839,7 +839,7 @@ After=netplan-ovs-br0.service
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/ovs-vsctl --may-exist add-bond br0 bond0 patchy eth0
+ExecStart=/usr/bin/ovs-vsctl --may-exist add-bond br0 bond0 patchy eth0 -- set Interface patchy type=patch options:peer=patchx
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=off
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan/lacp=off
@@ -850,21 +850,7 @@ After=netplan-ovs-br1.service
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/ovs-vsctl set Interface patchx type=patch -- set Interface patchx options:peer=patchy
 ExecStart=/usr/bin/ovs-vsctl set Port patchx external-ids:netplan=true
-ExecStart=/usr/bin/ovs-vsctl set Interface patchx external-ids:netplan/type=patch
-ExecStart=/usr/bin/ovs-vsctl set Interface patchx external-ids:netplan/options/peer=patchy
-'''},
-                         'patchy.service': OVS_VIRTUAL % {'iface': 'patchy', 'extra':
-                                                          '''Requires=netplan-ovs-bond0.service
-After=netplan-ovs-bond0.service
-
-[Service]
-Type=oneshot
-ExecStart=/usr/bin/ovs-vsctl set Interface patchy type=patch -- set Interface patchy options:peer=patchx
-ExecStart=/usr/bin/ovs-vsctl set Port patchy external-ids:netplan=true
-ExecStart=/usr/bin/ovs-vsctl set Interface patchy external-ids:netplan/type=patch
-ExecStart=/usr/bin/ovs-vsctl set Interface patchy external-ids:netplan/options/peer=patchx
 '''},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         self.assert_networkd({'br0.network': ND_WITHIP % ('br0', '192.170.1.1/24'),
@@ -892,13 +878,13 @@ ExecStart=/usr/bin/ovs-vsctl set Interface patchy external-ids:netplan/options/p
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
-ExecStart=/usr/bin/ovs-vsctl --may-exist add-port br0 patch0-1
+ExecStart=/usr/bin/ovs-vsctl --may-exist add-port br0 patch0-1 -- set Interface patch0-1 type=patch options:peer=patch1-0
 ''' + OVS_BR_DEFAULT % {'iface': 'br0'}},
                          'br1.service': OVS_VIRTUAL % {'iface': 'br1', 'extra': '''
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br1
-ExecStart=/usr/bin/ovs-vsctl --may-exist add-port br1 patch1-0
+ExecStart=/usr/bin/ovs-vsctl --may-exist add-port br1 patch1-0 -- set Interface patch1-0 type=patch options:peer=patch0-1
 ''' + OVS_BR_DEFAULT % {'iface': 'br1'}},
                          'patch0-1.service': OVS_VIRTUAL % {'iface': 'patch0-1', 'extra':
                                                             '''Requires=netplan-ovs-br0.service
@@ -906,10 +892,7 @@ After=netplan-ovs-br0.service
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/ovs-vsctl set Interface patch0-1 type=patch -- set Interface patch0-1 options:peer=patch1-0
 ExecStart=/usr/bin/ovs-vsctl set Port patch0-1 external-ids:netplan=true
-ExecStart=/usr/bin/ovs-vsctl set Interface patch0-1 external-ids:netplan/type=patch
-ExecStart=/usr/bin/ovs-vsctl set Interface patch0-1 external-ids:netplan/options/peer=patch1-0
 '''},
                          'patch1-0.service': OVS_VIRTUAL % {'iface': 'patch1-0', 'extra':
                                                             '''Requires=netplan-ovs-br1.service
@@ -917,10 +900,7 @@ After=netplan-ovs-br1.service
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/ovs-vsctl set Interface patch1-0 type=patch -- set Interface patch1-0 options:peer=patch0-1
 ExecStart=/usr/bin/ovs-vsctl set Port patch1-0 external-ids:netplan=true
-ExecStart=/usr/bin/ovs-vsctl set Interface patch1-0 external-ids:netplan/type=patch
-ExecStart=/usr/bin/ovs-vsctl set Interface patch1-0 external-ids:netplan/options/peer=patch0-1
 '''},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         self.assert_networkd({'br0.network': ND_WITHIP % ('br0', '192.168.1.1/24'),

--- a/tests/generator/test_ovs.py
+++ b/tests/generator/test_ovs.py
@@ -852,6 +852,14 @@ After=netplan-ovs-br1.service
 Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl set Port patchx external-ids:netplan=true
 '''},
+                         'patchy.service': OVS_VIRTUAL % {'iface': 'patchy', 'extra':
+                                                          '''Requires=netplan-ovs-bond0.service
+After=netplan-ovs-bond0.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/ovs-vsctl set Interface patchy external-ids:netplan=true
+'''},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         self.assert_networkd({'br0.network': ND_WITHIP % ('br0', '192.170.1.1/24'),
                               'br1.network': ND_WITHIP % ('br1', '2001:FFfe::1/64'),

--- a/tests/generator/test_ovs.py
+++ b/tests/generator/test_ovs.py
@@ -185,7 +185,6 @@ After=netplan-ovs-br0.service
 Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-bond br0 bond0 eth1 eth2
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan=true
-ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan/external-ids/netplan=true
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=off
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan/lacp=off
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:iface-id=myhostname
@@ -254,7 +253,6 @@ After=netplan-ovs-br0.service
 Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-bond br0 bond0 eth1 eth2
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan=true
-ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan/external-ids/netplan=true
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=active
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan/lacp=active
 '''},
@@ -320,7 +318,6 @@ After=netplan-ovs-br0.service
 Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-bond br0 bond0 eth1 eth2
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan=true
-ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan/external-ids/netplan=true
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=off
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan/lacp=off
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 bond_mode=balance-tcp
@@ -360,7 +357,6 @@ After=netplan-ovs-br0.service
 Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-bond br0 bond0 eth1 eth2
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan=true
-ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan/external-ids/netplan=true
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=off
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan/lacp=off
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 bond_mode=active-backup
@@ -468,7 +464,6 @@ ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-port br0 eth1
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-port br0 eth2
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan=true
-ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan/external-ids/netplan=true
 ExecStart=/usr/bin/ovs-vsctl set-fail-mode br0 secure
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan/global/set-fail-mode=secure
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 mcast_snooping_enable=true
@@ -587,7 +582,7 @@ ExecStart=/usr/bin/ovs-vsctl set Controller br0 external-ids:netplan/connection-
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl set-ssl /key/path /some/path /another/path
-ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:netplan/global/set-ssl=/key/path;/some/path;/another/path
+ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:netplan/global/set-ssl=/key/path,/some/path,/another/path
 '''},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane
@@ -684,7 +679,7 @@ ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:netplan/global/set-
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl set-ssl /key/path /some/path /another/path
-ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:netplan/global/set-ssl=/key/path;/some/path;/another/path
+ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:netplan/global/set-ssl=/key/path,/some/path,/another/path
 '''},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane
@@ -789,7 +784,6 @@ After=netplan-ovs-br0.service
 Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-bond br0 bond0 eth1 eth2
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan=true
-ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan/external-ids/netplan=true
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=off
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan/lacp=off
 '''},
@@ -847,7 +841,6 @@ After=netplan-ovs-br0.service
 Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-bond br0 bond0 patchy eth0
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan=true
-ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan/external-ids/netplan=true
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=off
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan/lacp=off
 '''},
@@ -859,7 +852,6 @@ After=netplan-ovs-br1.service
 Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl set Interface patchx type=patch -- set Interface patchx options:peer=patchy
 ExecStart=/usr/bin/ovs-vsctl set Port patchx external-ids:netplan=true
-ExecStart=/usr/bin/ovs-vsctl set Port patchx external-ids:netplan/external-ids/netplan=true
 ExecStart=/usr/bin/ovs-vsctl set Interface patchx external-ids:netplan/type=patch
 ExecStart=/usr/bin/ovs-vsctl set Interface patchx external-ids:netplan/options/peer=patchy
 '''},
@@ -871,7 +863,6 @@ After=netplan-ovs-bond0.service
 Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl set Interface patchy type=patch -- set Interface patchy options:peer=patchx
 ExecStart=/usr/bin/ovs-vsctl set Port patchy external-ids:netplan=true
-ExecStart=/usr/bin/ovs-vsctl set Port patchy external-ids:netplan/external-ids/netplan=true
 ExecStart=/usr/bin/ovs-vsctl set Interface patchy external-ids:netplan/type=patch
 ExecStart=/usr/bin/ovs-vsctl set Interface patchy external-ids:netplan/options/peer=patchx
 '''},
@@ -917,7 +908,6 @@ After=netplan-ovs-br0.service
 Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl set Interface patch0-1 type=patch -- set Interface patch0-1 options:peer=patch1-0
 ExecStart=/usr/bin/ovs-vsctl set Port patch0-1 external-ids:netplan=true
-ExecStart=/usr/bin/ovs-vsctl set Port patch0-1 external-ids:netplan/external-ids/netplan=true
 ExecStart=/usr/bin/ovs-vsctl set Interface patch0-1 external-ids:netplan/type=patch
 ExecStart=/usr/bin/ovs-vsctl set Interface patch0-1 external-ids:netplan/options/peer=patch1-0
 '''},
@@ -929,7 +919,6 @@ After=netplan-ovs-br1.service
 Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl set Interface patch1-0 type=patch -- set Interface patch1-0 options:peer=patch0-1
 ExecStart=/usr/bin/ovs-vsctl set Port patch1-0 external-ids:netplan=true
-ExecStart=/usr/bin/ovs-vsctl set Port patch1-0 external-ids:netplan/external-ids/netplan=true
 ExecStart=/usr/bin/ovs-vsctl set Interface patch1-0 external-ids:netplan/type=patch
 ExecStart=/usr/bin/ovs-vsctl set Interface patch1-0 external-ids:netplan/options/peer=patch0-1
 '''},
@@ -965,7 +954,6 @@ After=netplan-ovs-br0.service
 Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0.100 br0 100
 ExecStart=/usr/bin/ovs-vsctl set Interface br0.100 external-ids:netplan=true
-ExecStart=/usr/bin/ovs-vsctl set Interface br0.100 external-ids:netplan/external-ids/netplan=true
 '''},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane
@@ -995,7 +983,6 @@ After=netplan-ovs-br0.service
 Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0.100 br0 100
 ExecStart=/usr/bin/ovs-vsctl set Interface br0.100 external-ids:netplan=true
-ExecStart=/usr/bin/ovs-vsctl set Interface br0.100 external-ids:netplan/external-ids/netplan=true
 '''},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane

--- a/tests/generator/test_ovs.py
+++ b/tests/generator/test_ovs.py
@@ -584,7 +584,7 @@ ExecStart=/usr/bin/ovs-vsctl set Controller br0 external-ids:netplan/connection-
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl set-ssl /key/path /some/path /another/path
-ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:netplan/global/set-ssl=/key/path,/some/path,/another/path
+ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:netplan/global/set-ssl=/key/path /some/path /another/path
 '''},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane
@@ -681,7 +681,7 @@ ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:netplan/global/set-
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/ovs-vsctl set-ssl /key/path /some/path /another/path
-ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:netplan/global/set-ssl=/key/path,/some/path,/another/path
+ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:netplan/global/set-ssl=/key/path /some/path /another/path
 '''},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane

--- a/tests/integration/ovs.py
+++ b/tests/integration/ovs.py
@@ -416,9 +416,9 @@ class _CommonTests():
 
     def test_settings_tag_cleanup(self):
         self.setup_eth(None, False)
-        #self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-br', 'ovs0'])
-        #self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-br', 'ovs1'])
-        #self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-port', 'bond0'])
+        self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-br', 'ovs0'])
+        self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-br', 'ovs1'])
+        self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-port', 'bond0'])
         with open(self.config, 'w') as f:
             f.write('''network:
   version: 2
@@ -475,14 +475,6 @@ class _CommonTests():
         before = self._collect_ovs_settings('ovs0')
         subprocess.check_call(['netplan', 'apply', '--only-ovs-cleanup'])
         after = self._collect_ovs_settings('ovs0')
-
-        #for k, v in before.items():
-        #    print(k)
-        #    print(v.decode('utf-8'))
-        #print('==========')
-        #for k, v in after.items():
-        #    print(k)
-        #    print(v.decode('utf-8'))
 
         # Verify interfaces
         for data in (before['show'], after['show']):

--- a/tests/integration/ovs.py
+++ b/tests/integration/ovs.py
@@ -238,8 +238,9 @@ class _CommonTests():
         self.assertIn(b'        Port %(ec)b\n            Interface %(ec)b' % {b'ec': self.dev_e_client.encode()}, out)
         self.assertIn(b'        Port %(e2c)b\n            Interface %(e2c)b' % {b'e2c': self.dev_e2_client.encode()}, out)
         # Verify the bridge was tagged 'netplan:true' correctly
-        out = subprocess.check_output(['ovs-vsctl', '--columns=name,external-ids', '-f', 'csv', '-d', 'bare', 'list', 'Bridge'])
-        self.assertIn(b'ovsbr,netplan=true', out)
+        out = subprocess.check_output(['ovs-vsctl', '--columns=name,external-ids', '-f', 'csv', '-d', 'bare',
+                                       'list', 'Bridge', 'ovsbr'])
+        self.assertIn(b'netplan=true', out)
         self.assert_iface('ovsbr', ['inet 192.170.1.1/24'])
 
     def test_bond_base(self):

--- a/tests/integration/ovs.py
+++ b/tests/integration/ovs.py
@@ -478,7 +478,7 @@ class _CommonTests():
         self.assertNotIn(b'iface-id=myhostname', after['external-ids-Bridge'])
         self.assertIn(b'iface-id=mylocaliface', before['external-ids-Interface'])
         self.assertNotIn(b'iface-id=mylocaliface', after['external-ids-Interface'])
-        for tbl in ('Bridge', 'Port', 'Interface'):
+        for tbl in ('Bridge', 'Port'):
             # The netplan=true tag shall be kept unitl the interface is deleted
             self.assertIn(b'netplan=true', before['external-ids-%s' % tbl])
             self.assertIn(b'netplan=true', after['external-ids-%s' % tbl])

--- a/tests/integration/ovs.py
+++ b/tests/integration/ovs.py
@@ -29,6 +29,37 @@ from base import IntegrationTestsBase, test_backends
 
 class _CommonTests():
 
+    def _collect_ovs_settings(self, bridge0):
+        d = {}
+        d['show'] = subprocess.check_output(['ovs-vsctl', 'show'])
+        d['ssl'] = subprocess.check_output(['ovs-vsctl', 'get-ssl'])
+        # TODO: Controller -> connection-mode
+        # TODO: global protocols
+        # Get external-ids
+        for tbl in ('Open_vSwitch',):  #: TODO: Controller
+            d['external-ids-%s' % tbl] = subprocess.check_output(['ovs-vsctl', '--columns=external-ids', '-f', 'csv', '-d',
+                                                                  'bare', '--no-headings', 'list', tbl])
+        for tbl in ('Bridge', 'Port', 'Interface'):
+            d['external-ids-%s' % tbl] = subprocess.check_output(['ovs-vsctl', '--columns=name,external-ids', '-f', 'csv', '-d',
+                                                                  'bare', '--no-headings',  'list', tbl])
+        # Get other-config
+        for tbl in ('Open_vSwitch',):  #: TODO: Controller
+            d['other-config-%s' % tbl] = subprocess.check_output(['ovs-vsctl', '--columns=other-config', '-f', 'csv', '-d',
+                                                                  'bare', '--no-headings',  'list', tbl])
+        for tbl in ('Bridge', 'Port', 'Interface'):
+            d['other-config-%s' % tbl] = subprocess.check_output(['ovs-vsctl', '--columns=name,other-config', '-f', 'csv', '-d',
+                                                                  'bare', '--no-headings',  'list', tbl])
+        # Get bond settings
+        for col in ('bond_mode', 'lacp'):
+            d['%s-Bond' % col] = subprocess.check_output(['ovs-vsctl', '--columns=name,%s' % col, '-f', 'csv', '-d', 'bare',
+                                                           '--no-headings', 'list', 'Port'])
+        # Get bridge settings
+        d['set-fail-mode-Bridge'] = subprocess.check_output(['ovs-vsctl', 'get-fail-mode', bridge0])
+        for col in ('mcast_snooping_enable', 'rstp_enable', 'protocols'):
+            d['%s-Bridge' % col] = subprocess.check_output(['ovs-vsctl', '--columns=name,%s' % col, '-f', 'csv', '-d', 'bare',
+                                                             '--no-headings', 'list', 'Bridge'])
+        return d
+
     def test_cleanup_interfaces(self):
         self.setup_eth(None, False)
         self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-br', 'ovs0'])
@@ -326,6 +357,131 @@ class _CommonTests():
         (out, err) = p.communicate()
         self.assertIn('ovs0: The \'ovs-vsctl\' tool is required to setup OpenVSwitch interfaces.', err)
         self.assertNotEqual(p.returncode, 0)
+
+    def test_settings_tag_cleanup(self):
+        self.setup_eth(None, False)
+        #self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-br', 'ovs0'])
+        #self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-port', 'bond0'])
+        with open(self.config, 'w') as f:
+            f.write('''network:
+  version: 2
+  openvswitch:
+    # FIXME: global protocols are broken?!
+    #protocols: [OpenFlow10, OpenFlow11, OpenFlow12]
+    ports:
+      - [patch0-1, patch1-0]
+    ssl:
+      ca-cert: /some/ca-cert.pem
+      certificate: /another/cert.pem
+      private-key: /private/key.pem
+    external-ids:
+      somekey: somevalue
+    other-config:
+      key: value
+  ethernets:
+    %(ec)s:
+      addresses: [10.5.32.26/20]
+      openvswitch:
+        external-ids:
+          iface-id: mylocaliface
+        other-config:
+          disable-in-band: false
+    %(e2c)s: {}
+  bonds:
+    bond0:
+      interfaces: [patch1-0, %(e2c)s]
+      openvswitch:
+        lacp: passive
+      parameters:
+        mode: balance-tcp
+  bridges:
+    ovs0:
+      addresses: [10.5.48.11/20]
+      interfaces: [patch0-1, %(ec)s, bond0]
+      openvswitch:
+        protocols: [OpenFlow10, OpenFlow11, OpenFlow12]
+        # TODO: validate controllers
+        #controller:
+        #  addresses: [tcp:127.0.0.1, "pssl:1337:[::1]", unix:/some/socket]
+        fail-mode: secure
+        mcast-snooping: true
+        external-ids:
+          iface-id: myhostname
+        other-config:
+          disable-in-band: true
+    ovs1:
+      openvswitch:
+        # Add ovs1 as rstp cannot be used if bridge contains a bond interface
+        rstp: true
+
+''' % {'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
+        self.generate_and_settle()
+        before = self._collect_ovs_settings('ovs0')
+        subprocess.check_call(['netplan', 'apply', '--only-ovs-cleanup'])
+        after = self._collect_ovs_settings('ovs0')
+
+        #for k, v in before.items():
+        #    print(k)
+        #    print(v.decode('utf-8'))
+        #print('==========')
+        #for k, v in after.items():
+        #    print(k)
+        #    print(v.decode('utf-8'))
+
+        # Verify interfaces
+        for data in (before['show'], after['show']):
+            self.assertIn(b'Bridge ovs0', data)
+            self.assertIn(b'Port ovs0', data)
+            self.assertIn(b'Interface ovs0', data)
+            self.assertIn(b'Port patch0-1', data)
+            self.assertIn(b'Interface patch0-1', data)
+            self.assertIn(b'Port eth42', data)
+            self.assertIn(b'Interface eth42', data)
+            self.assertIn(b'Bridge ovs1', data)
+            self.assertIn(b'Port ovs1', data)
+            self.assertIn(b'Interface ovs1', data)
+            self.assertIn(b'Port bond0', data)
+            self.assertIn(b'Interface eth42', data)
+            self.assertIn(b'Interface patch1-0', data)
+        # Verify all settings tags have been removed
+        for tbl in ('Open_vSwitch', 'Bridge', 'Port', 'Interface'):
+            self.assertNotIn(b'netplan/', after['external-ids-%s' % tbl])
+        # Verify SSL
+        for s in (b'Private key: /private/key.pem', b'Certificate: /another/cert.pem', b'CA Certificate: /some/ca-cert.pem'):
+            self.assertIn(s, before['ssl'])
+            self.assertNotIn(s, after['ssl'])
+        # Verify Bond
+        self.assertIn(b'bond0,balance-tcp\n', before['bond_mode-Bond'])
+        self.assertIn(b'bond0,\n', after['bond_mode-Bond'])
+        self.assertIn(b'bond0,passive\n', before['lacp-Bond'])
+        self.assertIn(b'bond0,\n', after['lacp-Bond'])
+        # Verify Bridge
+        self.assertIn(b'secure', before['set-fail-mode-Bridge'])
+        self.assertNotIn(b'secure', after['set-fail-mode-Bridge'])
+        self.assertIn(b'ovs0,true\n', before['mcast_snooping_enable-Bridge'])
+        self.assertIn(b'ovs0,false\n', after['mcast_snooping_enable-Bridge'])
+        self.assertIn(b'ovs1,true\n', before['rstp_enable-Bridge'])
+        self.assertIn(b'ovs1,false\n', after['rstp_enable-Bridge'])
+        self.assertIn(b'ovs0,OpenFlow10 OpenFlow11 OpenFlow12\n', before['protocols-Bridge'])
+        self.assertIn(b'ovs0,\n', after['protocols-Bridge'])
+        # Verify other-config
+        self.assertIn(b'key=value', before['other-config-Open_vSwitch'])
+        self.assertNotIn(b'key=value', after['other-config-Open_vSwitch'])
+        self.assertIn(b'ovs0,disable-in-band=true\n', before['other-config-Bridge'])
+        self.assertIn(b'ovs0,\n', after['other-config-Bridge'])
+        self.assertIn(b'eth42,disable-in-band=false\n', before['other-config-Interface'])
+        self.assertIn(b'eth42,\n', after['other-config-Interface'])
+        # Verify external-ids
+        self.assertIn(b'somekey=somevalue', before['external-ids-Open_vSwitch'])
+        self.assertNotIn(b'somekey=somevalue', after['external-ids-Open_vSwitch'])
+        self.assertIn(b'iface-id=myhostname', before['external-ids-Bridge'])
+        self.assertNotIn(b'iface-id=myhostname', after['external-ids-Bridge'])
+        self.assertIn(b'iface-id=mylocaliface', before['external-ids-Interface'])
+        self.assertNotIn(b'iface-id=mylocaliface', after['external-ids-Interface'])
+        for tbl in ('Bridge', 'Port', 'Interface'):
+            # The netplan=true tag shall be kept unitl the interface is deleted
+            self.assertIn(b'netplan=true', before['external-ids-%s' % tbl])
+            self.assertIn(b'netplan=true', after['external-ids-%s' % tbl])
 
     @unittest.skip("For debugging only")
     def test_zzz_ovs_debugging(self):  # Runs as the last test, to collect all logs

--- a/tests/test_ovs.py
+++ b/tests/test_ovs.py
@@ -38,7 +38,7 @@ Private key: /private/key.pem
 Certificate: /another/cert.pem
 CA Certificate: /some/ca-cert.pem
 Bootstrap: false'''
-        ovs.clear_setting('Open_vSwitch', '.', 'netplan/global/set-ssl', '/private/key.pem /another/cert.pem /some/ca-cert.pem')
+        ovs.clear_setting('Open_vSwitch', '.', 'netplan/global/set-ssl', '/private/key.pem,/another/cert.pem,/some/ca-cert.pem')
         mock_out.assert_called_once_with([OVS, 'get-ssl'], universal_newlines=True)
         mock.assert_has_calls([
             call([OVS, 'del-ssl']),
@@ -53,7 +53,7 @@ Private key: /private/key.pem
 Certificate: /another/cert.pem
 CA Certificate: /some/ca-cert.pem
 Bootstrap: false'''
-        ovs.clear_setting('Open_vSwitch', '.', 'netplan/global/set-ssl', '/some/key.pem /other/cert.pem /some/cert.pem')
+        ovs.clear_setting('Open_vSwitch', '.', 'netplan/global/set-ssl', '/some/key.pem,/other/cert.pem,/some/cert.pem')
         mock_out.assert_called_once_with([OVS, 'get-ssl'], universal_newlines=True)
         mock.assert_has_calls([
             call([OVS, 'remove', 'Open_vSwitch', '.', 'external-ids', 'netplan/global/set-ssl'])
@@ -66,9 +66,9 @@ Bootstrap: false'''
     @patch('subprocess.check_output')
     @patch('subprocess.check_call')
     def test_clear_global(self, mock, mock_out):
-        mock_out.return_value = 'tcp:127.0.0.1:1337 unix:/some/socket'
-        ovs.clear_setting('Bridge', 'ovs0', 'netplan/global/set-controller', 'tcp:127.0.0.1:1337 unix:/some/socket')
-        mock_out.assert_called_once_with([OVS, 'get-controller'], universal_newlines=True)
+        mock_out.return_value = 'tcp:127.0.0.1:1337\nunix:/some/socket'
+        ovs.clear_setting('Bridge', 'ovs0', 'netplan/global/set-controller', 'tcp:127.0.0.1:1337,unix:/some/socket')
+        mock_out.assert_called_once_with([OVS, 'get-controller', 'ovs0'], universal_newlines=True)
         mock.assert_has_calls([
             call([OVS, 'del-controller', 'ovs0']),
             call([OVS, 'remove', 'Bridge', 'ovs0', 'external-ids', 'netplan/global/set-controller'])
@@ -78,8 +78,8 @@ Bootstrap: false'''
     @patch('subprocess.check_call')
     def test_no_clear_global_different(self, mock, mock_out):
         mock_out.return_value = 'unix:/var/run/openvswitch/ovs0.mgmt'
-        ovs.clear_setting('Bridge', 'ovs0', 'netplan/global/set-controller', 'tcp:127.0.0.1:1337 unix:/some/socket')
-        mock_out.assert_called_once_with([OVS, 'get-controller'], universal_newlines=True)
+        ovs.clear_setting('Bridge', 'ovs0', 'netplan/global/set-controller', 'tcp:127.0.0.1:1337,unix:/some/socket')
+        mock_out.assert_called_once_with([OVS, 'get-controller', 'ovs0'], universal_newlines=True)
         mock.assert_has_calls([
             call([OVS, 'remove', 'Bridge', 'ovs0', 'external-ids', 'netplan/global/set-controller'])
         ])

--- a/tests/test_ovs.py
+++ b/tests/test_ovs.py
@@ -1,0 +1,129 @@
+#!/usr/bin/python3
+#
+# Copyright (C) 2020 Canonical, Ltd.
+# Author: Lukas Märdian <lukas.maerdian@canonical.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from unittest.mock import patch, call
+from netplan.cli.ovs import OPENVSWITCH_OVS_VSCTL as OVS
+
+import netplan.cli.ovs as ovs
+
+
+class TestOVS(unittest.TestCase):
+
+    @patch('subprocess.check_call')
+    def test_clear_settings_tag(self, mock):
+        ovs.clear_setting('Bridge', 'ovs0', 'netplan/external-ids/key', 'value')
+        mock.assert_called_with([OVS, 'remove', 'Bridge', 'ovs0', 'external-ids', 'netplan/external-ids/key'])
+
+    @patch('subprocess.check_output')
+    @patch('subprocess.check_call')
+    def test_clear_global_ssl(self, mock, mock_out):
+        mock_out.return_value = '''
+Private key: /private/key.pem
+Certificate: /another/cert.pem
+CA Certificate: /some/ca-cert.pem
+Bootstrap: false'''
+        ovs.clear_setting('Open_vSwitch', '.', 'netplan/global/set-ssl', '/private/key.pem /another/cert.pem /some/ca-cert.pem')
+        mock_out.assert_called_once_with([OVS, 'get-ssl'], universal_newlines=True)
+        mock.assert_has_calls([
+            call([OVS, 'del-ssl']),
+            call([OVS, 'remove', 'Open_vSwitch', '.', 'external-ids', 'netplan/global/set-ssl'])
+        ])
+
+    @patch('subprocess.check_output')
+    @patch('subprocess.check_call')
+    def test_no_clear_global_ssl_different(self, mock, mock_out):
+        mock_out.return_value = '''
+Private key: /private/key.pem
+Certificate: /another/cert.pem
+CA Certificate: /some/ca-cert.pem
+Bootstrap: false'''
+        ovs.clear_setting('Open_vSwitch', '.', 'netplan/global/set-ssl', '/some/key.pem /other/cert.pem /some/cert.pem')
+        mock_out.assert_called_once_with([OVS, 'get-ssl'], universal_newlines=True)
+        mock.assert_has_calls([
+            call([OVS, 'remove', 'Open_vSwitch', '.', 'external-ids', 'netplan/global/set-ssl'])
+        ])
+
+    def test_clear_global_unknown(self):
+        with self.assertRaises(Exception):
+            ovs.clear_setting('Bridge', 'ovs0', 'netplan/global/set-something', 'INVALID')
+
+    @patch('subprocess.check_output')
+    @patch('subprocess.check_call')
+    def test_clear_global(self, mock, mock_out):
+        mock_out.return_value = 'tcp:127.0.0.1:1337 unix:/some/socket'
+        ovs.clear_setting('Bridge', 'ovs0', 'netplan/global/set-controller', 'tcp:127.0.0.1:1337 unix:/some/socket')
+        mock_out.assert_called_once_with([OVS, 'get-controller'], universal_newlines=True)
+        mock.assert_has_calls([
+            call([OVS, 'del-controller', 'ovs0']),
+            call([OVS, 'remove', 'Bridge', 'ovs0', 'external-ids', 'netplan/global/set-controller'])
+        ])
+
+    @patch('subprocess.check_output')
+    @patch('subprocess.check_call')
+    def test_no_clear_global_different(self, mock, mock_out):
+        mock_out.return_value = 'unix:/var/run/openvswitch/ovs0.mgmt'
+        ovs.clear_setting('Bridge', 'ovs0', 'netplan/global/set-controller', 'tcp:127.0.0.1:1337 unix:/some/socket')
+        mock_out.assert_called_once_with([OVS, 'get-controller'], universal_newlines=True)
+        mock.assert_has_calls([
+            call([OVS, 'remove', 'Bridge', 'ovs0', 'external-ids', 'netplan/global/set-controller'])
+        ])
+
+    @patch('subprocess.check_call')
+    def test_clear_dict(self, mock):
+        ovs.clear_setting('Bridge', 'ovs0', 'netplan/other-config/key', 'value')
+        mock.assert_has_calls([
+            call([OVS, 'remove', 'Bridge', 'ovs0', 'other-config', 'key', 'value']),
+            call([OVS, 'remove', 'Bridge', 'ovs0', 'external-ids', 'netplan/other-config/key'])
+        ])
+
+    @patch('subprocess.check_call')
+    def test_clear_col(self, mock):
+        ovs.clear_setting('Port', 'bond0', 'netplan/bond_mode', 'balance-tcp')
+        mock.assert_has_calls([
+            call([OVS, 'remove', 'Port', 'bond0', 'bond_mode', 'balance-tcp']),
+            call([OVS, 'remove', 'Port', 'bond0', 'external-ids', 'netplan/bond_mode'])
+        ])
+
+    @patch('subprocess.check_call')
+    def test_clear_col_default(self, mock):
+        ovs.clear_setting('Bridge', 'ovs0', 'netplan/rstp_enable', 'true')
+        mock.assert_has_calls([
+            call([OVS, 'set', 'Bridge', 'ovs0', 'rstp_enable=false']),
+            call([OVS, 'remove', 'Bridge', 'ovs0', 'external-ids', 'netplan/rstp_enable'])
+        ])
+
+    def test_is_ovs_interface(self):
+        interfaces = dict()
+        interfaces['ovs0'] = {'openvswitch': {'set-fail-mode': 'secure'}}
+        self.assertTrue(ovs.is_ovs_interface('ovs0', interfaces))
+
+    def test_is_ovs_interface_false(self):
+        interfaces = dict()
+        interfaces['br0'] = {'interfaces': ['eth0', 'eth1']}
+        interfaces['eth0'] = {}
+        interfaces['eth1'] = {}
+        self.assertFalse(ovs.is_ovs_interface('br0', interfaces))
+
+    def test_is_ovs_interface_recursive(self):
+        interfaces = dict()
+        interfaces['patchx'] = {'peer': 'patchy', 'openvswitch': {}}
+        interfaces['patchy'] = {'peer': 'patchx', 'openvswitch': {}}
+        interfaces['ovs0'] = {'interfaces': ['bond0']}
+        interfaces['bond0'] = {'interfaces': ['patchx', 'patchy']}
+        self.assertTrue(ovs.is_ovs_interface('ovs0', interfaces))


### PR DESCRIPTION
## Description
This PR implements the "Common tags for all device types" section of the spec.
Whenever any OVS setting is applied inside the ovsdb, this code adds another setting for the corresponding interface inside the `external-ids` table, e.g.:
* `ovs-vsctl set-ssl client-key client-cert ca-cert`
* `ovs-vsctl set open_vswitch . external-ids:netplan/global/set-ssl=client-key,client-cert,ca-cert`
or:
* `ovs-vsctl set Bridge ovs0 other-config:some-key=42`
* `ovs-vsctl set Bridge ovs0 external-ids:netplan/other-config/some-key=42`
or:
* `ovs-vsctl set Port ovs1 lacp=off`
* `ovs-vsctl set Port ovs1 external-ids:netplan/lacp=off`

The netplan settings tag (`netplan/<column>[/<key>]=<value>`) marks the settings (`column[:key]=value`) inside ovsdb state, so that it can be cleaned up via `netplan apply --only-ovs-cleanup`. The cleanup will only happen if the setting and value are exactly the same as set/tagged by netplan. If the setting was touched manually (or by another process) netplan cleanup will not touch it. This way we can make sure to always start with a clean state before executing the OVS setup commands and submitting the new config/settings to ovsdb.

Additionally, this PR fixes the creation and tagging of OVS patch_ports and the setup of global OpenFlow protocols.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Closes an open bug in Launchpad.

