### PR TITLE
Clang fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ generate: libnetplan.so.$(NETPLAN_SOVER) nm.o networkd.o openvswitch.o generate.
 	$(CC) $(BUILDFLAGS) $(CFLAGS) $(LDFLAGS) -o $@ $^ -L. -lnetplan `pkg-config --cflags --libs glib-2.0 gio-2.0 yaml-0.1 uuid`
 
 netplan-dbus: src/dbus.c src/_features.h util.o
-	$(CC) $(BUILDFLAGS) $(CFLAGS) $(LDFLAGS) -o $@ $^ `pkg-config --cflags --libs libsystemd glib-2.0 gio-2.0`
+	$(CC) $(BUILDFLAGS) $(CFLAGS) $(LDFLAGS) -o $@ $(patsubst %.h,,$^) `pkg-config --cflags --libs libsystemd glib-2.0 gio-2.0`
 
 src/_features.h: src/[^_]*.[hc]
 	printf "#include <stddef.h>\nstatic const char *feature_flags[] __attribute__((__unused__)) = {\n" > $@

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -242,9 +242,6 @@ static int
 method_info(sd_bus_message *m, void *userdata, sd_bus_error *ret_error)
 {
     sd_bus_message *reply = NULL;
-    g_autoptr(GError) err = NULL;
-    g_autofree gchar *stdout = NULL;
-    g_autofree gchar *stderr = NULL;
     gint exit_status = 0;
 
     exit_status = sd_bus_message_new_method_return(m, &reply);

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -897,7 +897,6 @@ append_wpa_auth_conf(GString* s, const NetplanAuthenticationSettings* auth, cons
 static void
 write_wpa_unit(const NetplanNetDefinition* def, const char* rootdir)
 {
-    g_autoptr(GError) err = NULL;
     g_autofree gchar *stdouth = NULL;
 
     stdouth = systemd_escape(def->id);

--- a/src/parse.c
+++ b/src/parse.c
@@ -1899,7 +1899,6 @@ handle_wireguard_peers(yaml_document_t* doc, yaml_node_t* node, const void* _, G
     }
 
     for (yaml_node_item_t *i = node->data.sequence.items.start; i < node->data.sequence.items.top; i++) {
-        g_autofree char* addr = NULL;
         yaml_node_t *entry = yaml_document_get_node(doc, *i);
         assert_type(entry, YAML_MAPPING_NODE);
 


### PR DESCRIPTION
## Description

These fixes make sure we can compile and run tests using `CC=clang`

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

