### PR TITLE
NM: refactor keyfile generator, by using GLib's keyfile writer instead of custom writer

### DIFF
--- a/src/nm.c
+++ b/src/nm.c
@@ -599,12 +599,12 @@ write_nm_conf_access_point(NetplanNetDefinition* def, const char* rootdir, const
         const char* con_type = NULL;
         switch (def->type) {
             case NETPLAN_DEF_TYPE_WIFI:
-                con_type = "802-11-wireless"; //should we just use "wifi" here?
+                con_type = "wifi";
             case NETPLAN_DEF_TYPE_MODEM:
                 /* Avoid adding an [ethernet] section into the [gsm/cdma] description. */
                 break;
             default:
-                con_type = "802-3-ethernet"; //should we just use "ethernet" here?
+                con_type = "ethernet";
         }
 
         if (con_type) {
@@ -618,11 +618,10 @@ write_nm_conf_access_point(NetplanNetDefinition* def, const char* rootdir, const
                 g_key_file_set_uint64(kf, con_type, "wake-on-wlan", def->wowlan);
         }
     } else {
-        /* Should we just use just "ethernet" here? */
         if (def->set_mac)
-            g_key_file_set_string(kf, "802-3-ethernet", "cloned-mac-address", def->set_mac);
+            g_key_file_set_string(kf, "ethernet", "cloned-mac-address", def->set_mac);
         if (def->mtubytes)
-            g_key_file_set_uint64(kf, "802-3-ethernet", "mtu", def->mtubytes);
+            g_key_file_set_uint64(kf, "ethernet", "mtu", def->mtubytes);
     }
 
     if (def->type == NETPLAN_DEF_TYPE_VLAN) {

--- a/tests/generator/test_bridges.py
+++ b/tests/generator/test_bridges.py
@@ -361,7 +361,7 @@ id=netplan-br0
 type=bridge
 interface-name=br0
 
-[802-3-ethernet]
+[ethernet]
 cloned-mac-address=00:01:02:03:04:05
 
 [ipv4]

--- a/tests/generator/test_common.py
+++ b/tests/generator/test_common.py
@@ -705,7 +705,7 @@ id=netplan-bond0
 type=bond
 interface-name=bond0
 
-[802-3-ethernet]
+[ethernet]
 mtu=9000
 
 [ipv4]
@@ -723,8 +723,6 @@ master=bond0
 
 [ethernet]
 wake-on-lan=0
-
-[802-3-ethernet]
 mtu=1280
 
 [ipv4]

--- a/tests/generator/test_ethernets.py
+++ b/tests/generator/test_ethernets.py
@@ -354,8 +354,6 @@ interface-name=eth1
 
 [ethernet]
 wake-on-lan=0
-
-[802-3-ethernet]
 mtu=1280
 
 [ipv4]
@@ -451,8 +449,6 @@ interface-name=eth0
 
 [ethernet]
 wake-on-lan=0
-
-[802-3-ethernet]
 cloned-mac-address=00:01:02:03:04:05
 
 [ipv4]
@@ -569,8 +565,6 @@ type=ethernet
 
 [ethernet]
 wake-on-lan=0
-
-[802-3-ethernet]
 mac-address=11:22:33:44:55:66
 
 [ipv4]
@@ -709,8 +703,6 @@ interface-name=engreen
 
 [ethernet]
 wake-on-lan=0
-
-[802-3-ethernet]
 mac-address=00:11:22:33:44:55
 
 [ipv4]

--- a/tests/generator/test_tunnels.py
+++ b/tests/generator/test_tunnels.py
@@ -359,7 +359,7 @@ persistent-keepalive=23
 endpoint=1.2.3.4:5
 preshared-key=7voRZ/ojfXgfPOlswo3Lpma1RJq7qijIEEUEMShQFV8=
 preshared-key-flags=0
-allowed-ips=0.0.0.0/0;2001:fe:ad:de:ad:be:ef:1/24''')})
+allowed-ips=0.0.0.0/0;2001:fe:ad:de:ad:be:ef:1/24;''')})
 
     def test_simple_multi_pass(self):
         """[wireguard] Validate generation of a wireguard config, which is parsed multiple times"""
@@ -397,7 +397,7 @@ listen-port=12345
 [wireguard-peer.M9nt4YujIOmNrRmpIRTmYSfMdrpvE7u6WkG8FY8WjG4=]
 persistent-keepalive=23
 endpoint=1.2.3.4:5
-allowed-ips=0.0.0.0/0;2001:fe:ad:de:ad:be:ef:1/24
+allowed-ips=0.0.0.0/0;2001:fe:ad:de:ad:be:ef:1/24;
 
 [ipv4]
 method=manual
