### PR TITLE
Add per-route MTU option (LP: #1860201)

### DIFF
--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -574,6 +574,10 @@ These options are available for all types of interfaces.
           see ``/etc/iproute2/rt_tables``.
           (``NetworkManager``: as of v1.10.0)
 
+    ``mtu`` (scalar) – since **0.101**
+     :    The MTU to be used for the route, in bytes. Must be a positive integer
+          value.
+
 ``routing-policy`` (mapping)
 
 :    The ``routing-policy`` block defines extra routing policy for a network,

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -442,6 +442,8 @@ write_route(NetplanIPRoute* r, GString* s)
         g_string_append_printf(s, "Metric=%d\n", r->metric);
     if (r->table != NETPLAN_ROUTE_TABLE_UNSPEC)
         g_string_append_printf(s, "Table=%d\n", r->table);
+    if (r->mtubytes != NETPLAN_MTU_UNSPEC)
+        g_string_append_printf(s, "MTUBytes=%u\n", r->mtubytes);
 }
 
 static void
@@ -568,7 +570,7 @@ write_network_file(const NetplanNetDefinition* def, const char* rootdir, const c
     }
 
     if (def->mtubytes) {
-        g_string_append_printf(link, "MTUBytes=%d\n", def->mtubytes);
+        g_string_append_printf(link, "MTUBytes=%u\n", def->mtubytes);
     }
 
     if (def->emit_lldp) {

--- a/src/nm.c
+++ b/src/nm.c
@@ -222,6 +222,7 @@ write_routes(const NetplanNetDefinition* def, GString *s, int family)
             g_string_append(s, "\n");
 
             if (   cur_route->onlink
+                || cur_route->mtubytes
                 || cur_route->table != NETPLAN_ROUTE_TABLE_UNSPEC
                 || cur_route->from) {
                 g_string_append_printf(s, "route%d_options=", j);
@@ -229,6 +230,8 @@ write_routes(const NetplanNetDefinition* def, GString *s, int family)
                     /* onlink for IPv6 addresses is only supported since nm-1.18.0. */
                     g_string_append_printf(s, "onlink=true,");
                 }
+                if (cur_route->mtubytes != NETPLAN_MTU_UNSPEC)
+                    g_string_append_printf(s, "mtu=%u,", cur_route->mtubytes);
                 if (cur_route->table != NETPLAN_ROUTE_TABLE_UNSPEC)
                     g_string_append_printf(s, "table=%u,", cur_route->table);
                 if (cur_route->from)
@@ -615,7 +618,7 @@ write_nm_conf_access_point(NetplanNetDefinition* def, const char* rootdir, const
             g_string_append_printf(link_str, "cloned-mac-address=%s\n", def->set_mac);
         }
         if (def->mtubytes) {
-            g_string_append_printf(link_str, "mtu=%d\n", def->mtubytes);
+            g_string_append_printf(link_str, "mtu=%u\n", def->mtubytes);
         }
         if (def->wowlan && def->wowlan > NETPLAN_WIFI_WOWLAN_DEFAULT)
             g_string_append_printf(link_str, "wake-on-wlan=%u\n", def->wowlan);
@@ -642,7 +645,7 @@ write_nm_conf_access_point(NetplanNetDefinition* def, const char* rootdir, const
             g_string_append_printf(link_str, "cloned-mac-address=%s\n", def->set_mac);
         }
         if (def->mtubytes) {
-            g_string_append_printf(link_str, "mtu=%d\n", def->mtubytes);
+            g_string_append_printf(link_str, "mtu=%u\n", def->mtubytes);
         }
 
         if (link_str->len > 0) {

--- a/src/parse.c
+++ b/src/parse.c
@@ -1517,6 +1517,7 @@ static const mapping_entry_handler routes_handlers[] = {
     {"type", YAML_SCALAR_NODE, handle_routes_type},
     {"via", YAML_SCALAR_NODE, handle_routes_ip, NULL, route_offset(via)},
     {"metric", YAML_SCALAR_NODE, handle_routes_guint, NULL, route_offset(metric)},
+    {"mtu", YAML_SCALAR_NODE, handle_routes_guint, NULL, route_offset(mtubytes)},
     {NULL}
 };
 

--- a/src/parse.h
+++ b/src/parse.h
@@ -425,6 +425,7 @@ typedef struct {
     gboolean has_auth;
 } NetplanWifiAccessPoint;
 
+#define NETPLAN_MTU_UNSPEC 0
 #define NETPLAN_METRIC_UNSPEC G_MAXUINT
 #define NETPLAN_ROUTE_TABLE_UNSPEC 0
 #define NETPLAN_IP_RULE_PRIO_UNSPEC G_MAXUINT
@@ -446,6 +447,8 @@ typedef struct {
     /* valid metrics are valid positive integers.
      * invalid metrics are represented by METRIC_UNSPEC */
     guint metric;
+
+    guint mtubytes;
 } NetplanIPRoute;
 
 typedef struct {

--- a/tests/generator/test_errors.py
+++ b/tests/generator/test_errors.py
@@ -528,6 +528,21 @@ class TestConfigErrors(TestBase):
         - 192.168.14.2/24
         - 2001:FFfe::1/64''', expect_fail=True)
 
+    def test_device_bad_route_mtu(self):
+        err = self.generate('''network:
+  version: 2
+  ethernets:
+    engreen:
+      routes:
+        - to: 10.10.0.0/16
+          via: 10.1.1.1
+          mtu: -1
+      addresses:
+        - 192.168.14.2/24
+        - 2001:FFfe::1/64''', expect_fail=True)
+
+        self.assertIn("invalid unsigned int value '-1'", err)
+
     def test_device_route_family_mismatch_ipv6_to(self):
         self.generate('''network:
   version: 2

--- a/tests/generator/test_routing.py
+++ b/tests/generator/test_routing.py
@@ -344,6 +344,31 @@ PreferredSource=192.168.14.2
 Metric=100
 '''})
 
+    def test_route_v4_mtu(self):
+        self.generate('''network:
+  version: 2
+  ethernets:
+    engreen:
+      addresses: ["192.168.14.2/24"]
+      routes:
+        - to: 10.10.10.0/24
+          via: 192.168.14.20
+          mtu: 1500
+          ''')
+
+        self.assert_networkd({'engreen.network': '''[Match]
+Name=engreen
+
+[Network]
+LinkLocalAddressing=ipv6
+Address=192.168.14.2/24
+
+[Route]
+Destination=10.10.10.0/24
+Gateway=192.168.14.20
+MTUBytes=1500
+'''})
+
     def test_route_v6_single(self):
         self.generate('''network:
   version: 2
@@ -868,6 +893,39 @@ method=manual
 address1=192.168.14.2/24
 route1=10.10.10.0/24,192.168.1.20
 route1_options=table=31337
+
+[ipv6]
+method=ignore
+'''})
+        self.assert_networkd({})
+
+    def test_route_mtu(self):
+        out = self.generate('''network:
+  version: 2
+  ethernets:
+    engreen:
+      renderer: NetworkManager
+      addresses: ["192.168.14.2/24"]
+      routes:
+        - to: 10.10.10.0/24
+          via: 192.168.1.20
+          mtu: 1500
+          ''')
+        self.assertEqual('', out)
+
+        self.assert_nm({'engreen': '''[connection]
+id=netplan-engreen
+type=ethernet
+interface-name=engreen
+
+[ethernet]
+wake-on-lan=0
+
+[ipv4]
+method=manual
+address1=192.168.14.2/24
+route1=10.10.10.0/24,192.168.1.20
+route1_options=mtu=1500
 
 [ipv6]
 method=ignore

--- a/tests/integration/routing.py
+++ b/tests/integration/routing.py
@@ -177,6 +177,23 @@ class _CommonTests():
         self.assertIn(b'metric 799',
                       subprocess.check_output(['ip', '-6', 'route', 'show', '2001:f00f:f00f::/64']))
 
+    def test_per_route_mtu(self):
+        self.setup_eth(None)
+        with open(self.config, 'w') as f:
+            f.write('''network:
+  renderer: %(r)s
+  ethernets:
+    %(ec)s:
+      addresses:
+          - 192.168.5.99/24
+      gateway4: 192.168.5.1
+      routes:
+          - to: 10.10.10.0/24
+            via: 192.168.5.254
+            mtu: 777''' % {'r': self.backend, 'ec': self.dev_e_client})
+        self.generate_and_settle()
+        self.assertIn(b'mtu 777',  # check mtu from static route
+                      subprocess.check_output(['ip', 'route', 'show', '10.10.10.0/24']))
 
 
 @unittest.skipIf("networkd" not in test_backends,


### PR DESCRIPTION
This patch introduces a way to set MTU for specific routes. It adds an 'mtu'
field to the `NetplanIPRoute` struct, and makes use of already existing route
handling code to add the MTU-related fields for networkd and NM backends.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [x] New/changed keys in YAML format are documented.
- [x] \(Optional\) Closes an open bug in Launchpad. ([LP: #1860201](https://bugs.launchpad.net/netplan/+bug/1860201))

