### PR TITLE
Documentation for get/set CLI and DBus Config/Try/Cancel/Apply/Get/Set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ PYFLAKES3 ?= $(shell which pyflakes-3 || which pyflakes3 || echo true)
 PYCODESTYLE3 ?= $(shell which pycodestyle-3 || which pycodestyle || which pep8 || echo true)
 NOSETESTS3 ?= $(shell which nosetests-3 || which nosetests3 || echo true)
 
-default: netplan/_features.py generate netplan-dbus dbus/io.netplan.Netplan.service doc/netplan.html doc/netplan.5 doc/netplan-generate.8 doc/netplan-apply.8 doc/netplan-try.8
+default: netplan/_features.py generate netplan-dbus dbus/io.netplan.Netplan.service doc/netplan.html doc/netplan.5 doc/netplan-generate.8 doc/netplan-apply.8 doc/netplan-try.8 doc/netplan-dbus.8
 
 %.o: src/%.c
 	$(CC) $(BUILDFLAGS) $(CFLAGS) $(LDFLAGS) -c $^ `pkg-config --cflags --libs glib-2.0 gio-2.0 yaml-0.1 uuid`

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ PYFLAKES3 ?= $(shell which pyflakes-3 || which pyflakes3 || echo true)
 PYCODESTYLE3 ?= $(shell which pycodestyle-3 || which pycodestyle || which pep8 || echo true)
 NOSETESTS3 ?= $(shell which nosetests-3 || which nosetests3 || echo true)
 
-default: netplan/_features.py generate netplan-dbus dbus/io.netplan.Netplan.service doc/netplan.html doc/netplan.5 doc/netplan-generate.8 doc/netplan-apply.8 doc/netplan-try.8 doc/netplan-dbus.8
+default: netplan/_features.py generate netplan-dbus dbus/io.netplan.Netplan.service doc/netplan.html doc/netplan.5 doc/netplan-generate.8 doc/netplan-apply.8 doc/netplan-try.8 doc/netplan-dbus.8 doc/netplan-get.8 doc/netplan-set.8
 
 %.o: src/%.c
 	$(CC) $(BUILDFLAGS) $(CFLAGS) $(LDFLAGS) -c $^ `pkg-config --cflags --libs glib-2.0 gio-2.0 yaml-0.1 uuid`

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,6 @@ libnetplan.so.$(NETPLAN_SOVER): parse.o util.o validation.o error.o
 	$(CC) -shared -Wl,-soname,libnetplan.so.$(NETPLAN_SOVER) $(BUILDFLAGS) $(CFLAGS) $(LDFLAGS) -o $@ $^ `pkg-config --libs glib-2.0 gio-2.0 yaml-0.1`
 	ln -snf libnetplan.so.$(NETPLAN_SOVER) libnetplan.so
 
-#generate: src/generate.[hc] src/parse.[hc] src/util.[hc] src/networkd.[hc] src/nm.[hc] src/validation.[hc] src/error.[hc]
 generate: libnetplan.so.$(NETPLAN_SOVER) nm.o networkd.o openvswitch.o generate.o sriov.o
 	$(CC) $(BUILDFLAGS) $(CFLAGS) $(LDFLAGS) -o $@ $^ -L. -lnetplan `pkg-config --cflags --libs glib-2.0 gio-2.0 yaml-0.1 uuid`
 

--- a/doc/manpage-footer.md
+++ b/doc/manpage-footer.md
@@ -1,3 +1,3 @@
 # SEE ALSO
 
-  **netplan-generate**(8), **netplan-apply**(8), **netplan-try**(8), **systemd-networkd**(8), **NetworkManager**(8)
+  **netplan-generate**(8), **netplan-apply**(8), **netplan-try**(8), **netplan-get**(8), **netplan-set**(8), **netplan-dbus**(8), **systemd-networkd**(8), **NetworkManager**(8)

