### PR TITLE
Fix 'networkmanager:' backend options for modem connections

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -2221,6 +2221,7 @@ static const mapping_entry_handler vlan_def_handlers[] = {
 
 static const mapping_entry_handler modem_def_handlers[] = {
     COMMON_LINK_HANDLERS,
+    COMMON_BACKEND_HANDLERS,
     {"apn", YAML_SCALAR_NODE, handle_netdef_str, NULL, netdef_offset(modem_params.apn)},
     {"auto-config", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(modem_params.auto_config)},
     {"device-id", YAML_SCALAR_NODE, handle_netdef_str, NULL, netdef_offset(modem_params.device_id)},

--- a/tests/generator/test_modems.py
+++ b/tests/generator/test_modems.py
@@ -372,3 +372,32 @@ method=ignore
 '''})
         self.assert_networkd({})
         self.assert_nm_udev(None)
+
+    def test_modem_nm_integration(self):
+        self.generate('''network:
+  version: 2
+  renderer: NetworkManager
+  modems:
+    mobilephone:
+      auto-config: true
+      networkmanager:
+        uuid: b22d8f0f-3f34-46bd-ac28-801fa87f1eb6''')
+        self.assert_nm({'mobilephone': '''[connection]
+id=netplan-mobilephone
+type=gsm
+interface-name=mobilephone
+
+[gsm]
+auto-config=true
+
+[ethernet]
+wake-on-lan=0
+
+[ipv4]
+method=link-local
+
+[ipv6]
+method=ignore
+'''})
+        self.assert_networkd({})
+        self.assert_nm_udev(None)


### PR DESCRIPTION
## Description
The `COMMON_BACKEND_HANDLERS` have been forgotten for `modem` connections apparently. Add them to allow the definition of the special `networkmanager:` mapping, used for NetworkManager integration. E.g. this `networkmanager.uuid` setting:

```
network:
  version: 2
  renderer: NetworkManager
  modems:
    mycon:
      auto-config: true
      networkmanager:
        uuid: b22d8f0f-3f34-46bd-ac28-801fa87f1eb6
```

We do not (yet) use that information (like uuid) in the current implementation. But reading YAML via NetworkManager will be broken if the `networkmanager:` mapping is not accepted.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

