### PR TITLE
DBus Config Management (try-improvement)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,8 +46,8 @@ libnetplan.so.$(NETPLAN_SOVER): parse.o util.o validation.o error.o
 generate: libnetplan.so.$(NETPLAN_SOVER) nm.o networkd.o openvswitch.o generate.o sriov.o
 	$(CC) $(BUILDFLAGS) $(CFLAGS) $(LDFLAGS) -o $@ $^ -L. -lnetplan `pkg-config --cflags --libs glib-2.0 gio-2.0 yaml-0.1 uuid`
 
-netplan-dbus: src/dbus.c src/_features.h
-	$(CC) $(BUILDFLAGS) $(CFLAGS) $(LDFLAGS) -o $@ $^ `pkg-config --cflags --libs libsystemd glib-2.0`
+netplan-dbus: src/dbus.c src/_features.h util.o
+	$(CC) $(BUILDFLAGS) $(CFLAGS) $(LDFLAGS) -o $@ $^ `pkg-config --cflags --libs libsystemd glib-2.0 gio-2.0`
 
 src/_features.h: src/[^_]*.[hc]
 	printf "#include <stddef.h>\nstatic const char *feature_flags[] __attribute__((__unused__)) = {\n" > $@

--- a/dbus/io.netplan.Netplan.conf
+++ b/dbus/io.netplan.Netplan.conf
@@ -11,6 +11,8 @@
     <allow send_destination="io.netplan.Netplan"
            send_interface="io.netplan.Netplan"/>
     <allow send_destination="io.netplan.Netplan"
+           send_interface="io.netplan.Netplan.Config"/>
+    <allow send_destination="io.netplan.Netplan"
            send_interface="org.freedesktop.DBus.Introspectable"/>
   </policy>
 

--- a/netplan/cli/commands/set.py
+++ b/netplan/cli/commands/set.py
@@ -36,7 +36,7 @@ class NetplanSet(utils.NetplanCommand):
     def run(self):
         self.parser.add_argument('key_value', type=str,
                                  help='The nested key=value pair in dotted format. Value can be NULL to delete a key.')
