### PR TITLE
generate: implement just-in-time behaviour for generate

### DIFF
--- a/doc/netplan-generate.md
+++ b/doc/netplan-generate.md
@@ -25,6 +25,11 @@ configuration.
 You will not normally need to run this directly as it is run by
 **netplan apply**, **netplan try**, or at boot.
 
+Only if executed during the systemd ``initializing`` phase
+(i.e. "Early bootup, before ``basic.target`` is reached"), will
+it attempt to start/apply the newly created service units.
+**Requires feature: generate-just-in-time**
+
 For details of the configuration file format, see **netplan**(5).
 
 # OPTIONS

--- a/src/generate.c
+++ b/src/generate.c
@@ -67,7 +67,7 @@ check_called_just_in_time()
 static void
 start_unit_jit(gchar *unit)
 {
-    const gchar *argv[] = { "/bin/systemctl", "start", "--no-block", unit, NULL };
+    const gchar *argv[] = { "/bin/systemctl", "start", "--no-block", "--no-ask-password", unit, NULL };
     g_spawn_sync(NULL, (gchar**)argv, NULL, G_SPAWN_DEFAULT, NULL, NULL, NULL, NULL, NULL, NULL);
 };
 // LCOV_EXCL_END

--- a/src/generate.c
+++ b/src/generate.c
@@ -312,6 +312,7 @@ int main(int argc, char** argv)
         g_assert(f != NULL);
         fclose(f);
     } else if (check_called_just_in_time()) {
+        /* netplan-feature: generate-just-in-time */
         /* When booting with cloud-init, network configuration
          * might be provided just-in-time. Specifically after
          * system-generators were executed, but before

--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -4,9 +4,10 @@
 # Wifi (mac80211-hwsim). These need to be run in a VM and do change the system
 # configuration.
 #
-# Copyright (C) 2018 Canonical, Ltd.
+# Copyright (C) 2018-2020 Canonical, Ltd.
 # Author: Martin Pitt <martin.pitt@ubuntu.com>
 # Author: Mathieu Trudel-Lapierre <mathieu.trudel-lapierre@canonical.com>
+# Author: Lukas Märdian <lukas.maerdian@canonical.com>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -407,3 +408,12 @@ class IntegrationTestsBase(unittest.TestCase):
         p = subprocess.Popen(['systemctl', 'is-active', unit], stdout=subprocess.PIPE)
         out = p.communicate()[0]
         return p.returncode == 0 or out.startswith(b'activating')
+
+
+class IntegrationTestReboot(IntegrationTestsBase):
+
+    def tearDown(self):
+        # Do not tearDown in the middle of a reboot test
+        # Only after the 2nd part of the test ran (after reboot)
+        if os.getenv('AUTOPKGTEST_REBOOT_MARK'):
+            super().tearDown()

--- a/tests/integration/cloud-init.py
+++ b/tests/integration/cloud-init.py
@@ -1,0 +1,106 @@
+#!/usr/bin/python3
+#
+# Integration tests for complex networking scenarios
+# (ie. mixes of various features, may test real live cases)
+#
+# These need to be run in a VM and do change the system
+# configuration.
+#
+# Copyright (C) 2020 Canonical, Ltd.
+# Author: Lukas Märdian <lukas.maerdian@canonical.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import sys
+import os
+import time
+import subprocess
+import unittest
+
+from base import IntegrationTestReboot, test_backends
+
+
+@unittest.skipIf("networkd" not in test_backends,
+                     "skipping as networkd backend tests are disabled")
+class TestSpecialReboot(IntegrationTestReboot):
+    backend = 'networkd'
+
+    def test_generate_start_services_just_in_time(self):
+        self.setup_eth(None)
+        MARKER = 'cloud_init_generate'
+        # PART 1: set up the requried files before rebooting
+        if os.getenv('AUTOPKGTEST_REBOOT_MARK') != MARKER:
+            # any netplan YAML config
+            with open(self.config, 'w') as f:
+                f.write('''network:
+  ethernets:
+    ethbn:
+      match: {name: %(ec)s}
+      dhcp4: true''' % {'ec': self.dev_e_client})
+            # Prepare a dummy netplan service unit, which will be moved to /run/systemd/system/
+            # during early boot, as if it would have been created by 'netplan generate'
+            with open ('/netplan-dummy.service', 'w') as f:
+                f.write('''[Unit]
+Description=Check if this dummy is properly started by systemd
+
+[Service]
+Type=oneshot
+# Keep it running, so we can verify it was properly started
+RemainAfterExit=yes
+ExecStart=echo "Doing nothing ..."
+''')
+            # A service simulating cloud-init, calling 'netplan generate' during early boot
+            # at the 'initialization' phase of systemd (before basic.target is reached).
+            with open ('/etc/systemd/system/cloud-init-dummy.service', 'w') as f:
+                f.write('''[Unit]
+Description=Simulating cloud-init's 'netplan generate' call during early boot
+DefaultDependencies=no
+Before=basic.target
+After=sysinit.target
+
+[Install]
+WantedBy=multi-user.target
+
+[Service]
+Type=oneshot
+# Keep it running, so we can verify it was properly started
+RemainAfterExit=yes
+# Simulate creating a new service unit (i.e. netplan-wpa-*.service / netplan-ovs-*.service)
+ExecStart=/bin/mv /netplan-dummy.service /run/systemd/system/
+ExecStart=/usr/sbin/netplan generate
+''')
+            subprocess.check_call(['systemctl', '--quiet', 'enable', 'cloud-init-dummy.service'])
+            subprocess.check_call(['systemctl', '--quiet', 'disable', 'systemd-networkd.service'])
+            subprocess.check_call(['/tmp/autopkgtest-reboot', MARKER])
+        # PART 2: after reboot verify all (newly created) services have been started
+        else:
+            self.addCleanup(subprocess.call, ['rm', '/run/systemd/system/netplan-dummy.service'])
+            self.addCleanup(subprocess.call, ['rm', '/etc/systemd/system/cloud-init-dummy.service'])
+            self.addCleanup(subprocess.call, ['systemctl', '--quiet', 'disable', 'cloud-init-dummy.service'])
+            
+            time.sleep(5)  # Give some time for systemd to finish the boot transaction
+            # Verify our cloud-init simulation worked
+            out = subprocess.check_output(['systemctl', 'status', 'cloud-init-dummy.service'], universal_newlines=True)
+            self.assertIn('Active: active (exited)', out)
+            self.assertIn('mv /netplan-dummy.service /run/systemd/system/ (code=exited, status=0/SUCCESS)', out)
+            self.assertIn('netplan generate (code=exited, status=0/SUCCESS)', out)
+            # Verify the previously disabled networkd is running again
+            out = subprocess.check_output(['systemctl', 'status', 'systemd-networkd.service'], universal_newlines=True)
+            self.assertIn('Active: active (running)', out)
+            # Verify the newly created services were started just-in-time
+            out = subprocess.check_output(['systemctl', 'status', 'netplan-dummy.service'], universal_newlines=True)
+            self.assertIn('Active: active (exited)', out)
+            self.assertIn('echo Doing nothing ... (code=exited, status=0/SUCCESS)', out)
+
+
+unittest.main(testRunner=unittest.TextTestRunner(stream=sys.stdout, verbosity=2))


### PR DESCRIPTION
If system is initializing (basic.target not reached yet), and `netplan
generate` is called ensure that any netplan generated service units
are added to the initial boot transaction.

This should resolve cloud-init first-time booting with
systemd-networkd disabled, or with requirement to add wlan/wifi units.


## Description

I've tested this by sideloading this new code branch to lxd container.

Disabling systemd-networkd `systemctl disable systemd-networkd`

Removing `rm -rf /etc/netplan/50-cloud-init.yaml /var/log/cloud-init-output.log /var/log/cloud-init.log`

Executing `cloud-init clean`

And rebooting.

On reboot, I observed, that despite not being enabled systemd-networkd & netplan-ovs-cleanup did start or attempted to start, at the right time during initial boot, and correctly ordered before reaching network.target / network-online.target.

The below was tested on focal.

```
# journalctl -u systemd-networkd -u systemd-networkd.socket -u systemd-networkd-wait-online -u network.target -u basic.target -u network-online.target -u netplan-ovs-cleanup.service -b
-- Logs begin at Mon 2020-09-07 15:46:59 UTC, end at Mon 2020-09-07 23:17:01 UTC. --
Sep 07 22:56:13 wealthy-shiner systemd[1]: Listening on Network Service Netlink Socket.
Sep 07 22:56:13 wealthy-shiner systemd[1]: Condition check resulted in OpenVSwitch configuration for cleanup being skipped.
Sep 07 22:56:13 wealthy-shiner systemd[1]: Starting Network Service...
Sep 07 22:56:13 wealthy-shiner systemd-networkd[183]: eth0: IPv6 successfully enabled
Sep 07 22:56:13 wealthy-shiner systemd-networkd[183]: Enumeration completed
Sep 07 22:56:13 wealthy-shiner systemd[1]: Started Network Service.
Sep 07 22:56:13 wealthy-shiner systemd[1]: Reached target Network.
Sep 07 22:56:13 wealthy-shiner systemd[1]: Starting Wait for Network to be Configured...
Sep 07 22:56:13 wealthy-shiner systemd-networkd[183]: eth0: DHCPv4 address 10.54.137.244/24 via 10.54.137.1
Sep 07 22:56:13 wealthy-shiner systemd-networkd[183]: eth0: Gained IPv6LL
Sep 07 22:56:13 wealthy-shiner systemd-networkd-wait-online[184]: managing: eth0
Sep 07 22:56:13 wealthy-shiner systemd[1]: Finished Wait for Network to be Configured.
Sep 07 22:56:14 wealthy-shiner systemd[1]: Reached target Network is Online.
Sep 07 22:56:14 wealthy-shiner systemd[1]: Reached target Basic System.
```

This thus implements the just-in-time nature of ensuring that required units from netplan are started during boot, even if netplan configuration arrives on disk, just-in-time, before network-pre.target.

Furthermore, we could potentially completely eliminate requirement for cloud-init to call `netplan generate` by-hand if we were to add a service unit which does `ExecStart=/usr/bin/netplan generate` and is wanted by the `network-pre.target`. That is true, because cloud-init-local.service is before network-pre.target and ensures that network configuration is on disk before network-pre.target is starting.

## Checklist

- [x] Runs `make check` successfully.
- [ ] Retains 100% code coverage (`make check-coverage`).

Coverage is reduced! but this code path will need at integration test-suite that requires root, as newly added code paths must not be called with a root-dir arg.

- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Closes an open bug in Launchpad.