### PR TITLE
Remove version information from the description of the info flag

### DIFF
--- a/netplan/cli/commands/info.py
+++ b/netplan/cli/commands/info.py
@@ -25,7 +25,7 @@ class NetplanInfo(utils.NetplanCommand):
 
     def __init__(self):
         super().__init__(command_id='info',
-                         description='Show current netplan version and available features',
+                         description='Show available features',
                          leaf=True)
 
     def run(self):  # pragma: nocover (covered in autopkgtest)


### PR DESCRIPTION
## Description
Remove version information from the `info` flag description. Version information has been removed [in this commit](https://github.com/CanonicalLtd/netplan/commit/9ea105bef2cea28916213aad93a37ea85d89fdbc), but the message hasn't been updated.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [x] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Closes an open bug in Launchpad.