-        self.parser.add_argument('--origin-hint', type=str, default='90-netplan-set',
+        self.parser.add_argument('--origin-hint', type=str, default='70-netplan-set',
                                  help='Can be used to help choose a name for the overwrite YAML file. \
                                        A .yaml suffix will be appended automatically.')
         self.parser.add_argument('--root-dir', default='/',

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -51,9 +51,12 @@ terminate_try_child_process(int status, NetplanData *d, const char *config_id)
         path = g_strdup_printf("/io/netplan/Netplan/config/%s", config_id);
         r = sd_bus_message_new_signal(d->bus, &msg, path,
                                       "io.netplan.Netplan.Config", "Changed");
-    } else
+    }
+    /* Currently disabled in favor of io.netplan.Netplan.Config Changed() signal
+    else
         r = sd_bus_message_new_signal(d->bus, &msg, "/io/netplan/Netplan",
                                       "io.netplan.Netplan", "Changed");
+    */
     if (r < 0) {
         // LCOV_EXCL_START
         fprintf(stderr, "Could not create .Changed() signal: %s\n", strerror(-r));
@@ -77,8 +80,10 @@ _try_accept(bool accept, sd_bus_message *m, NetplanData *d, sd_bus_error *ret_er
     if (!accept) signal = SIGINT;
 
     /* Child does not exist or exited already ... */
+    /* Not needed, as io.netplan.Netplan Try() is diabled for now
     if (d->try_pid < 0)
         return sd_bus_reply_method_return(m, "b", false);
+    */
 
     /* Do not send the accept/reject signal, if this call is for another config state */
     if (d->handler_id != NULL && g_strcmp0(d->config_id, d->handler_id))
@@ -317,8 +322,11 @@ method_set(sd_bus_message *m, void *userdata, sd_bus_error *ret_error)
 
     if (!!strcmp(origin_hint, ""))
         origin = g_strdup_printf("--origin-hint=%s", origin_hint);
+
+    /* Not needed as io.netplan.Netplan methods are disabled
     else
         origin = g_strdup("");
+    */
 
     if (d->config_id)
         root_dir = g_strdup_printf("--root-dir=%s/netplan-config-%s", g_get_tmp_dir(), d->config_id);
@@ -375,9 +383,11 @@ method_try(sd_bus_message *m, void *userdata, sd_bus_error *ret_error)
     NetplanData *d = userdata;
 
     /* Fail if another 'netplan try' process is already running.
-     * 'try_pid' can be pre-set to G_MAXINT, if called via method_config_try() */
+     * 'try_pid' can be pre-set to G_MAXINT, if called via method_config_try()
+     * Not needed as io.netplan.Netplan Try() is currently disabled
     if (d->try_pid > 0 && d->try_pid != G_MAXINT)
         return sd_bus_error_setf(ret_error, SD_BUS_ERROR_FAILED, "cannot run netplan try: already running");
+    */
 
     if (sd_bus_message_read_basic (m, 'u', &seconds) < 0)
         return sd_bus_error_setf(ret_error, SD_BUS_ERROR_FAILED, "cannot extract timeout_seconds"); // LCOV_EXCL_LINE
@@ -625,10 +635,12 @@ static const sd_bus_vtable netplan_vtable[] = {
     SD_BUS_VTABLE_START(0),
     SD_BUS_METHOD("Apply", "", "b", method_apply, 0),
     SD_BUS_METHOD("Info", "", "a(sv)", method_info, 0),
+    /* Disabled for now, use methods from io.netplan.Netplan.Config instead
     SD_BUS_METHOD("Get", "", "s", method_get, 0),
     SD_BUS_METHOD("Set", "ss", "b", method_set, 0),
     SD_BUS_METHOD("Try", "u", "b", method_try, 0),
     SD_BUS_METHOD("Cancel", "", "b", method_cancel, 0),
+    */
     SD_BUS_METHOD("Config", "", "o", method_config, 0),
     SD_BUS_VTABLE_END
 };

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -139,6 +139,7 @@ _copy_yaml_state(char *src_root, char *dst_root, sd_bus_error *ret_error)
             g_object_unref(source);
             g_object_unref(dest);
             g_free(dest_path);
+            globfree(&gl);
             return r;
             // LCOV_EXCL_STOP
         }

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -17,13 +17,6 @@
 #include "_features.h"
 #include "util.h"
 
-// LCOV_EXCL_START
-/* XXX: (cyphermox)
- * This file  is completely excluded from coverage on purpose. Tests should
- * still include code in here, but sadly coverage does not appear to
- * correctly capture tests being run over a DBus bus.
- */
-
 typedef struct {
     sd_bus *bus;
     sd_event_source *try_es;
@@ -45,7 +38,7 @@ terminate_try_child_process(int status, NetplanData *d, const char *config_id)
     int r = 0;
 
     if (!WIFEXITED(status))
-        fprintf(stderr, "'netplan try' exited with status: %d\n", WEXITSTATUS(status));
+        fprintf(stderr, "'netplan try' exited with status: %d\n", WEXITSTATUS(status)); // LCOV_EXCL_LINE
 
     /* Cleanup current 'netplan try' child process */
     sd_event_source_unref(d->try_es);
@@ -62,13 +55,15 @@ terminate_try_child_process(int status, NetplanData *d, const char *config_id)
         r = sd_bus_message_new_signal(d->bus, &msg, "/io/netplan/Netplan",
                                       "io.netplan.Netplan", "Changed");
     if (r < 0) {
+        // LCOV_EXCL_START
         fprintf(stderr, "Could not create .Changed() signal: %s\n", strerror(-r));
         return r;
+        // LCOV_EXCL_STOP
     }
 
     r = sd_bus_send(d->bus, msg, NULL);
     if (r < 0)
-        fprintf(stderr, "Could not send .Changed() signal: %s\n", strerror(-r));
+        fprintf(stderr, "Could not send .Changed() signal: %s\n", strerror(-r)); // LCOV_EXCL_LINE
     sd_bus_message_unrefp(&msg);
     return r;
 }
@@ -103,7 +98,7 @@ _try_accept(bool accept, sd_bus_message *m, NetplanData *d, sd_bus_error *ret_er
     waitpid(d->try_pid, &status, 0);
     g_spawn_check_exit_status(status, &error);
     if (error != NULL)
-        return sd_bus_error_setf(ret_error, SD_BUS_ERROR_FAILED, "netplan try failed: %s", error->message);
+        return sd_bus_error_setf(ret_error, SD_BUS_ERROR_FAILED, "netplan try failed: %s", error->message); // LCOV_EXCL_LINE
 
     terminate_try_child_process(status, d, d->config_id);
     return sd_bus_reply_method_return(m, "b", true);
@@ -116,8 +111,10 @@ _copy_yaml_state(char *src_root, char *dst_root, sd_bus_error *ret_error)
     g_autoptr(GError) err = NULL;
     int r = find_yaml_glob(src_root, &gl);
     if (!!r)
+        // LCOV_EXCL_START
         return sd_bus_error_setf(ret_error, SD_BUS_ERROR_FAILED,
                                  "Failed glob for YAML files\n");
+        // LCOV_EXCL_STOP
 
     /* Copy all *.yaml files from "/SRC_ROOT/{etc,run,lib}/netplan/" to
      * "/DST_ROOT/{etc,run,lib}/netplan/" */
@@ -134,6 +131,7 @@ _copy_yaml_state(char *src_root, char *dst_root, sd_bus_error *ret_error)
                                  |G_FILE_COPY_ALL_METADATA,
                     NULL, NULL, NULL, &err);
         if (err != NULL) {
+            // LCOV_EXCL_START
             r = sd_bus_error_setf(ret_error, SD_BUS_ERROR_FAILED,
                                   "Failed to copy file %s -> %s: %s\n",
                                   g_file_get_path(source), g_file_get_path(dest),
@@ -142,6 +140,7 @@ _copy_yaml_state(char *src_root, char *dst_root, sd_bus_error *ret_error)
             g_object_unref(dest);
             g_free(dest_path);
             return r;
+            // LCOV_EXCL_STOP
         }
         g_object_unref(source);
         g_object_unref(dest);
@@ -208,6 +207,7 @@ method_apply(sd_bus_message *m, void *userdata, sd_bus_error *ret_error)
        argv[0] = getenv("DBUS_TEST_NETPLAN_CMD");
 
     g_spawn_sync("/", argv, NULL, 0, NULL, NULL, &stdout, &stderr, &exit_status, &err);
+    // LCOV_EXCL_START
     if (err != NULL)
         return sd_bus_error_setf(ret_error, SD_BUS_ERROR_FAILED,
                                  "cannot run netplan apply: %s", err->message);
@@ -216,6 +216,7 @@ method_apply(sd_bus_message *m, void *userdata, sd_bus_error *ret_error)
        return sd_bus_error_setf(ret_error, SD_BUS_ERROR_FAILED,
                                 "netplan apply failed: %s\nstdout: '%s'\nstderr: '%s'",
                                 err->message, stdout, stderr);
+    // LCOV_EXCL_STOP
 
     return sd_bus_reply_method_return(m, "b", true);
 }
@@ -231,39 +232,39 @@ method_info(sd_bus_message *m, void *userdata, sd_bus_error *ret_error)
 
     exit_status = sd_bus_message_new_method_return(m, &reply);
     if (exit_status < 0)
-       return exit_status;
+       return exit_status; // LCOV_EXCL_LINE
 
     exit_status = sd_bus_message_open_container(reply, 'a', "(sv)");
     if (exit_status < 0)
-       return exit_status;
+       return exit_status; // LCOV_EXCL_LINE
 
     exit_status = sd_bus_message_open_container(reply, 'r', "sv");
     if (exit_status < 0)
-       return exit_status;
+       return exit_status; // LCOV_EXCL_LINE
 
     exit_status = sd_bus_message_append(reply, "s", "Features");
     if (exit_status < 0)
-       return exit_status;
+       return exit_status; // LCOV_EXCL_LINE
 
     exit_status = sd_bus_message_open_container(reply, 'v', "as");
     if (exit_status < 0)
-       return exit_status;
+       return exit_status; // LCOV_EXCL_LINE
 
     exit_status = sd_bus_message_append_strv(reply, (char**)feature_flags);
     if (exit_status < 0)
-       return exit_status;
+       return exit_status; // LCOV_EXCL_LINE
 
     exit_status = sd_bus_message_close_container(reply);
     if (exit_status < 0)
-       return exit_status;
+       return exit_status; // LCOV_EXCL_LINE
 
     exit_status = sd_bus_message_close_container(reply);
     if (exit_status < 0)
-       return exit_status;
+       return exit_status; // LCOV_EXCL_LINE
 
     exit_status = sd_bus_message_close_container(reply);
     if (exit_status < 0)
-       return exit_status;
+       return exit_status; // LCOV_EXCL_LINE
 
     return sd_bus_send(NULL, reply, NULL);
 }
@@ -288,11 +289,11 @@ method_get(sd_bus_message *m, void *userdata, sd_bus_error *ret_error)
 
     g_spawn_sync("/", argv, NULL, 0, NULL, NULL, &stdout, &stderr, &exit_status, &err);
     if (err != NULL)
-        return sd_bus_error_setf(ret_error, SD_BUS_ERROR_FAILED, "cannot run netplan get: %s", err->message);
+        return sd_bus_error_setf(ret_error, SD_BUS_ERROR_FAILED, "cannot run netplan get: %s", err->message); // LCOV_EXCL_LINE
 
     g_spawn_check_exit_status(exit_status, &err);
     if (err != NULL)
-       return sd_bus_error_setf(ret_error, SD_BUS_ERROR_FAILED, "netplan get failed: %s\nstdout: '%s'\nstderr: '%s'", err->message, stdout, stderr);
+       return sd_bus_error_setf(ret_error, SD_BUS_ERROR_FAILED, "netplan get failed: %s\nstdout: '%s'\nstderr: '%s'", err->message, stdout, stderr); // LCOV_EXCL_LINE
 
     return sd_bus_reply_method_return(m, "s", stdout);
 }
@@ -311,7 +312,7 @@ method_set(sd_bus_message *m, void *userdata, sd_bus_error *ret_error)
     char *origin_hint = NULL;
 
     if (sd_bus_message_read(m, "ss", &config_delta, &origin_hint) < 0)
-        return sd_bus_error_setf(ret_error, SD_BUS_ERROR_FAILED, "cannot extract config_delta or origin_hint");
+        return sd_bus_error_setf(ret_error, SD_BUS_ERROR_FAILED, "cannot extract config_delta or origin_hint"); // LCOV_EXCL_LINE
 
     if (!!strcmp(origin_hint, ""))
         origin = g_strdup_printf("--origin-hint=%s", origin_hint);
