### PR TITLE
Flush IPs of NM managed interfaces (LP: #1870561)

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -23,6 +23,9 @@ import glob
 import netplan.cli.utils as utils
 
 
+DEVICES = ['eth0', 'eth1', 'ens3', 'ens4', 'br0']
+
+
 class TestUtils(unittest.TestCase):
 
     def setUp(self):
@@ -43,7 +46,28 @@ class TestUtils(unittest.TestCase):
         self._create_nm_keyfile('netplan-test.nmconnection', 'eth0')
         self._create_nm_keyfile('netplan-test2.nmconnection', 'eth1')
         ifaces = utils.nm_interfaces(glob.glob(os.path.join(self.workdir.name,
-                                     'run/NetworkManager/system-connections/*.nmconnection')))
+                                     'run/NetworkManager/system-connections/*.nmconnection')),
+                                     DEVICES)
         self.assertTrue('eth0' in ifaces)
         self.assertTrue('eth1' in ifaces)
         self.assertTrue(len(ifaces) == 2)
+
+    def test_nm_interfaces_globbing(self):
+        self._create_nm_keyfile('netplan-test.nmconnection', 'eth?')
+        ifaces = utils.nm_interfaces(glob.glob(os.path.join(self.workdir.name,
+                                     'run/NetworkManager/system-connections/*.nmconnection')),
+                                     DEVICES)
+        self.assertTrue('eth0' in ifaces)
+        self.assertTrue('eth1' in ifaces)
+        self.assertTrue(len(ifaces) == 2)
+
+    def test_nm_interfaces_globbing2(self):
+        self._create_nm_keyfile('netplan-test.nmconnection', 'e*')
+        ifaces = utils.nm_interfaces(glob.glob(os.path.join(self.workdir.name,
+                                     'run/NetworkManager/system-connections/*.nmconnection')),
+                                     DEVICES)
+        self.assertTrue('eth0' in ifaces)
+        self.assertTrue('eth1' in ifaces)
+        self.assertTrue('ens3' in ifaces)
+        self.assertTrue('ens4' in ifaces)
+        self.assertTrue(len(ifaces) == 4)


### PR DESCRIPTION
## Description
There might be scenarios, where leftover IP addresses are assigned to a
given interface. This confuses NetworkManager and makes it create a new,
non netplan-* connection profile, using this leftover IP.

Flush the IP addresses of all NM managed interfaces, to avoid this
situation.

Fixes LP: #1870561

This PR passes all unit- and integration-test and the manual testing.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [x] \(Optional\) Closes an open bug in Launchpad: https://bugs.launchpad.net/netplan/+bug/1870561

