### PR TITLE
Added per route initcwnd/initrwnd option

### DIFF
--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -578,6 +578,15 @@ These options are available for all types of interfaces.
      :    The MTU to be used for the route, in bytes. Must be a positive integer
           value.
 
+    ``initcwnd`` (scalar) – since ****
+     :    The initcwnd to be used for the route, represented bynumber of segments.
+           Must be a positive integer value.
+
+    ``initrwnd`` (scalar) – since ****
+     :    The initrwnd to be used for the route, represented bynumber of segments. 
+          Must be a positive integer value.
+
+
 ``routing-policy`` (mapping)
 
 :    The ``routing-policy`` block defines extra routing policy for a network,

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -444,6 +444,10 @@ write_route(NetplanIPRoute* r, GString* s)
         g_string_append_printf(s, "Table=%d\n", r->table);
     if (r->mtubytes != NETPLAN_MTU_UNSPEC)
         g_string_append_printf(s, "MTUBytes=%u\n", r->mtubytes);
+     if (r->initcwnd != NETPLAN_INITCWND_UNSPEC)
+         g_string_append_printf(s, "InitialCongestionWindow=%u\n", r->initcwnd);
+     if (r->initrwnd != NETPLAN_INITRWND_UNSPEC)
+         g_string_append_printf(s, "InitialAdvertisedReceiveWindow=%u\n", r->initrwnd);
 }
 
 static void

--- a/src/nm.c
+++ b/src/nm.c
@@ -222,6 +222,8 @@ write_routes(const NetplanNetDefinition* def, GString *s, int family)
             g_string_append(s, "\n");
 
             if (   cur_route->onlink
+                || cur_route->initrwnd
+                || cur_route->initcwnd
                 || cur_route->mtubytes
                 || cur_route->table != NETPLAN_ROUTE_TABLE_UNSPEC
                 || cur_route->from) {
@@ -230,6 +232,10 @@ write_routes(const NetplanNetDefinition* def, GString *s, int family)
                     /* onlink for IPv6 addresses is only supported since nm-1.18.0. */
                     g_string_append_printf(s, "onlink=true,");
                 }
+                if (cur_route->initrwnd != NETPLAN_INITRWND_UNSPEC)
+                    g_string_append_printf(s, "initrwnd=%u,", cur_route->initrwnd);
+                if (cur_route->initcwnd != NETPLAN_INITCWND_UNSPEC)
+                    g_string_append_printf(s, "initcwnd=%u,", cur_route->initcwnd);
                 if (cur_route->mtubytes != NETPLAN_MTU_UNSPEC)
                     g_string_append_printf(s, "mtu=%u,", cur_route->mtubytes);
                 if (cur_route->table != NETPLAN_ROUTE_TABLE_UNSPEC)

--- a/src/parse.c
+++ b/src/parse.c
@@ -1518,6 +1518,8 @@ static const mapping_entry_handler routes_handlers[] = {
     {"via", YAML_SCALAR_NODE, handle_routes_ip, NULL, route_offset(via)},
     {"metric", YAML_SCALAR_NODE, handle_routes_guint, NULL, route_offset(metric)},
     {"mtu", YAML_SCALAR_NODE, handle_routes_guint, NULL, route_offset(mtubytes)},
+    {"initcwnd", YAML_SCALAR_NODE, handle_routes_guint, NULL, route_offset(initcwnd)},
+    {"initrwnd", YAML_SCALAR_NODE, handle_routes_guint, NULL, route_offset(initrwnd)},     
     {NULL}
 };
 

--- a/src/parse.h
+++ b/src/parse.h
@@ -425,6 +425,8 @@ typedef struct {
     gboolean has_auth;
 } NetplanWifiAccessPoint;
 
+#define NETPLAN_INITRWND_UNSPEC 0
+#define NETPLAN_INITCWND_UNSPEC 0
 #define NETPLAN_MTU_UNSPEC 0
 #define NETPLAN_METRIC_UNSPEC G_MAXUINT
 #define NETPLAN_ROUTE_TABLE_UNSPEC 0
@@ -449,6 +451,8 @@ typedef struct {
     guint metric;
 
     guint mtubytes;
+    guint initcwnd;
+    guint initrwnd;
 } NetplanIPRoute;
 
 typedef struct {

--- a/tests/generator/test_errors.py
+++ b/tests/generator/test_errors.py
@@ -543,6 +543,36 @@ class TestConfigErrors(TestBase):
 
         self.assertIn("invalid unsigned int value '-1'", err)
 
+    def test_device_bad_route_initcwnd(self):
+        err = self.generate('''network:
+  version: 2
+  ethernets:
+    engreen:
+      routes:
+        - to: 10.10.0.0/16
+          via: 10.1.1.1
+          initcwnd: -1
+      addresses:
+        - 192.168.14.2/24
+        - 2001:FFfe::1/64''', expect_fail=True)
+
+        self.assertIn("invalid unsigned int value '-1'", err)
+
+    def test_device_bad_route_initrwnd(self):
+        err = self.generate('''network:
+  version: 2
+  ethernets:
+    engreen:
+      routes:
+        - to: 10.10.0.0/16
+          via: 10.1.1.1
+          initrwnd: -1
+      addresses:
+        - 192.168.14.2/24
+        - 2001:FFfe::1/64''', expect_fail=True)
+
+        self.assertIn("invalid unsigned int value '-1'", err)
+
     def test_device_route_family_mismatch_ipv6_to(self):
         self.generate('''network:
   version: 2

--- a/tests/generator/test_routing.py
+++ b/tests/generator/test_routing.py
@@ -369,6 +369,56 @@ Gateway=192.168.14.20
 MTUBytes=1500
 '''})
 