@@ -328,11 +329,11 @@ method_set(sd_bus_message *m, void *userdata, sd_bus_error *ret_error)
 
     g_spawn_sync("/", argv, NULL, 0, NULL, NULL, &stdout, &stderr, &exit_status, &err);
     if (err != NULL)
-        return sd_bus_error_setf(ret_error, SD_BUS_ERROR_FAILED, "cannot run netplan set %s: %s", config_delta, err->message);
+        return sd_bus_error_setf(ret_error, SD_BUS_ERROR_FAILED, "cannot run netplan set %s: %s", config_delta, err->message); // LCOV_EXCL_LINE
 
     g_spawn_check_exit_status(exit_status, &err);
     if (err != NULL)
-       return sd_bus_error_setf(ret_error, SD_BUS_ERROR_FAILED, "netplan set failed: %s\nstdout: '%s'\nstderr: '%s'", err->message, stdout, stderr);
+       return sd_bus_error_setf(ret_error, SD_BUS_ERROR_FAILED, "netplan set failed: %s\nstdout: '%s'\nstderr: '%s'", err->message, stdout, stderr); // LCOV_EXCL_LINE
 
     return sd_bus_reply_method_return(m, "b", true);
 }
@@ -378,7 +379,7 @@ method_try(sd_bus_message *m, void *userdata, sd_bus_error *ret_error)
         return sd_bus_error_setf(ret_error, SD_BUS_ERROR_FAILED, "cannot run netplan try: already running");
 
     if (sd_bus_message_read_basic (m, 'u', &seconds) < 0)
-        return sd_bus_error_setf(ret_error, SD_BUS_ERROR_FAILED, "cannot extract timeout_seconds");
+        return sd_bus_error_setf(ret_error, SD_BUS_ERROR_FAILED, "cannot extract timeout_seconds"); // LCOV_EXCL_LINE
     if (seconds > 0)
         timeout = g_strdup_printf("--timeout=%u", seconds);
     gchar *argv[] = {SBINDIR "/" "netplan", "try", timeout, NULL};
@@ -392,8 +393,10 @@ method_try(sd_bus_message *m, void *userdata, sd_bus_error *ret_error)
                              G_SPAWN_DO_NOT_REAP_CHILD|G_SPAWN_STDOUT_TO_DEV_NULL,
                              NULL, NULL, &d->try_pid, &child_stdin, NULL, NULL, &err);
     if (err)
+        // LCOV_EXCL_START
         return sd_bus_error_setf(ret_error, SD_BUS_ERROR_FAILED,
                                  "cannot run netplan try: %s", err->message);
+        // LCOV_EXCL_STOP
 
     /* Register an event handler, trigged when the child process exits */
     if (d->config_id)
@@ -401,8 +404,10 @@ method_try(sd_bus_message *m, void *userdata, sd_bus_error *ret_error)
     r = sd_event_add_child(sd_bus_get_event(d->bus), &d->try_es, d->try_pid,
                            WEXITED, netplan_try_cancelled_cb, d);
     if (r < 0)
+        // LCOV_EXCL_START
         return sd_bus_error_setf(ret_error, SD_BUS_ERROR_FAILED,
                                  "cannot watch 'netplan try' child: %s", strerror(-r));
+        // LCOV_EXCL_STOP
 
     return sd_bus_reply_method_return(m, "b", true);
 }
@@ -492,8 +497,10 @@ method_config_try(sd_bus_message *m, void *userdata, sd_bus_error *ret_error)
         subdir = g_strdup_printf("%s/%s/netplan", path, NETPLAN_SUBDIRS[i]);
         r = g_mkdir_with_parents(subdir, 0700);
         if (r < 0)
+            // LCOV_EXCL_START
             return sd_bus_error_setf(ret_error, SD_BUS_ERROR_FAILED,
                                     "Failed to create '%s': %s\n", subdir, strerror(errno));
+            // LCOV_EXCL_STOP
         g_free(subdir);
     }
 
@@ -573,20 +580,24 @@ method_config(sd_bus_message *m, void *userdata, sd_bus_error *ret_error)
     /* Create temp. directory, according to "netplan-config-XXXXXX" template */
     path = g_dir_make_tmp("netplan-config-XXXXXX", &err);
     if (err != NULL)
+        // LCOV_EXCL_START
         return sd_bus_error_setf(ret_error, SD_BUS_ERROR_FAILED,
                                  "Failed to create temp dir: %s\n", err->message);
+        // LCOV_EXCL_STOP
 
     /* Extract the last 6 randomly generated chars (i.e. "XXXXXX" from template) */
     const char *id = path + strlen(path) - 6;
     const char *obj_path = g_strdup_printf("/io/netplan/Netplan/config/%s", id);
     r = sd_bus_add_object_vtable(d->bus, &slot, obj_path,
                                  "io.netplan.Netplan.Config", config_vtable, userdata);
+    // LCOV_EXCL_START
     if (r < 0)
         return sd_bus_error_setf(ret_error, SD_BUS_ERROR_FAILED,
                                  "Failed to add 'config' object: %s\n", strerror(-r));
     if (!g_hash_table_insert(d->config_slots, g_strdup(id), slot))
         return sd_bus_error_setf(ret_error, SD_BUS_ERROR_FAILED,
                                  "Failed to add object slot to HashTable\n");
+    // LCOV_EXCL_STOP
 
     /* Create {etc,run,lib} subdirs with owner r/w permissions */
     char *subdir = NULL;
@@ -594,8 +605,10 @@ method_config(sd_bus_message *m, void *userdata, sd_bus_error *ret_error)
         subdir = g_strdup_printf("%s/%s/netplan", path, NETPLAN_SUBDIRS[i]);
         r = g_mkdir_with_parents(subdir, 0700);
         if (r < 0)
+            // LCOV_EXCL_START
             return sd_bus_error_setf(ret_error, SD_BUS_ERROR_FAILED,
                                     "Failed to create '%s': %s\n", subdir, strerror(errno));
+            // LCOV_EXCL_STOP
         g_free(subdir);
     }
 
