### PR TITLE
Fix rename of matched interfaces at runtime (LP: #1904662)

### DIFF
--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -275,9 +275,9 @@ Virtual devices
 
 ``critical`` (bool)
 
-:   (networkd backend only) Designate the connection as "critical to the
-    system", meaning that special care will be taken by systemd-networkd to
-    not release the assigned IP when the daemon is restarted.
+:   Designate the connection as "critical to the system", meaning that special
+    care will be taken by to not release the assigned IP when the daemon is
+    restarted. (not recognized by NetworkManager)
 
 ``dhcp-identifier`` (scalar)
 

--- a/netplan/cli/commands/apply.py
+++ b/netplan/cli/commands/apply.py
@@ -206,11 +206,12 @@ class NetplanApply(utils.NetplanCommand):
                 if settings.get('_netplan_id'):
                     critical = config_manager.physical_interfaces[settings.get('_netplan_id')].get('critical')
                 if critical:
-                    logging.warning('Cannot rename {} -> {} at runtime, due to being critical'.format(iface, settings.get('name')))
+                    logging.warning('Cannot rename {} -> {} at runtime, due to being critical'
+                                    .format(iface, settings.get('name')))
                     continue
                 subprocess.check_call(['ip', 'link', 'set', 'dev', iface, 'down'],
-                                    stdout=subprocess.DEVNULL,
-                                    stderr=subprocess.DEVNULL)
+                                      stdout=subprocess.DEVNULL,
+                                      stderr=subprocess.DEVNULL)
                 subprocess.check_call(['ip', 'link', 'set',
                                        'dev', iface,
                                        'name', settings.get('name')],

--- a/netplan/cli/commands/apply.py
+++ b/netplan/cli/commands/apply.py
@@ -279,8 +279,14 @@ class NetplanApply(utils.NetplanCommand):
 
         # /sys/class/net/ens3/device -> ../../../virtio0
         # /sys/class/net/ens3/device/driver -> ../../../../bus/virtio/drivers/virtio_net
+        logging.debug('IFS {}'.format(interfaces))
+        logging.debug('PHYS {}'.format(phys))
+        matched_phys = phys.items()
+        matched_phys = list(map(lambda x: x[1]['matched_name'] if 'matched_name' in x[1] else x[0], matched_phys))
+        logging.info('M {}'.format(matched_phys))
         for interface in interfaces:
-            if interface not in phys:
+            logging.info('IF {}'.format(interface))
+            if interface not in matched_phys:
                 # do not rename  virtual devices
                 logging.debug('Skipping non-physical interface: %s', interface)
                 continue

--- a/netplan/cli/commands/apply.py
+++ b/netplan/cli/commands/apply.py
@@ -188,7 +188,9 @@ class NetplanApply(utils.NetplanCommand):
 
         # if the interface is up, we can still apply some .link file changes
         # but we cannot apply the interface rename via udev, as it won't touch
-        # the interface name, if it was already renamed once (e.g. during boot)
+        # the interface name, if it was already renamed once (e.g. during boot),
+        # because of the NamePolicy=keep default:
+        # https://www.freedesktop.org/software/systemd/man/systemd.net-naming-scheme.html
         devices = netifaces.interfaces()
         for device in devices:
             logging.debug('netplan triggering .link rules for %s', device)

--- a/netplan/cli/utils.py
+++ b/netplan/cli/utils.py
@@ -186,6 +186,7 @@ def is_interface_matching_macaddress(interface, match_mac):
 
     return match_mac == macaddress
 
+
 def get_matched_name(key, match):
     name_glob = "*"
     if 'name' in match:
@@ -203,7 +204,8 @@ def get_matched_name(key, match):
     # Filter for macaddress and/or driver glob
     filtered = matched_ifs.items()  # unfiltered list
     if len(filtered) > 1 and 'macaddress' in match:
-        filtered = list(filter(lambda x: x[1]['macaddress'] and x[1]['macaddress'] == '{}\n'.format(match['macaddress'].lower()), filtered))
+        filtered = list(filter(lambda x: x[1]['macaddress'] and x[1]['macaddress'] == match['macaddress'].strip().lower(),
+                               filtered))
     if len(filtered) > 1 and 'driver' in match:
         filtered = list(filter(lambda x: x[1]['driver'] and fnmatch.fnmatch(x[1]['driver'], match['driver']), filtered))
 

--- a/netplan/cli/utils.py
+++ b/netplan/cli/utils.py
@@ -193,14 +193,16 @@ def find_matched_name(key, match):
     if 'name' in match:
         name_glob = match['name']
     matched_ifs = dict()
-    for iface in glob.glob('/sys/class/net/{}'.format(name_glob)):
-        name = os.path.basename(iface)
+    for devdir in glob.glob('/sys/class/net/{}'.format(name_glob)):
+        name = os.path.basename(devdir)
         matched_ifs[name] = {'macaddress': None, 'driver': None}
-        if os.path.isfile(iface + '/address'):
-            with open(iface + '/address', 'r') as f:
+        address = os.path.join(devdir, 'address')
+        if os.path.isfile(address):
+            with open(address, 'r') as f:
                 matched_ifs[name]['macaddress'] = f.read().strip()
-        if os.path.islink(iface + '/device/driver'):
-            matched_ifs[name]['driver'] = os.readlink(iface + '/device/driver').split('/')[-1]
+        driver = os.path.realpath(os.path.join(devdir, 'device/driver'))
+        if os.path.islink(driver):
+            matched_ifs[name]['driver'] = os.path.basename(driver)
 
     # Filter for macaddress and/or driver glob
     filtered = matched_ifs.items()  # unfiltered list

--- a/netplan/cli/utils.py
+++ b/netplan/cli/utils.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2018-2020 Canonical, Ltd.
 # Author: Mathieu Trudel-Lapierre <mathieu.trudel-lapierre@canonical.com>
 # Author: Łukasz 'sil2100' Zemczak <lukasz.zemczak@canonical.com>
+# Author: Lukas 'slyon' Märdian <lukas.maerdian@canonical.com>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -18,7 +19,6 @@
 
 import sys
 import os
-import glob
 import logging
 import fnmatch
 import argparse
@@ -167,56 +167,46 @@ def get_interface_driver_name(interface, only_down=False):  # pragma: nocover (c
 
 def get_interface_macaddress(interface):  # pragma: nocover (covered in autopkgtest)
     link = netifaces.ifaddresses(interface)[netifaces.AF_LINK][0]
-
     return link.get('addr')
 
 
-def is_interface_matching_name(interface, match_driver):
-    return fnmatch.fnmatchcase(interface, match_driver)
+def is_interface_matching_name(interface, match_name):
+    # globs are supported
+    return fnmatch.fnmatchcase(interface, match_name)
 
 
 def is_interface_matching_driver_name(interface, match_driver):
     driver_name = get_interface_driver_name(interface)
-
-    return match_driver == driver_name
+    # globs are supported
+    return fnmatch.fnmatchcase(driver_name, match_driver)
 
 
 def is_interface_matching_macaddress(interface, match_mac):
     macaddress = get_interface_macaddress(interface)
+    # exact, case insensitive match. globs are not supported
+    return match_mac.lower() == macaddress.lower()
 
-    return match_mac == macaddress
 
+def find_matching_iface(interfaces, match):
+    assert isinstance(match, dict)
 
-# TODO: make use of or get rid of get_interface_ ...mac/driver...
-def find_matched_name(key, match):
-    name_glob = "*"
-    if 'name' in match:
-        name_glob = match['name']
-    matched_ifs = dict()
-    for devdir in glob.glob('/sys/class/net/{}'.format(name_glob)):
-        name = os.path.basename(devdir)
-        matched_ifs[name] = {'macaddress': None, 'driver': None}
-        address = os.path.join(devdir, 'address')
-        if os.path.isfile(address):
-            with open(address, 'r') as f:
-                matched_ifs[name]['macaddress'] = f.read().strip()
-        driver = os.path.realpath(os.path.join(devdir, 'device/driver'))
-        if os.path.islink(driver):
-            matched_ifs[name]['driver'] = os.path.basename(driver)
+    # Filter for match.name glob, fallback to '*'
+    name_glob = match.get('name') if match.get('name', False) else '*'
+    matches = fnmatch.filter(interfaces, name_glob)
 
-    # Filter for macaddress and/or driver glob
-    filtered = matched_ifs.items()  # unfiltered list
-    if len(filtered) > 1 and 'macaddress' in match:
-        filtered = list(filter(lambda x: x[1]['macaddress'] and x[1]['macaddress'] == match['macaddress'].lower(),
-                               filtered))
-    if len(filtered) > 1 and 'driver' in match:
-        filtered = list(filter(lambda x: x[1]['driver'] and fnmatch.fnmatch(x[1]['driver'], match['driver']), filtered))
+    # Filter for match.macaddress (exact match)
+    if len(matches) > 1 and match.get('macaddress'):
+        matches = list(filter(lambda iface: is_interface_matching_macaddress(iface, match.get('macaddress')), matches))
+
+    # Filter for match.driver glob
+    if len(matches) > 1 and match.get('driver'):
+        matches = list(filter(lambda iface: is_interface_matching_driver_name(iface, match.get('driver')), matches))
 
     # Return current name of unique matched interface, if available
-    if len(filtered) != 1:
-        logging.warning('Cannot find unique matching name for {} out of: {}'.format(key, filtered))
+    if len(matches) != 1:
+        logging.info(matches)
         return None
-    return filtered[0][0]
+    return matches[0]
 
 
 class NetplanCommand(argparse.Namespace):

--- a/netplan/cli/utils.py
+++ b/netplan/cli/utils.py
@@ -187,7 +187,8 @@ def is_interface_matching_macaddress(interface, match_mac):
     return match_mac == macaddress
 
 
-def get_matched_name(key, match):
+# TODO: make use of or get rid of get_interface_ ...mac/driver...
+def find_matched_name(key, match):
     name_glob = "*"
     if 'name' in match:
         name_glob = match['name']
@@ -197,14 +198,14 @@ def get_matched_name(key, match):
         matched_ifs[name] = {'macaddress': None, 'driver': None}
         if os.path.isfile(iface + '/address'):
             with open(iface + '/address', 'r') as f:
-                matched_ifs[name]['macaddress'] = f.read()
+                matched_ifs[name]['macaddress'] = f.read().strip()
         if os.path.islink(iface + '/device/driver'):
             matched_ifs[name]['driver'] = os.readlink(iface + '/device/driver').split('/')[-1]
 
     # Filter for macaddress and/or driver glob
     filtered = matched_ifs.items()  # unfiltered list
     if len(filtered) > 1 and 'macaddress' in match:
-        filtered = list(filter(lambda x: x[1]['macaddress'] and x[1]['macaddress'] == match['macaddress'].strip().lower(),
+        filtered = list(filter(lambda x: x[1]['macaddress'] and x[1]['macaddress'] == match['macaddress'].lower(),
                                filtered))
     if len(filtered) > 1 and 'driver' in match:
         filtered = list(filter(lambda x: x[1]['driver'] and fnmatch.fnmatch(x[1]['driver'], match['driver']), filtered))

--- a/netplan/configmanager.py
+++ b/netplan/configmanager.py
@@ -18,7 +18,6 @@
 '''netplan configuration manager'''
 
 import glob
-import fnmatch
 import logging
 import os
 import shutil
@@ -245,50 +244,17 @@ class ConfigManager(object):
 
         return new_interfaces
 
-    def _get_matched_name(self, key, match):
-        name_glob = "*"
-        if 'name' in match:
-            name_glob = match['name']
-        matched_ifs = dict()
-        for iface in glob.glob('/sys/class/net/{}'.format(name_glob)):
-            name = os.path.basename(iface)
-            matched_ifs[name] = {'macaddress': None, 'driver': None}
-            if os.path.isfile(iface + '/address'):
-                with open(iface + '/address', 'r') as f:
-                    matched_ifs[name]['macaddress'] = f.read()
-            if os.path.islink(iface + '/device/driver'):
-                matched_ifs[name]['driver'] = os.readlink(iface + '/device/driver').split('/')[-1]
-
-        # Filter for macaddress and/or driver glob
-        filtered = matched_ifs.items()  # unfiltered list
-        if len(filtered) > 1 and 'macaddress' in match:
-            filtered = list(filter(lambda x: x[1]['macaddress'] and x[1]['macaddress'] == '{}\n'.format(match['macaddress'].lower()), filtered))
-        if len(filtered) > 1 and 'driver' in match:
-            filtered = list(filter(lambda x: x[1]['driver'] and fnmatch.fnmatch(x[1]['driver'], match['driver']), filtered))
-
-        # Return current name of unique matched interface, if available
-        if len(filtered) != 1:
-            logging.warning('Cannot find unique matching name for {} out of: {}'.format(key, filtered))
-            return None
-        return filtered[0][0]
-
-    def _merge_interface_config(self, orig, new, physical = False):
+    def _merge_interface_config(self, orig, new):
         new_interfaces = set()
         changed_ifaces = list(new.keys())
 
         for ifname in changed_ifaces:
-            if physical and 'match' in new[ifname]:
-                matched_name = self._get_matched_name(ifname, new[ifname]['match'])
             iface = new.pop(ifname)
             if ifname in orig:
                 logging.debug("{} exists in {}".format(ifname, orig))
-                if matched_name:
-                    iface['matched_name'] = matched_name
                 orig[ifname].update(iface)
             else:
                 logging.debug("{} not found in {}".format(ifname, orig))
-                if matched_name:
-                    iface['matched_name'] = matched_name
                 orig[ifname] = iface
                 new_interfaces.add(ifname)
 
@@ -309,13 +275,13 @@ class ConfigManager(object):
                         new_interfaces |= new
                         self.network['openvswitch'] = network.get('openvswitch')
                     if 'ethernets' in network:
-                        new = self._merge_interface_config(self.ethernets, network.get('ethernets'), True)
+                        new = self._merge_interface_config(self.ethernets, network.get('ethernets'))
                         new_interfaces |= new
                     if 'modems' in network:
-                        new = self._merge_interface_config(self.modems, network.get('modems'), True)
+                        new = self._merge_interface_config(self.modems, network.get('modems'))
                         new_interfaces |= new
                     if 'wifis' in network:
-                        new = self._merge_interface_config(self.wifis, network.get('wifis'), True)
+                        new = self._merge_interface_config(self.wifis, network.get('wifis'))
                         new_interfaces |= new
                     if 'bridges' in network:
                         new = self._merge_interface_config(self.bridges, network.get('bridges'))

--- a/tests/integration/ethernets.py
+++ b/tests/integration/ethernets.py
@@ -240,6 +240,29 @@ class _CommonTests():
         # Verify IPv4 and IPv6 link local addresses are there
         self.assert_iface(self.dev_e_client, ['inet6 fe80:', 'inet 169.254.'])
 
+    def test_rename_interfaces(self):
+        self.setup_eth(None)
+        with open(self.config, 'w') as f:
+            f.write('''network:
+  renderer: %(r)s
+  ethernets:
+    idx:
+      match:
+        name: %(ec)s
+      set-name: iface1
+      addresses: [10.10.10.11/24]
+    idy:
+      match:
+        macaddress: %(e2c_mac)s
+      set-name: iface2
+      addresses: [10.10.10.22/24]
+''' % {'r': self.backend, 'ec': self.dev_e_client, 'e2c_mac': self.dev_e2_client_mac})
+        self.generate_and_settle()
+        self.assert_iface('iface1', ['inet 10.10.10.11'])
+        self.assert_iface_up('iface1', ['inet 10.10.10.11'])
+        self.assert_iface('iface2', ['inet 10.10.10.22'])
+        self.assert_iface_up('iface2', ['inet 10.10.10.22'])
+
 
 @unittest.skipIf("networkd" not in test_backends,
                      "skipping as networkd backend tests are disabled")


### PR DESCRIPTION
## Description
Renaming of network interfaces was not working when running `netplan apply` and interfaces would only be renamed after a reboot via udev. There is some udev-rename logic inside `cli/commands/apply.py`, which doesn't seem to be working, though.

This seems to be related to systemd-udevd's `NamePolicy=keep` default, which is set explicitly as of systemd v240 [0][1] and prevents renaming of interfaces via udev, if the name was set once (i.e. during boot). Even before v240 this has be the (implicit) default, so I'm not sure if this rename logic has ever worked...

I reworked/refactored the renaming of interfaces in `apply.py` to make use of iproute2 `ip link set eth_OLD set name eth_NEW` command instead and also added an integration test.

In order to rename interfaces via iproute2, they need to be DOWN, therefore the new code is bringing all to-be-renamed interfaces - which are not defined to be `critical` - down during `apply` and renames them accordingly.

Also, there was another issue with the detection of physical interfaces, where the system's current network interface names (from `netifaces.interfaces()`) have been compared to `config_manager.py`'s physical_interfaces list, which are not (always) actual interface names (but netplan IDs), especially for netplan definitions with a `match` condition. So I added another util to lookup/match the actual interface name for a given `match:` condition.

[0] https://www.freedesktop.org/software/systemd/man/systemd.net-naming-scheme.html
[1] https://github.com/systemd/systemd/blob/e62a7fea757f259eb330da5b6d3ab4ede46400a2/NEWS#L25

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [x] \(Optional\) Closes an open bug in Launchpad: [LP: #1904662](https://pad.lv/1904662)