+    def test_route_v4_initcwnd(self):
+        self.generate('''network:
+  version: 2
+  ethernets:
+    engreen:
+      addresses: ["192.168.14.2/24"]
+      routes:
+        - to: 10.10.10.0/24
+          via: 192.168.14.20
+          initcwnd: 16
+        ''')
+
+        self.assert_networkd({'engreen.network': '''[Match]
+Name=engreen
+
+[Network]
+LinkLocalAddressing=ipv6
+Address=192.168.14.2/24
+
+[Route]
+Destination=10.10.10.0/24
+Gateway=192.168.14.20
+InitialCongestionWindow=16
+'''})
+
+    def test_route_v4_initrwnd(self):
+        self.generate('''network:
+  version: 2
+  ethernets:
+    engreen:
+      addresses: ["192.168.14.2/24"]
+      routes:
+        - to: 10.10.10.0/24
+          via: 192.168.14.20
+          initrwnd: 16
+        ''')
+
+        self.assert_networkd({'engreen.network': '''[Match]
+Name=engreen
+
+[Network]
+LinkLocalAddressing=ipv6
+Address=192.168.14.2/24
+
+[Route]
+Destination=10.10.10.0/24
+Gateway=192.168.14.20
+InitialAdvertisedReceiveWindow=16
+'''})
+
     def test_route_v6_single(self):
         self.generate('''network:
   version: 2
@@ -931,6 +981,73 @@ route1_options=mtu=1500
 method=ignore
 '''})
         self.assert_networkd({})
+
+    def test_route_initcwnd(self):
+        out = self.generate('''network:
+  version: 2
+  ethernets:
+    engreen:
+      renderer: NetworkManager
+      addresses: ["192.168.14.2/24"]
+      routes:
+        - to: 10.10.10.0/24
+          via: 192.168.1.20
+          initcwnd: 16
+        ''')
+        self.assertEqual('', out)
+
+        self.assert_nm({'engreen': '''[connection]
+id=netplan-engreen
+type=ethernet
+interface-name=engreen
+
+[ethernet]
+wake-on-lan=0
+
+[ipv4]
+method=manual
+address1=192.168.14.2/24
+route1=10.10.10.0/24,192.168.1.20
+route1_options=initcwnd=16
+
+[ipv6]
+method=ignore
+'''})
+        self.assert_networkd({})
+
+    def test_route_initrwnd(self):
+        out = self.generate('''network:
+  version: 2
+  ethernets:
+    engreen:
+      renderer: NetworkManager
+      addresses: ["192.168.14.2/24"]
+      routes:
+        - to: 10.10.10.0/24
+          via: 192.168.1.20
+          initrwnd: 16
+        ''')
+        self.assertEqual('', out)
+
+        self.assert_nm({'engreen': '''[connection]
+id=netplan-engreen
+type=ethernet
+interface-name=engreen
+
+[ethernet]
+wake-on-lan=0
+
+[ipv4]
+method=manual
+address1=192.168.14.2/24
+route1=10.10.10.0/24,192.168.1.20
+route1_options=initrwnd=16
+
+[ipv6]
+method=ignore
+'''})
+        self.assert_networkd({})
+
 
     def test_route_options(self):
         out = self.generate('''network:

--- a/tests/integration/routing.py
+++ b/tests/integration/routing.py
@@ -195,6 +195,41 @@ class _CommonTests():
         self.assertIn(b'mtu 777',  # check mtu from static route
                       subprocess.check_output(['ip', 'route', 'show', '10.10.10.0/24']))
 
+    def test_per_route_initcwnd(self):
+        self.setup_eth(None)
+        with open(self.config, 'w') as f:
+            f.write('''network:
+  renderer: %(r)s
+  ethernets:
+    %(ec)s:
+      addresses:
+        - 192.168.5.99/24
+      gateway4: 192.168.5.1
+        routes:
+          - to: 10.10.10.0/24
+            via: 192.168.5.254
+            initcwnd: 16''' % {'r': self.backend, 'ec': self.dev_e_client})
+        self.generate_and_settle()
+        self.assertIn(b'initcwnd 16',  # check initcwnd from static route
+                    subprocess.check_output(['ip', 'route', 'show', '10.10.10.0/24']))
+
+    def test_per_route_initrwnd(self):
+        self.setup_eth(None)
+        with open(self.config, 'w') as f:
+            f.write('''network:
+  renderer: %(r)s
+  ethernets:
+    %(ec)s:
+      addresses:
+         - 192.168.5.99/24
+      gateway4: 192.168.5.1
+      routes:
+        - to: 10.10.10.0/24
+          via: 192.168.5.254
+          initrwnd: 16''' % {'r': self.backend, 'ec': self.dev_e_client})
+        self.generate_and_settle()
+        self.assertIn(b'mtu 777',  # check mtu from static route
+                    subprocess.check_output(['ip', 'route', 'show', '10.10.10.0/24']))
 
 @unittest.skipIf("networkd" not in test_backends,
                      "skipping as networkd backend tests are disabled")


### PR DESCRIPTION
## Description

Add possibility to set initcwnd/initrwnd options on routes.

## Checklist

- [ ] Runs `make check` successfully.
- [ ] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