@@ -621,6 +634,14 @@ static const sd_bus_vtable netplan_vtable[] = {
  * DBus setup
  */
 
+static int
+terminate_mainloop_cb(sd_event_source *es, const struct signalfd_siginfo *si, void* userdata) {
+    sd_event *event = userdata;
+    /* Gracefully terminate the mainloop, to write GCOV output */
+    sd_event_exit(event, 0);
+    return 0;
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -635,16 +656,21 @@ main(int argc, char *argv[])
     if (getenv("DBUS_TEST_NETPLAN_ROOT") != 0)
         NETPLAN_ROOT = getenv("DBUS_TEST_NETPLAN_ROOT");
 
+    /* TODO: consider sd_bus_default(&bus) for easier testing on session/user bus */
     r = sd_bus_open_system(&bus);
     if (r < 0) {
+        // LCOV_EXCL_START
         fprintf(stderr, "Failed to connect to system bus: %s\n", strerror(-r));
         goto finish;
+        // LCOV_EXCL_STOP
     }
 
     r = sd_event_new(&event);
     if (r < 0) {
+        // LCOV_EXCL_START
         fprintf(stderr, "Failed to create event loop: %s\n", strerror(-r));
         goto finish;
+        // LCOV_EXCL_STOP
     }
 
     /* Initialize the userdata */
@@ -661,8 +687,10 @@ main(int argc, char *argv[])
                                  netplan_vtable,
                                  data);
     if (r < 0) {
+        // LCOV_EXCL_START
         fprintf(stderr, "Failed to issue method call: %s\n", strerror(-r));
         goto finish;
+        // LCOV_EXCL_STOP
     }
 
     r = sd_bus_request_name(bus, "io.netplan.Netplan", 0);
@@ -673,19 +701,23 @@ main(int argc, char *argv[])
 
     r = sd_bus_attach_event(bus, event, SD_EVENT_PRIORITY_NORMAL);
     if (r < 0) {
+        // LCOV_EXCL_START
         fprintf(stderr, "Failed to attach event loop: %s\n", strerror(-r));
         goto finish;
+        // LCOV_EXCL_STOP
     }
 
     /* Mask the SIGCHLD signal, so we can listen to it via mainloop */
     sigemptyset(&mask);
     sigaddset(&mask, SIGCHLD);
+    sigaddset(&mask, SIGTERM);
     sigprocmask(SIG_BLOCK, &mask, NULL);
 
     /* Start the event loop, wait for requests */
+    sd_event_add_signal(event, NULL, SIGTERM, terminate_mainloop_cb, event);
     r = sd_event_loop(event);
     if (r < 0)
-        fprintf(stderr, "Failed mainloop: %s\n", strerror(-r));
+        fprintf(stderr, "Failed mainloop: %s\n", strerror(-r)); // LCOV_EXCL_LINE
 finish:
     g_free(data);
     sd_event_unref(event);
@@ -695,5 +727,3 @@ finish:
 
     return r < 0 ? EXIT_FAILURE : EXIT_SUCCESS;
 }
-
-// LCOV_EXCL_STOP

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -146,6 +146,7 @@ _copy_yaml_state(char *src_root, char *dst_root, sd_bus_error *ret_error)
         g_object_unref(dest);
         g_free(dest_path);
     }
+    globfree(&gl);
     return r;
 }
 

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -515,7 +515,9 @@ method_config_try(sd_bus_message *m, void *userdata, sd_bus_error *ret_error)
     _copy_yaml_state(state_dir, NETPLAN_ROOT, ret_error);
 
     /* Exec try */
-    return method_try(m, userdata, ret_error);
+    r = method_try(m, userdata, ret_error);
+    d->config_id = NULL;
+    return r;
 }
 
 static int
@@ -589,7 +591,7 @@ method_config(sd_bus_message *m, void *userdata, sd_bus_error *ret_error)
     const char *id = path + strlen(path) - 6;
     const char *obj_path = g_strdup_printf("/io/netplan/Netplan/config/%s", id);
     r = sd_bus_add_object_vtable(d->bus, &slot, obj_path,
-                                 "io.netplan.Netplan.Config", config_vtable, userdata);
+                                 "io.netplan.Netplan.Config", config_vtable, d);
     // LCOV_EXCL_START
     if (r < 0)
         return sd_bus_error_setf(ret_error, SD_BUS_ERROR_FAILED,

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -489,7 +489,7 @@ method_config_try(sd_bus_message *m, void *userdata, sd_bus_error *ret_error)
     char *subdir = NULL;
     for (int i = 0; i < 3; i++) {
         subdir = g_strdup_printf("%s/%s/netplan", path, NETPLAN_SUBDIRS[i]);
-        r = g_mkdir_with_parents(subdir, 0600);
+        r = g_mkdir_with_parents(subdir, 0700);
         if (r < 0)
             return sd_bus_error_setf(ret_error, SD_BUS_ERROR_FAILED,
                                     "Failed to create '%s': %s\n", subdir, strerror(errno));
@@ -591,7 +591,7 @@ method_config(sd_bus_message *m, void *userdata, sd_bus_error *ret_error)
     char *subdir = NULL;
     for (int i = 0; i < 3; i++) {
         subdir = g_strdup_printf("%s/%s/netplan", path, NETPLAN_SUBDIRS[i]);
-        r = g_mkdir_with_parents(subdir, 0600);
+        r = g_mkdir_with_parents(subdir, 0700);
         if (r < 0)
             return sd_bus_error_setf(ret_error, SD_BUS_ERROR_FAILED,
                                     "Failed to create '%s': %s\n", subdir, strerror(errno));

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -426,12 +426,6 @@ method_try(sd_bus_message *m, void *userdata, sd_bus_error *ret_error)
     return sd_bus_reply_method_return(m, "b", true);
 }
 
-static int
-method_cancel(sd_bus_message *m, void *userdata, sd_bus_error *ret_error)
-{
-    return _try_accept(FALSE, m, userdata, ret_error);
-}
-
 /**
  * io.netplan.Netplan.Config methods
  */
@@ -567,7 +561,7 @@ method_config_cancel(sd_bus_message *m, void *userdata, sd_bus_error *ret_error)
 
     /* Cancel the current 'netplan try' process */
     if (d->try_pid > 0)
-        r = method_cancel(m, d, ret_error);
+        r = _try_accept(FALSE, m, d, ret_error);
     else
         r = sd_bus_reply_method_return(m, "b", true);
 

--- a/src/generate.c
+++ b/src/generate.c
@@ -79,7 +79,7 @@ start_unit_jit(gchar *unit)
     const gchar *argv[] = { "/bin/systemctl", "start", "--no-block", "--no-ask-password", unit, NULL };
     g_spawn_sync(NULL, (gchar**)argv, NULL, G_SPAWN_DEFAULT, NULL, NULL, NULL, NULL, NULL, NULL);
 };
-// LCOV_EXCL_END
+// LCOV_EXCL_STOP
 
 static void
 nd_iterator_list(gpointer value, gpointer user_data)
@@ -320,7 +320,7 @@ int main(int argc, char** argv)
                 g_free(unit_name);
             }
         }
-        // LCOV_EXCL_END
+        // LCOV_EXCL_STOP
     }
 
     return 0;

--- a/src/util.c
+++ b/src/util.c
@@ -63,7 +63,7 @@ void g_string_free_to_file(GString* s, const char* rootdir, const char* path, co
         // LCOV_EXCL_START
         g_fprintf(stderr, "ERROR: cannot create file %s: %s\n", path, error->message);
         exit(1);
-        // LCOV_EXCL_END
+        // LCOV_EXCL_STOP
     }
 }
 

--- a/src/util.h
+++ b/src/util.h
@@ -15,6 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#define __USE_MISC
 #include <glob.h>
 #pragma once
 

--- a/src/util.h
+++ b/src/util.h
@@ -15,6 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <glob.h>
 #pragma once
 
 extern GHashTable* wifi_frequency_24;
@@ -23,6 +24,7 @@ extern GHashTable* wifi_frequency_5;
 void safe_mkdir_p_dir(const char* file_path);
 void g_string_free_to_file(GString* s, const char* rootdir, const char* path, const char* suffix);
 void unlink_glob(const char* rootdir, const char* _glob);
+int find_yaml_glob(const char* rootdir, glob_t* out_glob);
 
 int wifi_get_freq24(int channel);
 int wifi_get_freq5(int channel);

--- a/tests/dbus/test_dbus.py
+++ b/tests/dbus/test_dbus.py
@@ -308,18 +308,10 @@ class TestNetplanDBus(unittest.TestCase):
         # Create test YAML
         test_file_lib = os.path.join(self.tmp, 'lib', 'netplan', 'lib_test.yaml')
         with open(test_file_lib, 'w') as f:
