### PR TITLE
Fix changing of macaddress with systemd v247

### DIFF
--- a/src/networkd.c
+++ b/src/networkd.c
@@ -572,6 +572,8 @@ write_network_file(const NetplanNetDefinition* def, const char* rootdir, const c
     if (def->mtubytes) {
         g_string_append_printf(link, "MTUBytes=%u\n", def->mtubytes);
     }
+    if (def->set_mac)
+        g_string_append_printf(link, "MACAddress=%s\n", def->set_mac);
 
     if (def->emit_lldp) {
         g_string_append(network, "EmitLLDP=true\n");

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -227,7 +227,7 @@ write_link_file(const NetplanNetDefinition* def, const char* rootdir, const char
         return;
 
     /* do we need to write a .link file? */
-    if (!def->set_name && !def->wake_on_lan && !def->mtubytes && !def->set_mac)
+    if (!def->set_name && !def->wake_on_lan && !def->mtubytes)
         return;
 
     /* build file contents */
@@ -241,9 +241,6 @@ write_link_file(const NetplanNetDefinition* def, const char* rootdir, const char
     g_string_append_printf(s, "WakeOnLan=%s\n", def->wake_on_lan ? "magic" : "off");
     if (def->mtubytes)
         g_string_append_printf(s, "MTUBytes=%u\n", def->mtubytes);
-    if (def->set_mac)
-        g_string_append_printf(s, "MACAddress=%s\n", def->set_mac);
-
 
     orig_umask = umask(022);
     g_string_free_to_file(s, rootdir, path, ".link");

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -566,15 +566,13 @@ write_network_file(const NetplanNetDefinition* def, const char* rootdir, const c
         }
     }
 
-    if (def->mtubytes) {
+    if (def->mtubytes)
         g_string_append_printf(link, "MTUBytes=%u\n", def->mtubytes);
-    }
     if (def->set_mac)
         g_string_append_printf(link, "MACAddress=%s\n", def->set_mac);
 
-    if (def->emit_lldp) {
+    if (def->emit_lldp)
         g_string_append(network, "EmitLLDP=true\n");
-    }
 
     if (def->dhcp4 && def->dhcp6)
         g_string_append(network, "DHCP=yes\n");

--- a/tests/generator/test_bridges.py
+++ b/tests/generator/test_bridges.py
@@ -35,6 +35,9 @@ class TestNetworkd(TestBase):
         self.assert_networkd({'br0.network': '''[Match]
 Name=br0
 
+[Link]
+MACAddress=00:01:02:03:04:05
+
 [Network]
 DHCP=ipv4
 LinkLocalAddressing=ipv6

--- a/tests/generator/test_ethernets.py
+++ b/tests/generator/test_ethernets.py
@@ -225,7 +225,8 @@ unmanaged-devices+=interface-name:green,''')
       macaddress: 00:01:02:03:04:05
       dhcp4: true''')
 
-        self.assert_networkd({'def1.network': ND_DHCP4 % 'green',
+        self.assert_networkd({'def1.network': (ND_DHCP4 % 'green')
+                              .replace('[Network]', '[Link]\nMACAddress=00:01:02:03:04:05\n\n[Network]'),
                               'def1.link': '[Match]\nOriginalName=green\n\n[Link]\nWakeOnLan=off\nMACAddress=00:01:02:03:04:05\n'
                               })
         self.assert_networkd_udev(None)

--- a/tests/generator/test_ethernets.py
+++ b/tests/generator/test_ethernets.py
@@ -226,8 +226,7 @@ unmanaged-devices+=interface-name:green,''')
       dhcp4: true''')
 
         self.assert_networkd({'def1.network': (ND_DHCP4 % 'green')
-                              .replace('[Network]', '[Link]\nMACAddress=00:01:02:03:04:05\n\n[Network]'),
-                              'def1.link': '[Match]\nOriginalName=green\n\n[Link]\nWakeOnLan=off\nMACAddress=00:01:02:03:04:05\n'
+                              .replace('[Network]', '[Link]\nMACAddress=00:01:02:03:04:05\n\n[Network]')
                               })
         self.assert_networkd_udev(None)
 
@@ -443,13 +442,7 @@ method=ignore
       macaddress: 00:01:02:03:04:05
       dhcp4: true''')
 
-        self.assert_networkd({'eth0.link': '''[Match]
-OriginalName=eth0
-
-[Link]
-WakeOnLan=off
-MACAddress=00:01:02:03:04:05
-'''})
+        self.assert_networkd(None)
 
         self.assert_nm({'eth0': '''[connection]
 id=netplan-eth0

--- a/tests/generator/test_vlans.py
+++ b/tests/generator/test_vlans.py
@@ -62,7 +62,8 @@ Kind=vlan
 Id=3
 ''',
                               'enblue.network': ND_WITHIP % ('enblue', '1.2.3.4/24'),
-                              'enred.network': ND_EMPTY % ('enred', 'ipv6'),
+                              'enred.network': (ND_EMPTY % ('enred', 'ipv6'))
+                              .replace('[Network]', '[Link]\nMACAddress=aa:bb:cc:dd:ee:11\n\n[Network]'),
                               'engreen.network': (ND_DHCP6_WOCARRIER % 'engreen')})
 
         self.assert_nm(None, '''[keyfile]

--- a/tests/integration/ethernets.py
+++ b/tests/integration/ethernets.py
@@ -72,7 +72,7 @@ class _CommonTests():
                              ['master'])
         out = subprocess.check_output(['ip', 'link', 'show', self.dev_e2_client],
                                       universal_newlines=True)
-        self.assertTrue('ether 00:01:02:03:04:05' in out)
+        self.assertIn('ether 00:01:02:03:04:05', out)
         subprocess.check_call(['ip', 'link', 'set', self.dev_e2_client,
                                'address', self.dev_e2_client_mac])
 


### PR DESCRIPTION
## Description
Starting with systemd v247 the [.link](https://www.freedesktop.org/software/systemd/man/systemd.link.html#MACAddress=1) file section to change the MAC address does not seem to have an effect anymore:
```
[Link]
MACAddress=00:11:22:33:44:55
```
Changing/clearing `MACAddressPolicy=` did not help to make the .link file set the MAC address.

Whereas the same section applied to a [.network](https://www.freedesktop.org/software/systemd/man/systemd.network.html#MACAddress=1) file seems to fix the situation:
```
[Link]
MACAddress=00:11:22:33:44:55
```
Documentation indicates that those do the same thing, so I'm applying both now. It passes all integration tests this way, for old and new systemd.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

