### PR TITLE
Implement ipv6-address-token-id key (LP: #1737976)

### DIFF
--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -272,11 +272,11 @@ Virtual devices
     Stateless Address Autoconfiguration (only supported with `NetworkManager`
     backend). Possible values are ``eui64`` or ``stable-privacy``.
 
-``ipv6-address-token-id`` (scalar) – since **0.100**
+``ipv6-address-token`` (scalar) – since **0.100**
 
 :   Define an IPv6 address token for creating a static interface identifier for
-    IPv6 Stateless Address Autoconfiguration. This implies a slightly modified
-    ``eui64`` mode and is mutually exclusive with ``ipv6-address-generation``.
+    IPv6 Stateless Address Autoconfiguration. This is mutually exclusive with
+    ``ipv6-address-generation``.
 
 ``gateway4``, ``gateway6`` (scalar)
 

--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -272,6 +272,12 @@ Virtual devices
     Stateless Address Autoconfiguration (only supported with `NetworkManager`
     backend). Possible values are ``eui64`` or ``stable-privacy``.
 
+``ipv6-address-token-id`` (scalar) – since **0.100**
+
+:   Define an IPv6 address token for creating a static interface identifier for
+    IPv6 Stateless Address Autoconfiguration. This implies a slightly modified
+    ``eui64`` mode and is mutually exclusive with ``ipv6-address-generation``.
+
 ``gateway4``, ``gateway6`` (scalar)
 
 :   Set default gateway for IPv4/6, for manual address configuration. This

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -537,13 +537,17 @@ write_network_file(const NetplanNetDefinition* def, const char* rootdir, const c
     if (def->ip6_addresses)
         for (unsigned i = 0; i < def->ip6_addresses->len; ++i)
             g_string_append_printf(network, "Address=%s\n", g_array_index(def->ip6_addresses, char*, i));
-    if (def->ip6_addr_gen_mode) {
-        /* TODO: Figure out how we can configure ipv6-address-generation for networkd.
+    if (def->ip6_addr_gen_token) {
+        g_string_append_printf(network, "IPv6Token=static:%s\n", def->ip6_addr_gen_token);
+    } else if (def->ip6_addr_gen_mode > NETPLAN_ADDRGEN_EUI64) {
+        /* EUI-64 mode is enabled by default, if no IPv6Token= is specified */
+        /* TODO: Figure out how we can configure stable-privacy for networkd.
          *       IPv6Token= seems to be the corresponding option, but it doesn't do
          *       exactly what we need and has quite some restrictions, c.f.:
+         *       https://github.com/systemd/systemd/pull/16618
          *       https://github.com/systemd/systemd/issues/4625
          *       https://github.com/systemd/systemd/pull/14415 */
-        g_fprintf(stderr, "ERROR: %s: ipv6-address-generation is not supported by networkd\n", def->id);
+        g_fprintf(stderr, "ERROR: %s: ipv6-address-generation mode is not supported by networkd\n", def->id);
         exit(1);
     }
     if (def->accept_ra == NETPLAN_RA_MODE_ENABLED)

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -541,12 +541,8 @@ write_network_file(const NetplanNetDefinition* def, const char* rootdir, const c
         g_string_append_printf(network, "IPv6Token=static:%s\n", def->ip6_addr_gen_token);
     } else if (def->ip6_addr_gen_mode > NETPLAN_ADDRGEN_EUI64) {
         /* EUI-64 mode is enabled by default, if no IPv6Token= is specified */
-        /* TODO: Figure out how we can configure stable-privacy for networkd.
-         *       IPv6Token= seems to be the corresponding option, but it doesn't do
-         *       exactly what we need and has quite some restrictions, c.f.:
-         *       https://github.com/systemd/systemd/pull/16618
-         *       https://github.com/systemd/systemd/issues/4625
-         *       https://github.com/systemd/systemd/pull/14415 */
+        /* TODO: Enable stable-privacy mode for networkd, once PR#16618 has been released:
+         *       https://github.com/systemd/systemd/pull/16618 */
         g_fprintf(stderr, "ERROR: %s: ipv6-address-generation mode is not supported by networkd\n", def->id);
         exit(1);
     }

--- a/src/nm.c
+++ b/src/nm.c
@@ -670,7 +670,11 @@ write_nm_conf_access_point(NetplanNetDefinition* def, const char* rootdir, const
         if (def->ip6_addresses)
             for (unsigned i = 0; i < def->ip6_addresses->len; ++i)
                 g_string_append_printf(s, "address%i=%s\n", i+1, g_array_index(def->ip6_addresses, char*, i));
-        if (def->ip6_addr_gen_mode) {
+        if (def->ip6_addr_gen_token) {
+            /* Token implies EUI-64, i.e mode=0 */
+            g_string_append(s, "addr-gen-mode=0\n");
+            g_string_append_printf(s, "token=%s\n", def->ip6_addr_gen_token);
+        } else if (def->ip6_addr_gen_mode) {
             g_string_append_printf(s, "addr-gen-mode=%s\n", addr_gen_mode_str(def->ip6_addr_gen_mode));
         }
         if (def->ip6_privacy)

--- a/src/parse.c
+++ b/src/parse.c
@@ -1744,7 +1744,7 @@ static const mapping_entry_handler nameservers_handlers[] = {
     {"route-metric", YAML_SCALAR_NODE, handle_netdef_guint, NULL, netdef_offset(overrides.metric)},         \
     {"send-hostname", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(overrides.send_hostname)},  \
     {"use-dns", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(overrides.use_dns)},              \
-    {"use-domains", YAML_SCALAR_NODE, handle_netdef_str, NULL, netdef_offset(overrides.use_domains)},       \
+    {"use-domains", YAML_SCALAR_NODE, handle_netdef_str, NULL, netdef_offset(overrides.use_domains)},      \
     {"use-hostname", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(overrides.use_hostname)},    \
     {"use-mtu", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(overrides.use_mtu)},              \
     {"use-ntp", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(overrides.use_ntp)},              \
@@ -1772,7 +1772,7 @@ static const mapping_entry_handler dhcp6_overrides_handlers[] = {
     {"dhcp6-overrides", YAML_MAPPING_NODE, NULL, dhcp6_overrides_handlers},                   \
     {"gateway4", YAML_SCALAR_NODE, handle_gateway4},                                          \
     {"gateway6", YAML_SCALAR_NODE, handle_gateway6},                                          \
-    {"ipv6-address-generation", YAML_SCALAR_NODE, handle_netdef_addrgen},                     \
+    {"ipv6-address-generation", YAML_SCALAR_NODE, handle_netdef_addrgen},                               \
     {"ipv6-address-token", YAML_SCALAR_NODE, handle_netdef_addrtok, NULL, netdef_offset(ip6_addr_gen_token)}, \
     {"ipv6-mtu", YAML_SCALAR_NODE, handle_netdef_guint, NULL, netdef_offset(ipv6_mtubytes)},  \
     {"ipv6-privacy", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(ip6_privacy)}, \
@@ -1790,11 +1790,11 @@ static const mapping_entry_handler dhcp6_overrides_handlers[] = {
     {"networkmanager", YAML_MAPPING_NODE, NULL, nm_backend_settings_handlers}
 
 /* Handlers for physical links */
-#define PHYSICAL_LINK_HANDLERS                                                                \
-    {"match", YAML_MAPPING_NODE, handle_match},                                               \
-    {"set-name", YAML_SCALAR_NODE, handle_netdef_str, NULL, netdef_offset(set_name)},         \
-    {"wakeonlan", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(wake_on_lan)},    \
-    {"wakeonwlan", YAML_SEQUENCE_NODE, handle_wowlan, NULL, netdef_offset(wowlan)},           \
+#define PHYSICAL_LINK_HANDLERS                                                           \
+    {"match", YAML_MAPPING_NODE, handle_match},                                          \
+    {"set-name", YAML_SCALAR_NODE, handle_netdef_str, NULL, netdef_offset(set_name)},    \
+    {"wakeonlan", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(wake_on_lan)}, \
+    {"wakeonwlan", YAML_SEQUENCE_NODE, handle_wowlan, NULL, netdef_offset(wowlan)},       \
     {"emit-lldp", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(emit_lldp)}
 
 static const mapping_entry_handler ethernet_def_handlers[] = {

--- a/src/parse.c
+++ b/src/parse.c
@@ -509,9 +509,7 @@ handle_netdef_addrtok(yaml_document_t* doc, yaml_node_t* node, const void* data,
     g_assert(cur_netdef);
     gboolean ret = handle_netdef_str(doc, node, data, error);
     if (!is_ip6_address(cur_netdef->ip6_addr_gen_token))
-        return yaml_error(node, error, "invalid ipv6-address-token-id '%s'", scalar(node));
-    /* Setting a static token implies eui64 */
-    cur_netdef->ip6_addr_gen_mode = NETPLAN_ADDRGEN_EUI64;
+        return yaml_error(node, error, "invalid ipv6-address-token '%s'", scalar(node));
     return ret;
 }
 
@@ -1775,7 +1773,7 @@ static const mapping_entry_handler dhcp6_overrides_handlers[] = {
     {"gateway4", YAML_SCALAR_NODE, handle_gateway4},                                          \
     {"gateway6", YAML_SCALAR_NODE, handle_gateway6},                                          \
     {"ipv6-address-generation", YAML_SCALAR_NODE, handle_netdef_addrgen},                     \
-    {"ipv6-address-token-id", YAML_SCALAR_NODE, handle_netdef_addrtok, NULL, netdef_offset(ip6_addr_gen_token)}, \
+    {"ipv6-address-token", YAML_SCALAR_NODE, handle_netdef_addrtok, NULL, netdef_offset(ip6_addr_gen_token)}, \
     {"ipv6-mtu", YAML_SCALAR_NODE, handle_netdef_guint, NULL, netdef_offset(ipv6_mtubytes)},  \
     {"ipv6-privacy", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(ip6_privacy)}, \
     {"link-local", YAML_SEQUENCE_NODE, handle_link_local},                                    \

--- a/src/parse.h
+++ b/src/parse.h
@@ -228,6 +228,7 @@ struct net_definition {
     GArray* address_options;
     gboolean ip6_privacy;
     guint ip6_addr_gen_mode;
+    char* ip6_addr_gen_token;
     char* gateway4;
     char* gateway6;
     GArray* ip4_nameservers;

--- a/src/validation.c
+++ b/src/validation.c
@@ -195,8 +195,8 @@ validate_netdef_grammar(NetplanNetDefinition* nd, yaml_node_t* node, GError** er
             goto netdef_grammar_error;
     }
 
-    if (nd->ip6_addr_gen_mode > NETPLAN_ADDRGEN_EUI64 && nd->ip6_addr_gen_token)
-        return yaml_error(node, error, "%s: ipv6-address-generation and ipv6-address-token-id are mutually exclusive", nd->id);
+    if (nd->ip6_addr_gen_mode != NETPLAN_ADDRGEN_DEFAULT && nd->ip6_addr_gen_token)
+        return yaml_error(node, error, "%s: ipv6-address-generation and ipv6-address-token are mutually exclusive", nd->id);
 
     valid = TRUE;
 

--- a/src/validation.c
+++ b/src/validation.c
@@ -195,6 +195,9 @@ validate_netdef_grammar(NetplanNetDefinition* nd, yaml_node_t* node, GError** er
             goto netdef_grammar_error;
     }
 
+    if (nd->ip6_addr_gen_mode > NETPLAN_ADDRGEN_EUI64 && nd->ip6_addr_gen_token)
+        return yaml_error(node, error, "%s: ipv6-address-generation and ipv6-address-token-id are mutually exclusive", nd->id);
+
     valid = TRUE;
 
 netdef_grammar_error:

--- a/tests/generator/test_common.py
+++ b/tests/generator/test_common.py
@@ -613,6 +613,57 @@ RouteMetric=100
 UseMTU=true
 '''})
 
+    def test_ip6_addr_gen_mode(self):
+        self.generate('''network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    enblue:
+      dhcp6: yes
+      ipv6-address-generation: eui64''')
+        self.assert_networkd({'enblue.network': '''[Match]\nName=enblue\n
+[Network]
+DHCP=ipv6
+LinkLocalAddressing=ipv6
+
+[DHCP]
+RouteMetric=100
+UseMTU=true
+'''})
+
+    def test_ip6_addr_gen_token(self):
+        self.generate('''network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    engreen:
+      dhcp6: yes
+      ipv6-address-token-id: ::2
+    enblue:
+      dhcp6: yes
+      ipv6-address-generation: eui64
+      ipv6-address-token-id: "::2"''')
+        self.assert_networkd({'engreen.network': '''[Match]\nName=engreen\n
+[Network]
+DHCP=ipv6
+LinkLocalAddressing=ipv6
+IPv6Token=static:::2
+
+[DHCP]
+RouteMetric=100
+UseMTU=true
+''',
+                              'enblue.network': '''[Match]\nName=enblue\n
+[Network]
+DHCP=ipv6
+LinkLocalAddressing=ipv6
+IPv6Token=static:::2
+
+[DHCP]
+RouteMetric=100
+UseMTU=true
+'''})
+
 
 class TestNetworkManager(TestBase):
 
@@ -863,6 +914,51 @@ method=link-local
 [ipv6]
 method=auto
 addr-gen-mode=0
+'''})
+
+    def test_ip6_addr_gen_token(self):
+        self.generate('''network:
+  version: 2
+  renderer: NetworkManager
+  ethernets:
+    engreen:
+      dhcp6: yes
+      ipv6-address-token-id: ::2
+    enblue:
+      dhcp6: yes
+      ipv6-address-generation: eui64
+      ipv6-address-token-id: "::2"''')
+        self.assert_nm({'engreen': '''[connection]
+id=netplan-engreen
+type=ethernet
+interface-name=engreen
+
+[ethernet]
+wake-on-lan=0
+
+[ipv4]
+method=link-local
+
+[ipv6]
+method=auto
+addr-gen-mode=0
+token=::2
+''',
+                        'enblue': '''[connection]
+id=netplan-enblue
+type=ethernet
+interface-name=enblue
+
+[ethernet]
+wake-on-lan=0
+
+[ipv4]
+method=link-local
+
+[ipv6]
+method=auto
+addr-gen-mode=0
+token=::2
 '''})
 
     def test_eth_manual_addresses(self):

--- a/tests/generator/test_common.py
+++ b/tests/generator/test_common.py
@@ -638,11 +638,10 @@ UseMTU=true
   ethernets:
     engreen:
       dhcp6: yes
-      ipv6-address-token-id: ::2
+      ipv6-address-token: ::2
     enblue:
       dhcp6: yes
-      ipv6-address-generation: eui64
-      ipv6-address-token-id: "::2"''')
+      ipv6-address-token: "::2"''')
         self.assert_networkd({'engreen.network': '''[Match]\nName=engreen\n
 [Network]
 DHCP=ipv6
@@ -923,11 +922,10 @@ addr-gen-mode=0
   ethernets:
     engreen:
       dhcp6: yes
-      ipv6-address-token-id: ::2
+      ipv6-address-token: ::2
     enblue:
       dhcp6: yes
-      ipv6-address-generation: eui64
-      ipv6-address-token-id: "::2"''')
+      ipv6-address-token: "::2"''')
         self.assert_nm({'engreen': '''[connection]
 id=netplan-engreen
 type=ethernet

--- a/tests/generator/test_errors.py
+++ b/tests/generator/test_errors.py
@@ -354,9 +354,9 @@ class TestConfigErrors(TestBase):
   renderer: NetworkManager
   ethernets:
     engreen:
-      ipv6-address-token-id: "::2"
-      ipv6-address-generation: stable-privacy''', expect_fail=True)
-        self.assertIn("engreen: ipv6-address-generation and ipv6-address-token-id are mutually exclusive", err)
+      ipv6-address-token: "::2"
+      ipv6-address-generation: eui64''', expect_fail=True)
+        self.assertIn("engreen: ipv6-address-generation and ipv6-address-token are mutually exclusive", err)
 
     def test_invalid_addr_gen_token(self):
         err = self.generate('''network:
@@ -364,8 +364,8 @@ class TestConfigErrors(TestBase):
   renderer: NetworkManager
   ethernets:
     engreen:
-      ipv6-address-token-id: INVALID''', expect_fail=True)
-        self.assertIn("invalid ipv6-address-token-id 'INVALID'", err)
+      ipv6-address-token: INVALID''', expect_fail=True)
+        self.assertIn("invalid ipv6-address-token 'INVALID'", err)
 
     def test_invalid_address_node_type(self):
         err = self.generate('''network:

--- a/tests/generator/test_errors.py
+++ b/tests/generator/test_errors.py
@@ -345,8 +345,27 @@ class TestConfigErrors(TestBase):
   version: 2
   ethernets:
     engreen:
-      ipv6-address-generation: eui64''', expect_fail=True)
-        self.assertIn("ERROR: engreen: ipv6-address-generation is not supported by networkd", err)
+      ipv6-address-generation: stable-privacy''', expect_fail=True)
+        self.assertIn("ERROR: engreen: ipv6-address-generation mode is not supported by networkd", err)
+
+    def test_addr_gen_mode_and_addr_gen_token(self):
+        err = self.generate('''network:
+  version: 2
+  renderer: NetworkManager
+  ethernets:
+    engreen:
+      ipv6-address-token-id: "::2"
+      ipv6-address-generation: stable-privacy''', expect_fail=True)
+        self.assertIn("engreen: ipv6-address-generation and ipv6-address-token-id are mutually exclusive", err)
+
+    def test_invalid_addr_gen_token(self):
+        err = self.generate('''network:
+  version: 2
+  renderer: NetworkManager
+  ethernets:
+    engreen:
+      ipv6-address-token-id: INVALID''', expect_fail=True)
+        self.assertIn("invalid ipv6-address-token-id 'INVALID'", err)
 
     def test_invalid_address_node_type(self):
         err = self.generate('''network:

--- a/tests/integration/ethernets.py
+++ b/tests/integration/ethernets.py
@@ -213,6 +213,21 @@ class _CommonTests():
         self.generate_and_settle()
         self.assert_iface_up(self.dev_e_client, ['inet6 2600:'], ['inet 192.168'])
 
+    def test_ip6_token(self):
+        self.setup_eth('slaac')
+        with open(self.config, 'w') as f:
+            f.write('''network:
+  version: 2
+  renderer: %(r)s
+  ethernets:
+    %(ec)s:
+      dhcp6: yes
+      accept-ra: yes
+      ipv6-address-token-id: ::42
+    %(e2c)s: {}''' % {'r': self.backend, 'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
+        self.generate_and_settle()
+        self.assert_iface_up(self.dev_e_client, ['inet6 2600::42/64'])
+
 
 @unittest.skipIf("networkd" not in test_backends,
                      "skipping as networkd backend tests are disabled")

--- a/tests/integration/ethernets.py
+++ b/tests/integration/ethernets.py
@@ -223,7 +223,7 @@ class _CommonTests():
     %(ec)s:
       dhcp6: yes
       accept-ra: yes
-      ipv6-address-token-id: ::42
+      ipv6-address-token: ::42
     %(e2c)s: {}''' % {'r': self.backend, 'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
         self.generate_and_settle()
         self.assert_iface_up(self.dev_e_client, ['inet6 2600::42/64'])


### PR DESCRIPTION
## Description
This allows to statically configure the IPv6 host ID (low 64 bits) when auto-generated IPv6 addressing is used (i.e. DHCPv6 stateless, SLAAC).

It introduces one new YAML key in the schema: `ipv6-address-token-id`.

Fixes LP: #1737976

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [x] New/changed keys in YAML format are documented.
- [x] \(Optional\) Closes an open bug in Launchpad: https://bugs.launchpad.net/ubuntu/+source/nplan/+bug/1737976