-            f.write("""network:
-  version: 2
-  ethernets:
-    ethlib:
-      dhcp4: true""")
+            f.write('TESTING-lib')
         test_file_run = os.path.join(self.tmp, 'run', 'netplan', 'run_test.yaml')
         with open(test_file_run, 'w') as f:
-            f.write("""network:
-  version: 2
-  ethernets:
-    ethrun:
-      dhcp4: true""")
+            f.write('TESTING-run')
         self.assertTrue(os.path.isfile(os.path.join(self.tmp, 'etc', 'netplan', 'main_test.yaml')))
         self.assertTrue(os.path.isfile(os.path.join(self.tmp, 'lib', 'netplan', 'lib_test.yaml')))
         self.assertTrue(os.path.isfile(os.path.join(self.tmp, 'run', 'netplan', 'run_test.yaml')))
@@ -422,6 +414,12 @@ class TestNetplanDBus(unittest.TestCase):
     def test_netplan_dbus_config_apply(self):
         cid = self._new_config_object()
         tmpdir = '/tmp/netplan-config-{}'.format(cid)
+        with open(os.path.join(tmpdir, 'etc', 'netplan', 'apply_test.yaml'), 'w') as f:
+            f.write('TESTING-apply')
+        with open(os.path.join(tmpdir, 'lib', 'netplan', 'apply_test.yaml'), 'w') as f:
+            f.write('TESTING-apply')
+        with open(os.path.join(tmpdir, 'run', 'netplan', 'apply_test.yaml'), 'w') as f:
+            f.write('TESTING-apply')
 
         # Verify .Config.Apply() teardown of the config object and state dirs
         BUSCTL_NETPLAN_CMD = [
@@ -435,6 +433,11 @@ class TestNetplanDBus(unittest.TestCase):
         self.assertEqual(b'b true\n', out)
         self.assertEquals(self.mock_netplan_cmd.calls(), [["netplan", "apply"]])
         self.assertFalse(os.path.isdir(tmpdir))
+
+        # Verify the new YAML files were copied over
+        self.assertTrue(os.path.isfile(os.path.join(self.tmp, 'etc', 'netplan', 'apply_test.yaml')))
+        self.assertTrue(os.path.isfile(os.path.join(self.tmp, 'run', 'netplan', 'apply_test.yaml')))
+        self.assertTrue(os.path.isfile(os.path.join(self.tmp, 'lib', 'netplan', 'apply_test.yaml')))
 
         # Verify the object is gone from the bus
         err = self._check_dbus_error(BUSCTL_NETPLAN_CMD)

--- a/tests/dbus/test_dbus.py
+++ b/tests/dbus/test_dbus.py
@@ -292,13 +292,13 @@ class TestNetplanDBus(unittest.TestCase):
         ])
 
     def test_netplan_dbus_try(self):
-        self.mock_netplan_cmd.set_timeout(5)
+        self.mock_netplan_cmd.set_timeout(2)
         BUSCTL_NETPLAN_TRY = [
             "busctl", "call", "--system",
             "io.netplan.Netplan",
             "/io/netplan/Netplan",
             "io.netplan.Netplan",
-            "Try", "u", "5",
+            "Try", "u", "2",
         ]
         BUSCTL_NETPLAN_CANCEL = [
             "busctl", "call", "--system",
@@ -325,7 +325,7 @@ class TestNetplanDBus(unittest.TestCase):
         self.assertEqual("b true\n", output.decode("utf-8"))
 
         self.assertEquals(self.mock_netplan_cmd.calls(), [
-                ["netplan", "try", "--timeout=5"],
+                ["netplan", "try", "--timeout=2"],
                 # ["netplan", "apply"],  # This should NOT be here, as the current Try() was accepted, not re-applied
         ])
 
@@ -469,7 +469,7 @@ class TestNetplanDBus(unittest.TestCase):
         self.assertIn('Unknown object \'/io/netplan/Netplan/config/{}\''.format(cid), err)
 
     def test_netplan_dbus_config_try_cancel(self):
-        self.mock_netplan_cmd.set_timeout(5)
+        self.mock_netplan_cmd.set_timeout(2)
         cid = self._new_config_object()
         tmpdir = '/tmp/netplan-config-{}'.format(cid)
         backup = '/tmp/netplan-config-BACKUP'
@@ -486,7 +486,7 @@ class TestNetplanDBus(unittest.TestCase):
             "io.netplan.Netplan",
             "/io/netplan/Netplan/config/{}".format(cid),
             "io.netplan.Netplan.Config",
-            "Try", "u", "5",
+            "Try", "u", "2",
         ]
         out = subprocess.check_output(BUSCTL_NETPLAN_CMD)
         self.assertEqual(b'b true\n', out)
@@ -532,7 +532,7 @@ class TestNetplanDBus(unittest.TestCase):
         self.assertIn('Unknown object \'/io/netplan/Netplan/config/{}\''.format(cid), err)
 
         # Verify 'netplan try' has been called
-        self.assertEquals(self.mock_netplan_cmd.calls(), [["netplan", "try", "--timeout=5"]])
+        self.assertEquals(self.mock_netplan_cmd.calls(), [["netplan", "try", "--timeout=2"]])
 
     def test_netplan_dbus_config_try_cb(self):
         self.mock_netplan_cmd.set_timeout(1)  # self-quit after 1 sec
@@ -575,14 +575,14 @@ class TestNetplanDBus(unittest.TestCase):
         self.assertEquals(self.mock_netplan_cmd.calls(), [["netplan", "try", "--timeout=1"]])
 
     def test_netplan_dbus_config_try_try(self):
-        self.mock_netplan_cmd.set_timeout(5)
+        self.mock_netplan_cmd.set_timeout(2)
         cid = self._new_config_object()
         BUSCTL_NETPLAN_CMD = [
             "busctl", "call", "--system",
             "io.netplan.Netplan",
             "/io/netplan/Netplan/config/{}".format(cid),
             "io.netplan.Netplan.Config",
-            "Try", "u", "5",
+            "Try", "u", "2",
         ]
         out = subprocess.check_output(BUSCTL_NETPLAN_CMD)
         self.assertEqual(b'b true\n', out)
@@ -592,20 +592,20 @@ class TestNetplanDBus(unittest.TestCase):
             "io.netplan.Netplan",
             "/io/netplan/Netplan",
             "io.netplan.Netplan",
-            "Try", "u", "5",
+            "Try", "u", "2",
         ]
         err = self._check_dbus_error(BUSCTL_NETPLAN_CMD2)
         self.assertIn('cannot run netplan try: already running', err)
 
     def test_netplan_dbus_config_try_apply(self):
-        self.mock_netplan_cmd.set_timeout(5)
+        self.mock_netplan_cmd.set_timeout(2)
         cid = self._new_config_object()
         BUSCTL_NETPLAN_CMD = [
             "busctl", "call", "--system",
             "io.netplan.Netplan",
             "/io/netplan/Netplan/config/{}".format(cid),
             "io.netplan.Netplan.Config",
-            "Try", "u", "5",
+            "Try", "u", "2",
         ]
         out = subprocess.check_output(BUSCTL_NETPLAN_CMD)
         self.assertEqual(b'b true\n', out)
