### PR TITLE
cli:utils: handle emtpy netifaces.ifaddresess call (LP: #1913062)

### DIFF
--- a/netplan/cli/utils.py
+++ b/netplan/cli/utils.py
@@ -165,9 +165,10 @@ def get_interface_driver_name(interface, only_down=False):  # pragma: nocover (c
     return driver_name
 
 
-def get_interface_macaddress(interface):  # pragma: nocover (covered in autopkgtest)
-    link = netifaces.ifaddresses(interface)[netifaces.AF_LINK][0]
-    return link.get('addr')
+def get_interface_macaddress(interface):
+    # return an empty list (and string) if no LL data can be found
+    link = netifaces.ifaddresses(interface).get(netifaces.AF_LINK, [{}])[0]
+    return link.get('addr', '')
 
 
 def is_interface_matching_name(interface, match_name):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -19,6 +19,7 @@ import os
 import unittest
 import tempfile
 import glob
+import netifaces
 
 from unittest.mock import patch
 
@@ -96,3 +97,13 @@ class TestUtils(unittest.TestCase):
         match = {'name': 'ens?', 'driver': 'f*'}
         iface = utils.find_matching_iface(DEVICES, match)
         self.assertEqual(iface, 'ens4')
+
+    @patch('netifaces.ifaddresses')
+    def test_interface_macaddress(self, ifaddr):
+        ifaddr.side_effect = lambda _: {netifaces.AF_LINK: [{'addr': '00:01:02:03:04:05'}]}
+        self.assertEqual(utils.get_interface_macaddress('eth42'), '00:01:02:03:04:05')
+
+    @patch('netifaces.ifaddresses')
+    def test_interface_macaddress_empty(self, ifaddr):
+        ifaddr.side_effect = lambda _: {}
+        self.assertEqual(utils.get_interface_macaddress('eth42'), '')


### PR DESCRIPTION
## Description
In some cases the `netifaces.ifaddresses()` method returns an empty dict. Accessing this dict throws a `KeyError`, because there is no `netifaces.AF_LINK (= 17)` link layer address data.

```
File "/usr/share/netplan/netplan/cli/utils.py", line 169, in get_interface_macaddress
    link = netifaces.ifaddresses(interface)[netifaces.AF_LINK][0]
KeyError: 17
```

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [x] \(Optional\) Closes an open bug in Launchpad: https://bugs.launchpad.net/ubuntu/+source/netplan.io/+bug/1913062