@@ -427,7 +427,7 @@ method=ignore
                                            'allowed-ips': '[0.0.0.0/0, "2001:fe:ad:de:ad:be:ef:1/24"]',
                                            'keepalive': 23,
                                            'endpoint': '1.2.3.4:5'}, {
-                                           'public-key': 'M9nt4YujIOmNrRmpIRTmYSfMdrpvE7u6WkG8FY8WjG4=',
+                                           'public-key': 'M9nt4YujIOmNrRmpIRTmYSfMdrpvE7u6WkG8FY8WjG5=',
                                            'allowed-ips': '[0.0.0.0/0, "2001:fe:ad:de:ad:be:ef:1/24"]',
                                            'keepalive': 23,
                                            'endpoint': '1.2.3.4:5'}], renderer=self.backend)
@@ -441,7 +441,7 @@ PersistentKeepalive=23
 Endpoint=1.2.3.4:5
 
 [WireGuardPeer]
-PublicKey=M9nt4YujIOmNrRmpIRTmYSfMdrpvE7u6WkG8FY8WjG4=
+PublicKey=M9nt4YujIOmNrRmpIRTmYSfMdrpvE7u6WkG8FY8WjG5=
 AllowedIPs=0.0.0.0/0,2001:fe:ad:de:ad:be:ef:1/24
 PersistentKeepalive=23
 Endpoint=1.2.3.4:5'''),
@@ -452,12 +452,12 @@ Endpoint=1.2.3.4:5'''),
 [wireguard-peer.M9nt4YujIOmNrRmpIRTmYSfMdrpvE7u6WkG8FY8WjG4=]
 persistent-keepalive=23
 endpoint=1.2.3.4:5
-allowed-ips=0.0.0.0/0;2001:fe:ad:de:ad:be:ef:1/24
+allowed-ips=0.0.0.0/0;2001:fe:ad:de:ad:be:ef:1/24;
 
-[wireguard-peer.M9nt4YujIOmNrRmpIRTmYSfMdrpvE7u6WkG8FY8WjG4=]
+[wireguard-peer.M9nt4YujIOmNrRmpIRTmYSfMdrpvE7u6WkG8FY8WjG5=]
 persistent-keepalive=23
 endpoint=1.2.3.4:5
-allowed-ips=0.0.0.0/0;2001:fe:ad:de:ad:be:ef:1/24''')})
+allowed-ips=0.0.0.0/0;2001:fe:ad:de:ad:be:ef:1/24;''')})
 
     def test_privatekeyfile(self):
         """[wireguard] Validate generation of another simple wireguard config"""
@@ -504,7 +504,7 @@ Endpoint=[2001:fe:ad:de:ad:be:ef:11]:5'''),
 [wireguard-peer.M9nt4YujIOmNrRmpIRTmYSfMdrpvE7u6WkG8FY8WjG4=]
 persistent-keepalive=23
 endpoint=[2001:fe:ad:de:ad:be:ef:11]:5
-allowed-ips=0.0.0.0/0;2001:fe:ad:de:ad:be:ef:1/24''')})
+allowed-ips=0.0.0.0/0;2001:fe:ad:de:ad:be:ef:1/24;''')})
 
 
 # Execute the _CommonParserErrors only for one backend, to spare some test cycles

--- a/tests/generator/test_vlans.py
+++ b/tests/generator/test_vlans.py
@@ -232,8 +232,6 @@ uuid=%s
 
 [ethernet]
 wake-on-lan=0
-
-[802-3-ethernet]
 mac-address=11:22:33:44:55:66
 
 [ipv4]

--- a/tests/generator/test_wifis.py
+++ b/tests/generator/test_wifis.py
@@ -530,18 +530,16 @@ type=wifi
 [ethernet]
 wake-on-lan=0
 
-[802-11-wireless]
+[wifi]
 mac-address=11:22:33:44:55:66
+ssid=workplace
+mode=infrastructure
 
 [ipv4]
 method=link-local
 
 [ipv6]
 method=ignore
-
-[wifi]
-ssid=workplace
-mode=infrastructure
 '''})
 
     def test_wifi_match_all(self):
@@ -655,18 +653,16 @@ interface-name=wl0
 [ethernet]
 wake-on-lan=0
 
-[802-11-wireless]
+[wifi]
 wake-on-wlan=330
+ssid=homenet
+mode=infrastructure
 
 [ipv4]
 method=link-local
 
 [ipv6]
 method=ignore
-
-[wifi]
-ssid=homenet
-mode=infrastructure
 '''})
 
     def test_wifi_wowlan_default(self):


### PR DESCRIPTION
## Description
This is the 3rd in a series of pull requests to enable the implementation of a YAML/netplan backend for NetworkManager.

In this PR netplan's current keyfile generation code (in `nm.c`) is refactored to make use of GLib's keyfile writer, instead of using a custom, home grown approach. This way the keyfile settings can easily be read, written and overwritten (e.g. by the keyfile passthrough/fallback settings in #183) and it should be more robust overall.

While on it: Clean up the usage of keyfile alias for `ethernet`, `wifi` and `wifi-security`, which NetworkManager writes by default since a long time, see: https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/commit/c36200a225aefb2a3919618e75682646899b82c0

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