@@ -617,19 +617,18 @@ class TestNetplanDBus(unittest.TestCase):
             "io.netplan.Netplan",
             "Apply",
         ]
-        # FIXME: this seems to be FLAKY, but why?
         err = self._check_dbus_error(BUSCTL_NETPLAN_CMD2)
         self.assertIn('Another \'netplan try\' process is already running', err)
 
     def test_netplan_dbus_config_try_config_try(self):
-        self.mock_netplan_cmd.set_timeout(5)
+        self.mock_netplan_cmd.set_timeout(2)
         cid = self._new_config_object()
         BUSCTL_NETPLAN_CMD = [
             "busctl", "call", "--system",
             "io.netplan.Netplan",
             "/io/netplan/Netplan/config/{}".format(cid),
             "io.netplan.Netplan.Config",
-            "Try", "u", "5",
+            "Try", "u", "2",
         ]
         out = subprocess.check_output(BUSCTL_NETPLAN_CMD)
         self.assertEqual(b'b true\n', out)
@@ -640,7 +639,7 @@ class TestNetplanDBus(unittest.TestCase):
             "io.netplan.Netplan",
             "/io/netplan/Netplan/config/{}".format(cid2),
             "io.netplan.Netplan.Config",
-            "Try", "u", "5",
+            "Try", "u", "2",
         ]
         err = self._check_dbus_error(BUSCTL_NETPLAN_CMD2)
         self.assertIn('Another Try() is currently in progress: PID ', err)

--- a/tests/dbus/test_dbus.py
+++ b/tests/dbus/test_dbus.py
@@ -238,96 +238,96 @@ class TestNetplanDBus(unittest.TestCase):
         output = subprocess.check_output(BUSCTL_NETPLAN_INFO)
         self.assertIn("Features", output.decode("utf-8"))
 
-    def test_netplan_dbus_get(self):
-        self.mock_netplan_cmd.set_output("""network:
-  ens3:
-    addresses:
-    - 1.2.3.4/24
-    - 5.6.7.8/24
-    dhcp4: true""")
-        BUSCTL_NETPLAN_GET = [
-            "busctl", "call", "--system",
-            "io.netplan.Netplan",
-            "/io/netplan/Netplan",
-            "io.netplan.Netplan",
-            "Get"
-        ]
-        out = subprocess.check_output(BUSCTL_NETPLAN_GET, universal_newlines=True)
-        self.assertIn(r's "network:\n  ens3:\n    addresses:\n    - 1.2.3.4/24\n    - 5.6.7.8/24\n    dhcp4: true\n"', out)
-        self.assertEquals(self.mock_netplan_cmd.calls(), [
-                ["netplan", "get", "all"],
-        ])
-
-    def test_netplan_dbus_set(self):
-        BUSCTL_NETPLAN_SET = [
-            "busctl", "call", "--system",
-            "io.netplan.Netplan",
-            "/io/netplan/Netplan",
-            "io.netplan.Netplan",
-            "Set", "ss",
-            "ethernets.eth0={addresses: [5.6.7.8/24], dhcp4: false}",
-            ""
-        ]
-        out = subprocess.check_output(BUSCTL_NETPLAN_SET, universal_newlines=True)
-        self.assertEqual(out, "b true\n")
-        self.assertEquals(self.mock_netplan_cmd.calls(), [
-                ["netplan", "set", "ethernets.eth0={addresses: [5.6.7.8/24], dhcp4: false}"],
-        ])
-
-    def test_netplan_dbus_set_origin(self):
-        BUSCTL_NETPLAN_SET = [
-            "busctl", "call", "--system",
-            "io.netplan.Netplan",
-            "/io/netplan/Netplan",
-            "io.netplan.Netplan",
-            "Set", "ss",
-            "ethernets.eth0={addresses: [5.6.7.8/24], dhcp4: false}",
-            "99_snapd"
-        ]
-        out = subprocess.check_output(BUSCTL_NETPLAN_SET, universal_newlines=True)
-        self.assertEqual(out, "b true\n")
-        self.assertEquals(self.mock_netplan_cmd.calls(), [
-                ["netplan", "set", "ethernets.eth0={addresses: [5.6.7.8/24], dhcp4: false}",
-                 "--origin-hint=99_snapd"],
-        ])
-
-    def test_netplan_dbus_try(self):
-        self.mock_netplan_cmd.set_timeout(2)
-        BUSCTL_NETPLAN_TRY = [
-            "busctl", "call", "--system",
-            "io.netplan.Netplan",
-            "/io/netplan/Netplan",
-            "io.netplan.Netplan",
-            "Try", "u", "2",
-        ]
-        BUSCTL_NETPLAN_CANCEL = [
-            "busctl", "call", "--system",
-            "io.netplan.Netplan",
-            "/io/netplan/Netplan",
-            "io.netplan.Netplan",
-            "Cancel",
-        ]
-        BUSCTL_NETPLAN_APPLY = [
-            "busctl", "call", "--system",
-            "io.netplan.Netplan",
-            "/io/netplan/Netplan",
-            "io.netplan.Netplan",
-            "Apply",
-        ]
-
-        output = subprocess.check_output(BUSCTL_NETPLAN_CANCEL)
-        self.assertEqual("b false\n", output.decode("utf-8"))
-
-        output = subprocess.check_output(BUSCTL_NETPLAN_TRY)
-        self.assertEqual("b true\n", output.decode("utf-8"))
-
-        output = subprocess.check_output(BUSCTL_NETPLAN_APPLY)
-        self.assertEqual("b true\n", output.decode("utf-8"))
-
-        self.assertEquals(self.mock_netplan_cmd.calls(), [
-                ["netplan", "try", "--timeout=2"],
-                # ["netplan", "apply"],  # This should NOT be here, as the current Try() was accepted, not re-applied
-        ])
+#    def test_netplan_dbus_get(self):
+#        self.mock_netplan_cmd.set_output("""network:
+#  ens3:
+#    addresses:
+#    - 1.2.3.4/24
+#    - 5.6.7.8/24
+#    dhcp4: true""")
+#        BUSCTL_NETPLAN_GET = [
+#            "busctl", "call", "--system",
+#            "io.netplan.Netplan",
+#            "/io/netplan/Netplan",
+#            "io.netplan.Netplan",
+#            "Get"
+#        ]
+#        out = subprocess.check_output(BUSCTL_NETPLAN_GET, universal_newlines=True)
+#        self.assertIn(r's "network:\n  ens3:\n    addresses:\n    - 1.2.3.4/24\n    - 5.6.7.8/24\n    dhcp4: true\n"', out)
+#        self.assertEquals(self.mock_netplan_cmd.calls(), [
+#                ["netplan", "get", "all"],
+#        ])
+#
+#    def test_netplan_dbus_set(self):
+#        BUSCTL_NETPLAN_SET = [
+#            "busctl", "call", "--system",
+#            "io.netplan.Netplan",
+#            "/io/netplan/Netplan",
+#            "io.netplan.Netplan",
+#            "Set", "ss",
+#            "ethernets.eth0={addresses: [5.6.7.8/24], dhcp4: false}",
+#            ""
+#        ]
+#        out = subprocess.check_output(BUSCTL_NETPLAN_SET, universal_newlines=True)
+#        self.assertEqual(out, "b true\n")
+#        self.assertEquals(self.mock_netplan_cmd.calls(), [
+#                ["netplan", "set", "ethernets.eth0={addresses: [5.6.7.8/24], dhcp4: false}"],
+#        ])
+#
+#    def test_netplan_dbus_set_origin(self):
+#        BUSCTL_NETPLAN_SET = [
+#            "busctl", "call", "--system",
+#            "io.netplan.Netplan",
+#            "/io/netplan/Netplan",
+#            "io.netplan.Netplan",
+#            "Set", "ss",
+#            "ethernets.eth0={addresses: [5.6.7.8/24], dhcp4: false}",
+#            "99_snapd"
+#        ]
+#        out = subprocess.check_output(BUSCTL_NETPLAN_SET, universal_newlines=True)
+#        self.assertEqual(out, "b true\n")
+#        self.assertEquals(self.mock_netplan_cmd.calls(), [
+#                ["netplan", "set", "ethernets.eth0={addresses: [5.6.7.8/24], dhcp4: false}",
+#                 "--origin-hint=99_snapd"],
+#        ])
+#
+#    def test_netplan_dbus_try(self):
+#        self.mock_netplan_cmd.set_timeout(2)
+#        BUSCTL_NETPLAN_TRY = [
+#            "busctl", "call", "--system",
+#            "io.netplan.Netplan",
+#            "/io/netplan/Netplan",
+#            "io.netplan.Netplan",
+#            "Try", "u", "2",
+#        ]
+#        BUSCTL_NETPLAN_CANCEL = [
+#            "busctl", "call", "--system",
+#            "io.netplan.Netplan",
+#            "/io/netplan/Netplan",
+#            "io.netplan.Netplan",
+#            "Cancel",
+#        ]
+#        BUSCTL_NETPLAN_APPLY = [
+#            "busctl", "call", "--system",
+#            "io.netplan.Netplan",
+#            "/io/netplan/Netplan",
+#            "io.netplan.Netplan",
+#            "Apply",
+#        ]
+#
+#        output = subprocess.check_output(BUSCTL_NETPLAN_CANCEL)
+#        self.assertEqual("b false\n", output.decode("utf-8"))
+#
+#        output = subprocess.check_output(BUSCTL_NETPLAN_TRY)
+#        self.assertEqual("b true\n", output.decode("utf-8"))
+#
+#        output = subprocess.check_output(BUSCTL_NETPLAN_APPLY)
+#        self.assertEqual("b true\n", output.decode("utf-8"))
+#
+#        self.assertEquals(self.mock_netplan_cmd.calls(), [
+#                ["netplan", "try", "--timeout=2"],
+#                # ["netplan", "apply"],  # This should NOT be here, as the current Try() was accepted, not re-applied
+#        ])
 
     def test_netplan_dbus_config(self):
         # Create test YAML
