### PR TITLE
Fix MAAS/OVS first boot for single NIC/PXE systems

### DIFF
--- a/src/openvswitch.c
+++ b/src/openvswitch.c
@@ -38,8 +38,9 @@ write_ovs_systemd_unit(const char* id, const GString* cmds, const char* rootdir,
     g_string_append_printf(s, "Description=OpenVSwitch configuration for %s\n", id);
     g_string_append(s, "DefaultDependencies=no\n");
     /* run any ovs-netplan unit only after openvswitch-switch.service is ready */
-    g_string_append_printf(s, "Wants=openvswitch-switch.service\n");
-    g_string_append_printf(s, "After=openvswitch-switch.service\n");
+    g_string_append_printf(s, "Wants=ovsdb-server.service\n");
+    g_string_append_printf(s, "After=ovsdb-server.service\n");
+    g_string_append_printf(s, "Before=systemd-networkd.service\n");
     if (physical) {
         id_escaped = systemd_escape((char*) id);
         g_string_append_printf(s, "Requires=sys-subsystem-net-devices-%s.device\n", id_escaped);

--- a/src/openvswitch.c
+++ b/src/openvswitch.c
@@ -40,7 +40,6 @@ write_ovs_systemd_unit(const char* id, const GString* cmds, const char* rootdir,
     /* run any ovs-netplan unit only after openvswitch-switch.service is ready */
     g_string_append_printf(s, "Wants=ovsdb-server.service\n");
     g_string_append_printf(s, "After=ovsdb-server.service\n");
-    g_string_append_printf(s, "Before=systemd-networkd.service\n");
     if (physical) {
         id_escaped = systemd_escape((char*) id);
         g_string_append_printf(s, "Requires=sys-subsystem-net-devices-%s.device\n", id_escaped);

--- a/tests/generator/base.py
+++ b/tests/generator/base.py
@@ -47,7 +47,7 @@ ND_DHCP6_NOMTU = '[Match]\nName=%s\n\n[Network]\nDHCP=ipv6\nLinkLocalAddressing=
 ND_DHCPYES = '[Match]\nName=%s\n\n[Network]\nDHCP=yes\nLinkLocalAddressing=ipv6\n\n[DHCP]\nRouteMetric=100\nUseMTU=true\n'
 ND_DHCPYES_NOMTU = '[Match]\nName=%s\n\n[Network]\nDHCP=yes\nLinkLocalAddressing=ipv6\n\n[DHCP]\nRouteMetric=100\nUseMTU=false\n'
 _OVS_BASE = '[Unit]\nDescription=OpenVSwitch configuration for %(iface)s\nDefaultDependencies=no\n\
-Wants=ovsdb-server.service\nAfter=ovsdb-server.service\nBefore=systemd-networkd.service\n'
+Wants=ovsdb-server.service\nAfter=ovsdb-server.service\n'
 OVS_PHYSICAL = _OVS_BASE + 'Requires=sys-subsystem-net-devices-%(iface)s.device\nAfter=sys-subsystem-net-devices-%(iface)s\
 .device\nAfter=netplan-ovs-cleanup.service\nBefore=network.target\nWants=network.target\n%(extra)s'
 OVS_VIRTUAL = _OVS_BASE + 'After=netplan-ovs-cleanup.service\nBefore=network.target\nWants=network.target\n%(extra)s'

--- a/tests/generator/base.py
+++ b/tests/generator/base.py
@@ -47,7 +47,7 @@ ND_DHCP6_NOMTU = '[Match]\nName=%s\n\n[Network]\nDHCP=ipv6\nLinkLocalAddressing=
 ND_DHCPYES = '[Match]\nName=%s\n\n[Network]\nDHCP=yes\nLinkLocalAddressing=ipv6\n\n[DHCP]\nRouteMetric=100\nUseMTU=true\n'
 ND_DHCPYES_NOMTU = '[Match]\nName=%s\n\n[Network]\nDHCP=yes\nLinkLocalAddressing=ipv6\n\n[DHCP]\nRouteMetric=100\nUseMTU=false\n'
 _OVS_BASE = '[Unit]\nDescription=OpenVSwitch configuration for %(iface)s\nDefaultDependencies=no\n\
-Wants=openvswitch-switch.service\nAfter=openvswitch-switch.service\n'
+Wants=ovsdb-server.service\nAfter=ovsdb-server.service\nBefore=systemd-networkd.service\n'
 OVS_PHYSICAL = _OVS_BASE + 'Requires=sys-subsystem-net-devices-%(iface)s.device\nAfter=sys-subsystem-net-devices-%(iface)s\
 .device\nAfter=netplan-ovs-cleanup.service\nBefore=network.target\nWants=network.target\n%(extra)s'
 OVS_VIRTUAL = _OVS_BASE + 'After=netplan-ovs-cleanup.service\nBefore=network.target\nWants=network.target\n%(extra)s'


### PR DESCRIPTION
## Description
Netplan's Open vSwitch helper units are started too late, which makes `systemd-networkd-wait-online.service` fail the first time it is started. This leads to `cloud-init init` running in an invalid state, thus failing, which in turn makes the system (deployed via MAAS) end up with broken networking.

The helper units only depend on OVSDB, which is started in `network-pre.target`, thus we can make them depend on `ovsdb-server.service` instead of `openvswitch-switch.service`, to avoid failures in `wait-online`.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [x] \(Optional\) Closes an open bug in Launchpad: https://bugs.launchpad.net/cloud-init/+bug/1898997