--- a/doc/netplan-dbus.md
+++ b/doc/netplan-dbus.md
@@ -1,0 +1,39 @@
+---
+title: netplan-dbus
+section: 8
+author:
+- Lukas Märdian (<lukas.maerdian@canonical.com>)
+...
+
+# NAME
+
+netplan-dbus - daemon to access netplan's functionality via a DBus API
+
+# SYNOPSIS
+
+  **netplan-dbus**
+
+# DESCRIPTION
+
+**netplan-dbus** is a DBus daemon, providing ``io.netplan.Netplan`` on the system bus. The ``/io/netplan/Netplan`` object provides an ``io.netplan.Netplan`` interface, offering the following methods:
+
+ * ``Apply() -> b``: calls **netplan apply** and returns a success or failure status.
+ * ``Info() -> a(sv)``: returns a dict "Features -> as", containing an array of all available feature flags.
+ * ``Config() -> o``: prepares a new config object as ``/io/netplan/Netplan/config/<ID>``, by copying the current state from ``/{etc,run,lib}/netplan/*.yaml``
+
+The ``/io/netplan/Netplan/config/<ID>`` objects provide a ``io.netplan.Netplan.Config`` interface, offering the following methods:
+
+ * ``Get() -> s``: calls **netplan get --root-dir=/tmp/netplan-config-ID all** and returns the merged YAML config of the the given config object's state
+ * ``Set(s:CONFIG_DELTA, s:ORIGIN_HINT) -> b``: calls **netplan set --root-dir=/tmp/netplan-config-ID --origin-hint=<ORIGIN_HINT> CONFIG_DELTA**, where CONFIG_DELTA can be something like: ``network.ethernets.eth0.dhcp4=true`` and ORIGIN_HINT can be something like: ``70-snapd`` (it will then write the config to ``70-snapd.yaml``)
+ * ``Try(u:TIMEOUT_SEC) -> b``: replaces the main netplan configuration with this config object's state and calls **netplan try --timeout=TIMEOUT_SEC**
+ * ``Cancel() -> b``: rejects a currently running ``Try()`` attempt on this config object and/or discards the config object
+ * ``Apply() -> b``: replaces the main netplan configuration with this config object's state and calls **netplan apply**
+
+For information about the Apply()/Try()/Get()/Set() functionality, see
+**netplan-apply**(8)/**netplan-try**(8)/**netplan-get**(8)/**netplan-set**(8)
+accordingly. For details of the configuration file format, see **netplan**(5).
+
+# SEE ALSO
+
+  **netplan**(5), **netplan-apply**(8), **netplan-try**(8), **netplan-get**(8),
+  **netplan-set**(8)

--- a/doc/netplan-dbus.md
+++ b/doc/netplan-dbus.md
@@ -24,7 +24,10 @@ netplan-dbus - daemon to access netplan's functionality via a DBus API
 The ``/io/netplan/Netplan/config/<ID>`` objects provide a ``io.netplan.Netplan.Config`` interface, offering the following methods:
 
  * ``Get() -> s``: calls **netplan get --root-dir=/tmp/netplan-config-ID all** and returns the merged YAML config of the the given config object's state
- * ``Set(s:CONFIG_DELTA, s:ORIGIN_HINT) -> b``: calls **netplan set --root-dir=/tmp/netplan-config-ID --origin-hint=<ORIGIN_HINT> CONFIG_DELTA**, where CONFIG_DELTA can be something like: ``network.ethernets.eth0.dhcp4=true`` and ORIGIN_HINT can be something like: ``70-snapd`` (it will then write the config to ``70-snapd.yaml``)
+ * ``Set(s:CONFIG_DELTA, s:ORIGIN_HINT) -> b``: calls **netplan set --root-dir=/tmp/netplan-config-ID --origin-hint=ORIGIN_HINT CONFIG_DELTA**
+
+    CONFIG_DELTA can be something like: ``network.ethernets.eth0.dhcp4=true`` and ORIGIN_HINT can be something like: ``70-snapd`` (it will then write the config to ``70-snapd.yaml``). Once ``Set()`` is called on a config object, all other current and future config objects are being invalidated and cannot ``Set()`` or ``Try()/Apply()`` anymore, due to this pending dirty state. After the dirty config object is rejected via ``Cancel()``, the other config objects are valid again. If the dirty config object is accepted via ``Apply()``, newly created config objects will be valid, while the older states will stay invalid.
+
  * ``Try(u:TIMEOUT_SEC) -> b``: replaces the main netplan configuration with this config object's state and calls **netplan try --timeout=TIMEOUT_SEC**
  * ``Cancel() -> b``: rejects a currently running ``Try()`` attempt on this config object and/or discards the config object
  * ``Apply() -> b``: replaces the main netplan configuration with this config object's state and calls **netplan apply**

--- a/doc/netplan-get.md
+++ b/doc/netplan-get.md
@@ -1,0 +1,39 @@
+---
+title: netplan-get
+section: 8
+author:
+- Lukas Märdian (lukas.maerdian@canonical.com)
+...
+
+# NAME
+
+netplan-get - read merged netplan YAML configuration
+
+# SYNOPSIS
+
+  **netplan** [--debug] **get** -h | --help
+
+  **netplan** [--debug] **get** [--root-dir=ROOT_DIR] [key]
+
+# DESCRIPTION
+
+**netplan get [key]** reads all YAML files from ``/{etc,lib,run}/netplan/*.yaml`` and returns a merged view of the current configuration
+
+You can specify ``all`` as a key (the default) to get the full YAML tree or extract a subtree by specifying a nested key like: ``[network.]ethernets.eth0``.
+
+For details of the configuration file format, see **netplan**(5).
+
+# OPTIONS
+
+  -h, --help
+:    Print basic help.
+
+  --debug
+:    Print debugging output during the process.
+
+  --root-dir
+:    Read YAML files from this root instead of /
+
+# SEE ALSO
+
+  **netplan**(5), **netplan-set**(8), **netplan-dbus**(8)

--- a/doc/netplan-set.md
+++ b/doc/netplan-set.md
@@ -1,0 +1,42 @@
+---
+title: netplan-set
+section: 8
+author:
+- Lukas Märdian (lukas.maerdian@canonical.com)
+...
+
+# NAME
+
+netplan-set - write netplan YAML configuration snippets to file
+
+# SYNOPSIS
+
+  **netplan** [--debug] **set** -h | --help
+
+  **netplan** [--debug] **set** [--root-dir=ROOT_DIR] [--origin-hint=ORIGIN_HINT] [key=value]
+
+# DESCRIPTION
+
+**netplan set [key=value]** writes a given key/value pair or YAML subtree into a YAML file in ``/etc/netplan/*.yaml`` and validates its format.
+
+You can specify a single value as: ``"[network.]ethernets.eth0.dhcp4=[1.2.3.4/24, 5.6.7.8/24]"`` or a full subtree as: ``"[network.]ethernets.eth0={dhcp4: true, dhcp6: true}``.
+
+For details of the configuration file format, see **netplan**(5).
+
+# OPTIONS
+
+  -h, --help
+:    Print basic help.
+
+  --debug
+:    Print debugging output during the process.
+
+  --root-dir
+:    Write YAML files into this root instead of /
+
+  --origin-hint
+:    Specify the name of the overwrite YAML file, e.g.: ``70-netplan-set`` => ``/etc/netplan/70-netplan-set.yaml``
+
+# SEE ALSO
+
+  **netplan**(5), **netplan-get**(8), **netplan-dbus**(8)

--- a/doc/netplan-set.md
+++ b/doc/netplan-set.md
@@ -17,9 +17,9 @@ netplan-set - write netplan YAML configuration snippets to file
 
 # DESCRIPTION
 
-**netplan set [key=value]** writes a given key/value pair or YAML subtree into a YAML file in ``/etc/netplan/*.yaml`` and validates its format.
+**netplan set [key=value]** writes a given key/value pair or YAML subtree into a YAML file in ``/etc/netplan/`` and validates its format.
 
-You can specify a single value as: ``"[network.]ethernets.eth0.dhcp4=[1.2.3.4/24, 5.6.7.8/24]"`` or a full subtree as: ``"[network.]ethernets.eth0={dhcp4: true, dhcp6: true}``.
+You can specify a single value as: ``"[network.]ethernets.eth0.dhcp4=[1.2.3.4/24, 5.6.7.8/24]"`` or a full subtree as: ``"[network.]ethernets.eth0={dhcp4: true, dhcp6: true}"``.
 
 For details of the configuration file format, see **netplan**(5).
 

--- a/doc/netplan-try.md
+++ b/doc/netplan-try.md
@@ -21,6 +21,9 @@ netplan-try - try a configuration, optionally rolling it back
 automatically rolls it back if the user does not confirm the
 configuration within a time limit.
 
+A configuration can be confirmed or rejected interactively or by sending the
+SIGUSR1 or SIGINT signals.
+
 This may be especially useful on remote systems, to prevent an
 administrator being permanently locked out of systems in the case of a
 network configuration error.

--- a/examples/dbus_config_scenario.txt
+++ b/examples/dbus_config_scenario.txt
@@ -1,0 +1,41 @@
+# Example interaction with Netplan's DBus config API
+
+## Copy the current state from /{etc,run,lib}/netplan/*.yaml by creating a new config object
+$ busctl call io.netplan.Netplan /io/netplan/Netplan io.netplan.Netplan Config
+o "/io/netplan/Netplan/config/ULJIU0"
+
+## Read the merged YAML configuration
+$ busctl call io.netplan.Netplan /io/netplan/Netplan/config/ULJIU0 io.netplan.Netplan.Config Get
+s "network:\n  ethernets:\n    eth0:\n      dhcp4: true\n  renderer: networkd\n  version: 2\n"
+
+## Write a new config snippet into 70-snapd.yaml
+$ busctl call io.netplan.Netplan /io/netplan/Netplan/config/ULJIU0 io.netplan.Netplan.Config Set ss "ethernets.eth0={dhcp4: false, dhcp6: true}" "70-snapd"
+b true
+
+## Check the newly written configuration
+$ busctl call io.netplan.Netplan /io/netplan/Netplan/config/ULJIU0 io.netplan.Netplan.Config Get
+s "network:\n  ethernets:\n    eth0:\n      dhcp4: false\n      dhcp6: true\n  renderer: networkd\n  version: 2\n"
+
+## Try to apply the current config object's state
+$ busctl call io.netplan.Netplan /io/netplan/Netplan/config/ULJIU0 io.netplan.Netplan.Config Try u 20
+b true
+
+## Accept the Try() state within the 20 seconds timeout, if not it will be auto-rejected
+$ busctl call io.netplan.Netplan /io/netplan/Netplan/config/ULJIU0 io.netplan.Netplan.Config Apply
+b true
+
+[SIGNAL] io.netplan.Netplan /io/netplan/Netplan/config/ULJIU0 io.netplan.Netplan.Config Changed() is triggered
+[OBJECT] io.netplan.Netplan /io/netplan/Netplan/config/ULJIU0 is removed from the bus
+
+## Create a new config object and get the merged YAML config
+$ busctl call io.netplan.Netplan /io/netplan/Netplan io.netplan.Netplan Config
+o "/io/netplan/Netplan/config/KC0IU0
+$ busctl call io.netplan.Netplan /io/netplan/Netplan/config/KC0IU0 io.netplan.Netplan.Config Get
+s "network:\n  ethernets:\n    eth0:\n      dhcp4: false\n      dhcp6: true\n  renderer: networkd\n  version: 2\n"
+
+## Reject that config object again
+$ busctl call io.netplan.Netplan /io/netplan/Netplan/config/KC0IU0 io.netplan.Netplan.Config Cancel
+b true
+
+[SIGNAL] io.netplan.Netplan /io/netplan/Netplan/config/KC0IU0 io.netplan.Netplan.Config Changed() is triggered
+[OBJECT] io.netplan.Netplan /io/netplan/Netplan/config/KC0IU0 is removed from the bus

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -430,6 +430,7 @@ method_try(sd_bus_message *m, void *userdata, sd_bus_error *ret_error)
  * io.netplan.Netplan.Config methods
  */
 
+/* netplan-feature: dbus-config */
 static int
 method_config_apply(sd_bus_message *m, void *userdata, sd_bus_error *ret_error)
 {


### PR DESCRIPTION
## Description
Add man pages for `netplan get/set` CLI and `Config/Try/Cancel/Apply/Get/Set` DBus methods.
This PR also adds a `dbus-config` feature flag, to indicate the availability of the DBus configuration management.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [x] New/changed keys in YAML format are documented.
- [x] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