@@ -574,28 +574,28 @@ class TestNetplanDBus(unittest.TestCase):
         # Verify 'netplan try' has been called
         self.assertEquals(self.mock_netplan_cmd.calls(), [["netplan", "try", "--timeout=1"]])
 
-    def test_netplan_dbus_config_try_try(self):
-        self.mock_netplan_cmd.set_timeout(2)
-        cid = self._new_config_object()
-        BUSCTL_NETPLAN_CMD = [
-            "busctl", "call", "--system",
-            "io.netplan.Netplan",
-            "/io/netplan/Netplan/config/{}".format(cid),
-            "io.netplan.Netplan.Config",
-            "Try", "u", "2",
-        ]
-        out = subprocess.check_output(BUSCTL_NETPLAN_CMD)
-        self.assertEqual(b'b true\n', out)
-
-        BUSCTL_NETPLAN_CMD2 = [
-            "busctl", "call", "--system",
-            "io.netplan.Netplan",
-            "/io/netplan/Netplan",
-            "io.netplan.Netplan",
-            "Try", "u", "2",
-        ]
-        err = self._check_dbus_error(BUSCTL_NETPLAN_CMD2)
-        self.assertIn('cannot run netplan try: already running', err)
+#    def test_netplan_dbus_config_try_try(self):
+#        self.mock_netplan_cmd.set_timeout(2)
+#        cid = self._new_config_object()
+#        BUSCTL_NETPLAN_CMD = [
+#            "busctl", "call", "--system",
+#            "io.netplan.Netplan",
+#            "/io/netplan/Netplan/config/{}".format(cid),
+#            "io.netplan.Netplan.Config",
+#            "Try", "u", "2",
+#        ]
+#        out = subprocess.check_output(BUSCTL_NETPLAN_CMD)
+#        self.assertEqual(b'b true\n', out)
+#
+#        BUSCTL_NETPLAN_CMD2 = [
+#            "busctl", "call", "--system",
+#            "io.netplan.Netplan",
+#            "/io/netplan/Netplan",
+#            "io.netplan.Netplan",
+#            "Try", "u", "2",
+#        ]
+#        err = self._check_dbus_error(BUSCTL_NETPLAN_CMD2)
+#        self.assertIn('cannot run netplan try: already running', err)
 
     def test_netplan_dbus_config_try_apply(self):
         self.mock_netplan_cmd.set_timeout(2)

--- a/tests/dbus/test_dbus.py
+++ b/tests/dbus/test_dbus.py
@@ -27,6 +27,7 @@ if shutil.which('python3-coverage'):
 
 # Make sure we can import our development netplan.
 os.environ.update({'PYTHONPATH': '.'})
+NETPLAN_DBUS_CMD = os.path.join(os.path.dirname(__file__), "..", "..", "netplan-dbus")
 
 
 class MockCmd:
@@ -110,9 +111,8 @@ class TestNetplanDBus(unittest.TestCase):
         # run netplan-dbus in a fake system bus
         os.environ["DBUS_TEST_NETPLAN_CMD"] = self.mock_netplan_cmd.path
         os.environ["DBUS_TEST_NETPLAN_ROOT"] = self.tmp
-        p = subprocess.Popen(
-            os.path.join(os.path.dirname(__file__), "..", "..", "netplan-dbus"),
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        p = subprocess.Popen(NETPLAN_DBUS_CMD,
+                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         self.addCleanup(self._cleanup_netplan_dbus, p)
 
     def _cleanup_netplan_dbus(self, p):
@@ -178,6 +178,11 @@ class TestNetplanDBus(unittest.TestCase):
              "Apply",  # the method
              ],
         ])
+
+    def test_netplan_dbus_noroot(self):
+        r = subprocess.run(NETPLAN_DBUS_CMD, capture_output=True)
+        self.assertEquals(r.returncode, 1)
+        self.assertIn(b'Failed to acquire service name', r.stderr)
 
     def test_netplan_dbus_happy(self):
         BUSCTL_NETPLAN_APPLY = [

--- a/tests/dbus/test_dbus.py
+++ b/tests/dbus/test_dbus.py
@@ -464,7 +464,7 @@ class TestNetplanDBus(unittest.TestCase):
         ]
         out = subprocess.check_output(BUSCTL_NETPLAN_CMD)
         self.assertEqual(b'b true\n', out)
-        time.sleep(2)  # Give some time for the timeout to happen
+        time.sleep(1.5)  # Give some time for the timeout to happen
 
         # Verify the backup andconfig state dir are gone
         self.assertFalse(os.path.isdir(backup))

--- a/tests/dbus/test_dbus.py
+++ b/tests/dbus/test_dbus.py
@@ -238,97 +238,6 @@ class TestNetplanDBus(unittest.TestCase):
         output = subprocess.check_output(BUSCTL_NETPLAN_INFO)
         self.assertIn("Features", output.decode("utf-8"))
 
