### PR TITLE
doc: Add a caveat to wake on LAN which is systemd.link related (LP: #1909114)

### DIFF
--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -133,6 +133,10 @@ Virtual devices
 
 :    Enable wake on LAN. Off by default.
 
+     **Note:** This will not work reliably for devices matched by name
+     only and rendered by networkd, due to interactions with device
+     renaming in udev. Match devices by MAC when setting wake on LAN.
+
 ``emit-lldp`` (bool) – since **0.99**
 
 :    (networkd backend only) Whether to emit LLDP packets. Off by default.


### PR DESCRIPTION
## Description

Fixes [LP: #1909114](https://bugs.launchpad.net/netplan/+bug/1909114)


## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [x] \(Optional\) Closes an open bug in Launchpad.