-#    def test_netplan_dbus_get(self):
-#        self.mock_netplan_cmd.set_output("""network:
-#  ens3:
-#    addresses:
-#    - 1.2.3.4/24
-#    - 5.6.7.8/24
-#    dhcp4: true""")
-#        BUSCTL_NETPLAN_GET = [
-#            "busctl", "call", "--system",
-#            "io.netplan.Netplan",
-#            "/io/netplan/Netplan",
-#            "io.netplan.Netplan",
-#            "Get"
-#        ]
-#        out = subprocess.check_output(BUSCTL_NETPLAN_GET, universal_newlines=True)
-#        self.assertIn(r's "network:\n  ens3:\n    addresses:\n    - 1.2.3.4/24\n    - 5.6.7.8/24\n    dhcp4: true\n"', out)
-#        self.assertEquals(self.mock_netplan_cmd.calls(), [
-#                ["netplan", "get", "all"],
-#        ])
-#
-#    def test_netplan_dbus_set(self):
-#        BUSCTL_NETPLAN_SET = [
-#            "busctl", "call", "--system",
-#            "io.netplan.Netplan",
-#            "/io/netplan/Netplan",
-#            "io.netplan.Netplan",
-#            "Set", "ss",
-#            "ethernets.eth0={addresses: [5.6.7.8/24], dhcp4: false}",
-#            ""
-#        ]
-#        out = subprocess.check_output(BUSCTL_NETPLAN_SET, universal_newlines=True)
-#        self.assertEqual(out, "b true\n")
-#        self.assertEquals(self.mock_netplan_cmd.calls(), [
-#                ["netplan", "set", "ethernets.eth0={addresses: [5.6.7.8/24], dhcp4: false}"],
-#        ])
-#
-#    def test_netplan_dbus_set_origin(self):
-#        BUSCTL_NETPLAN_SET = [
-#            "busctl", "call", "--system",
-#            "io.netplan.Netplan",
-#            "/io/netplan/Netplan",
-#            "io.netplan.Netplan",
-#            "Set", "ss",
-#            "ethernets.eth0={addresses: [5.6.7.8/24], dhcp4: false}",
-#            "99_snapd"
-#        ]
-#        out = subprocess.check_output(BUSCTL_NETPLAN_SET, universal_newlines=True)
-#        self.assertEqual(out, "b true\n")
-#        self.assertEquals(self.mock_netplan_cmd.calls(), [
-#                ["netplan", "set", "ethernets.eth0={addresses: [5.6.7.8/24], dhcp4: false}",
-#                 "--origin-hint=99_snapd"],
-#        ])
-#
-#    def test_netplan_dbus_try(self):
-#        self.mock_netplan_cmd.set_timeout(2)
-#        BUSCTL_NETPLAN_TRY = [
-#            "busctl", "call", "--system",
-#            "io.netplan.Netplan",
-#            "/io/netplan/Netplan",
-#            "io.netplan.Netplan",
-#            "Try", "u", "2",
-#        ]
-#        BUSCTL_NETPLAN_CANCEL = [
-#            "busctl", "call", "--system",
-#            "io.netplan.Netplan",
-#            "/io/netplan/Netplan",
-#            "io.netplan.Netplan",
-#            "Cancel",
-#        ]
-#        BUSCTL_NETPLAN_APPLY = [
-#            "busctl", "call", "--system",
-#            "io.netplan.Netplan",
-#            "/io/netplan/Netplan",
-#            "io.netplan.Netplan",
-#            "Apply",
-#        ]
-#
-#        output = subprocess.check_output(BUSCTL_NETPLAN_CANCEL)
-#        self.assertEqual("b false\n", output.decode("utf-8"))
-#
-#        output = subprocess.check_output(BUSCTL_NETPLAN_TRY)
-#        self.assertEqual("b true\n", output.decode("utf-8"))
-#
-#        output = subprocess.check_output(BUSCTL_NETPLAN_APPLY)
-#        self.assertEqual("b true\n", output.decode("utf-8"))
-#
-#        self.assertEquals(self.mock_netplan_cmd.calls(), [
-#                ["netplan", "try", "--timeout=2"],
-#                # ["netplan", "apply"],  # This should NOT be here, as the current Try() was accepted, not re-applied
-#        ])
-
     def test_netplan_dbus_config(self):
         # Create test YAML
         test_file_lib = os.path.join(self.tmp, 'lib', 'netplan', 'lib_test.yaml')
@@ -573,29 +482,6 @@ class TestNetplanDBus(unittest.TestCase):
 
         # Verify 'netplan try' has been called
         self.assertEquals(self.mock_netplan_cmd.calls(), [["netplan", "try", "--timeout=1"]])
-
-#    def test_netplan_dbus_config_try_try(self):
-#        self.mock_netplan_cmd.set_timeout(2)
-#        cid = self._new_config_object()
-#        BUSCTL_NETPLAN_CMD = [
-#            "busctl", "call", "--system",
-#            "io.netplan.Netplan",
-#            "/io/netplan/Netplan/config/{}".format(cid),
-#            "io.netplan.Netplan.Config",
-#            "Try", "u", "2",
-#        ]
-#        out = subprocess.check_output(BUSCTL_NETPLAN_CMD)
-#        self.assertEqual(b'b true\n', out)
-#
-#        BUSCTL_NETPLAN_CMD2 = [
-#            "busctl", "call", "--system",
-#            "io.netplan.Netplan",
-#            "/io/netplan/Netplan",
-#            "io.netplan.Netplan",
-#            "Try", "u", "2",
-#        ]
-#        err = self._check_dbus_error(BUSCTL_NETPLAN_CMD2)
-#        self.assertIn('cannot run netplan try: already running', err)
 
     def test_netplan_dbus_config_try_apply(self):
         self.mock_netplan_cmd.set_timeout(2)

--- a/tests/test_cli_get_set.py
+++ b/tests/test_cli_get_set.py
@@ -46,7 +46,7 @@ class TestSet(unittest.TestCase):
     '''Test netplan set'''
     def setUp(self):
         self.workdir = tempfile.TemporaryDirectory(prefix='netplan_')
-        self.file = '90-netplan-set.yaml'
+        self.file = '70-netplan-set.yaml'
         self.path = os.path.join(self.workdir.name, 'etc', 'netplan', self.file)
         os.makedirs(os.path.join(self.workdir.name, 'etc', 'netplan'))
 


### PR DESCRIPTION
## Description
This implements the `io.netplan.Netplan /io/netplan/Netplan io.netplan.Netplan Config` method, which creates new `/io/netplan/Netplan/config/<ID>` objects, providing the following methods:
* `io.netplan.Netplan.Config Get`
* `io.netplan.Netplan.Config Set`
* `io.netplan.Netplan.Config Try`
* `io.netplan.Netplan.Config Apply`
* `io.netplan.Netplan.Config Cancel`
And also the `io.netplan.Netplan.Config Changed` signal.

Each new config object will copy the current global netplan state (from `/etc/netplan`) to `/tmp/netplan-config-<ID>` then Get/Set can be called on that temp directory. On Apply/Try it will backup the current global config to `/tmp/netplan-config-BACKUP` and copy over the current config state to `/etc/netplan`. On revert the data from `/tmp/netplan-config-BACKUP` will be restored.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

